### PR TITLE
Conditional validation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,12 @@ Changelog
 9.0.31 (unreleased)
 -------------------
 
-- Nothing changed yet.
+Changed:
+
+- In the CMS, conditional fields (that only appear when a checkbox is ticked)
+  can now be set to "required" and properly validated. Therefore the "question"
+  field for optional modules and the "tool notification" title and text fields
+  are now required.
 
 
 9.0.30 (2017-11-27)
@@ -211,7 +216,7 @@ BROWN-BAG RELEASE
 9.0.6 (2017-02-06)
 ------------------
 
-- Translation changes for NL 
+- Translation changes for NL
 
 9.0.5 (2017-02-01)
 ------------------

--- a/src/euphorie/content/dependency.py
+++ b/src/euphorie/content/dependency.py
@@ -1,0 +1,60 @@
+"""
+Dependency
+----------
+
+Special fields that allow us to make use of NuPlone's dependency engine also
+for validating required fields.
+A required field only needs to be validated against being empty if the
+condition is met, that means, if the checkbox that it depends on is ticked.
+"""
+
+from euphorie.content.user import BaseValidator
+from five import grok
+from htmllaundry.z3cform import HtmlText
+from plonetheme.nuplone.z3cform.directives import Dependency
+from z3c.form.interfaces import IForm
+from z3c.form.interfaces import IValidator
+from zope import schema
+from zope.interface import Interface
+
+
+class ConditionalField(object):
+    """Marker class for conditional fields"""
+
+
+class ConditionalTextLine(schema.TextLine, ConditionalField):
+    """ A Text line that is only shown under certain conditions """
+
+
+class ConditionalHtmlText(HtmlText, ConditionalField):
+    """ HTML Text field that is only shown under certain conditions """
+
+
+class ConditionalFieldValidator(grok.MultiAdapter, BaseValidator):
+    grok.implements(IValidator)
+    grok.adapts(Interface, Interface, IForm, ConditionalField, Interface)
+
+    def validate(self, value):
+        """
+        Only validate for required if the condition for the field is met.
+        If the field that our widget depends on is not checked, set the
+        flag for ignoring validation for required.
+        """
+        widget = self.widget
+        dependencies = getattr(self.widget.field, "_dependencies", [])
+        dependencies = [
+            dep for dep in dependencies if isinstance(dep, Dependency)]
+        if len(dependencies):
+            widgets = widget.__parent__
+            for dep in dependencies:
+                # We only care about "on" type dependencies
+                if dep.op != 'on':
+                    continue
+                d_widget = widgets[dep.field]
+                d_value = self.request.get(d_widget.name)
+                # The magic happens here: the flag is set on self.widget, but
+                # this is not persisted. Then the usual validation method
+                # of z3c.form.validation is called, with the updated widget.
+                self.widget.ignoreRequiredOnValidation = not d_value
+
+        return super(ConditionalFieldValidator, self).validate(value)

--- a/src/euphorie/content/module.py
+++ b/src/euphorie/content/module.py
@@ -20,6 +20,7 @@ from .risk import IRisk
 from .utils import DragDropHelper
 from .utils import StripMarkup
 from Acquisition import aq_chain
+from euphorie.content.dependency import ConditionalTextLine
 from five import grok
 from htmllaundry.z3cform import HtmlText
 from plone.app.dexterity.behaviors.metadata import IBasic
@@ -65,13 +66,13 @@ class IModule(form.Schema, IRichDescription, IBasic):
             default=False)
 
     depends("question", "optional", "on")
-    question = schema.TextLine(
+    question = ConditionalTextLine(
             title=_("label_module_question", default=u"Question"),
             description=_("help_module_question",
                 default=u"The question to ask the end-user if this module is "
                     u"optional. It must be formulated so that it is answerable "
                     u"with YES (the end-user will have to tick a box) or NO"),
-            required=False)
+            required=True)
 
     image = filefield.NamedBlobImage(
             title=_("label_image", default=u"Image file"),

--- a/src/euphorie/content/survey.py
+++ b/src/euphorie/content/survey.py
@@ -20,6 +20,8 @@ from .utils import DragDropHelper
 from .utils import StripMarkup
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from euphorie.content.dependency import ConditionalHtmlText
+from euphorie.content.dependency import ConditionalTextLine
 from five import grok
 from htmllaundry.z3cform import HtmlText
 from OFS.event import ObjectClonedEvent
@@ -110,17 +112,17 @@ class ISurvey(form.Schema, IBasic):
     depends("tool_notification_title",
             "enable_tool_notification",
             "on")
-    tool_notification_title = schema.TextLine(
+    tool_notification_title = ConditionalTextLine(
         title=_("label_tool_notification_title", default=u"Tool notification title"),
-        required=False)
+        required=True)
 
     depends("tool_notification_message",
             "enable_tool_notification",
             "on")
-    tool_notification_message = HtmlText(
+    tool_notification_message = ConditionalHtmlText(
         title=_(
             "label_tool_notification", default=u"Tool notification message"),
-        required=False)
+        required=True)
     form.widget(tool_notification_message=WysiwygFieldWidget)
 
 


### PR DESCRIPTION
Allow conditional fields (that are only visible via NuPlone's Dependency) to be marked as required. A custom validator then checks if the condition is met before raising a missing value error.