### PR TITLE
Manage and display the survey publication date

### DIFF
--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -12,4 +12,22 @@
       layer="euphorie.client.interfaces.IClientSkinLayer"
       />
 
+  <browser:page
+      name="publication_date"
+      for="euphorie.content.survey.ISurvey"
+      permission="euphorie.client.ViewSurvey"
+      class=".survey.PubblicationMenu"
+      allowed_attributes="set_date reset_date unset_date"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
+  <browser:page
+      name="publication_menu"
+      for="euphorie.content.survey.ISurvey"
+      permission="euphorie.client.ViewSurvey"
+      class=".survey.PubblicationMenu"
+      template="templates/publication_menu.pt"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
 </configure>

--- a/src/euphorie/client/browser/survey.py
+++ b/src/euphorie/client/browser/survey.py
@@ -4,9 +4,11 @@ from euphorie import MessageFactory as _
 from euphorie.client import utils
 from euphorie.client.session import SessionManager
 from plone import api
+from plone.app.event.base import localized_now
 from plone.autoform.form import AutoExtensibleForm
 from plone.memoize.view import memoize
 from plone.supermodel import model
+from Products.Five import BrowserView
 from z3c.form.form import EditForm
 from zope import schema
 
@@ -67,3 +69,34 @@ class Start(AutoExtensibleForm, EditForm):
                 type='success',
             )
         self.request.response.redirect("%s/@@profile" % survey.absolute_url())
+
+
+class PubblicationMenu(BrowserView):
+
+    def redirect(self):
+        target = (
+            self.request.get('HTTP_REFERER') or self.context.absolute_url()
+        )
+        return self.request.response.redirect(target)
+
+    def reset_date(self):
+        ''' Reset the session date to now
+        '''
+        self.session.published = localized_now()
+        return self.redirect()
+
+    def set_date(self):
+        ''' Set the session date to now
+        '''
+        return self.reset_date()
+
+    def unset_date(self):
+        ''' Unset the session date to now
+        '''
+        self.session.published = None
+        return self.redirect()
+
+    @property
+    @memoize
+    def session(self):
+        return SessionManager.session

--- a/src/euphorie/client/browser/templates/publication_menu.pt
+++ b/src/euphorie/client/browser/templates/publication_menu.pt
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      i18n:domain="euphorie"
+>
+  <body>
+    <div id="publication-menu"
+         hidden
+    >
+      <ul class="menu"
+          tal:switch="view/session/review_state"
+      >
+        <tal:case case="string:private">
+          <li>
+            <form class="pat-inject"
+                  action="${here/absolute_url}/@@publication_date/set_date#content"
+            >
+              <button class="icon-publish"
+                      type="submit"
+                      i18n:translate=""
+              >Publish Risk Assessment</button>
+            </form>
+          </li>
+        </tal:case>
+        <tal:case case="string:published">
+          <li>
+            <form class="pat-inject"
+                  action="${here/absolute_url}/@@publication_date/unset_date#content"
+            >
+              <button class="icon-cancel-circled"
+                      type="submit"
+                      i18n:translate=""
+              >Unpublish Risk Assessment</button>
+            </form>
+          </li>
+          <li>
+            <form class="pat-inject"
+                  action="${here/absolute_url}/@@publication_date/reset_date#content"
+            >
+              <button class="icon-arrows-cw"
+                      type="submit"
+                      i18n:translate=""
+              >Refresh publication date</button>
+            </form>
+          </li>
+        </tal:case>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/src/euphorie/client/browser/templates/start.pt
+++ b/src/euphorie/client/browser/templates/start.pt
@@ -10,6 +10,7 @@
       tal:define="
         webhelpers nocall:context/@@webhelpers;
         default_introduction nocall:context/@@default_introduction;
+        session view/session;
       "
       i18n:domain="euphorie"
 >
@@ -25,7 +26,7 @@
             data-pat-inject="source: #content; target: #content; &amp;&amp; source: #osc; target: #osc;"
       >
         <nav class="page-actions">
-
+          <a tal:replace="structure here/@@publication_badge|nothing" />
           <a class="icon-share iconified pat-tooltip"
              href="${request/ACTUAL_URL}#sharing-menu"
              title="Share this OiRA-Tool"
@@ -41,9 +42,6 @@
         </nav>
         <fieldset class="vertical pat-inject pat-subform pat-autosubmit focus"
                   data-pat-inject="url: ; source: #osc-header; target: #osc-header"
-                  tal:define="
-                    session view/session;
-                  "
         >
 
           <tal:for repeat="widgetid view/widgets">
@@ -57,7 +55,7 @@
                      autofocus="autofocus"
                      name="${name}"
                      type="text"
-                     value="${request/?name|view/session/?widgetid|nothing}"
+                     value="${request/?name|session/?widgetid|nothing}"
               />
               <tal:error condition="widget/error"
                          replace="structure widget/error/render|nothing"
@@ -159,8 +157,6 @@
           </li>
         </ul>
       </div>
-
-
       <metal:css use-macro="webhelpers/macros/appendix" />
 
     </metal:slot>

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -379,6 +379,13 @@ class SurveySession(BaseObject):
             default=functions.now())
     modified = schema.Column(types.DateTime, nullable=False,
             default=functions.now())
+
+    published = schema.Column(
+        types.DateTime,
+        nullable=True,
+        default=None,
+    )
+
     zodb_path = schema.Column(types.String(128), nullable=False)
 
     report_comment = schema.Column(types.UnicodeText())
@@ -389,6 +396,13 @@ class SurveySession(BaseObject):
     group = orm.relation(Group,
             backref=orm.backref("sessions", order_by=modified,
                                 cascade="all, delete, delete-orphan"))
+
+    @property
+    def review_state(self):
+        ''' Check if it the published column.
+        If it has return 'published' otherwise return 'private'
+        '''
+        return 'published' if self.published else 'private'
 
     def hasTree(self):
         return bool(Session.query(SurveyTreeItem)

--- a/src/euphorie/client/templates/sessions.pt
+++ b/src/euphorie/client/templates/sessions.pt
@@ -72,13 +72,15 @@
                       <a class="name field"
                          href="${request/getURL}?action=continue&amp;session=${session/id}"
                       >${session/title}</a>
-                      <span class="date field">
+                      <span class="date field"
+                            tal:condition="session/published"
+                      >
                         <tal:i18n i18n:translate="">Last published</tal:i18n>
                         <time class="pat-display-time"
                               datetime="${value}"
                               data-pat-display-time="from-now: true; locale: ${language}"
                               tal:define="
-                                value python:session.modified.strftime('%Y-%m-%d');
+                                value session/published/isoformat|nothing;
                               "
                         >${value}</time>
                       </span>

--- a/src/euphorie/client/tests/test_functional_login.py
+++ b/src/euphorie/client/tests/test_functional_login.py
@@ -133,48 +133,41 @@ class LoginTests(EuphorieFunctionalTestCase):
 
 class RegisterTests(EuphorieIntegrationTestCase):
 
-    def get_register_view(self):
-        return api.content.get_view(
-            'register',
-            self.portal.client,
-            self.get_client_request()
-        )
-
     def test_lowercase_email(self):
-        view = self.get_register_view()
-        view.errors = {}
-        view.request.form['email'] = 'JANE@example.com'
-        view.request.form['password1'] = 'secret'
-        view.request.form['password2'] = 'secret'
-        account = view._tryRegistration()
-        self.assertEqual(account.loginname, 'jane@example.com')
+        with self._get_view('register', self.portal.client) as view:
+            view.errors = {}
+            view.request.form['email'] = 'JANE@example.com'
+            view.request.form['password1'] = 'secret'
+            view.request.form['password2'] = 'secret'
+            account = view._tryRegistration()
+            self.assertEqual(account.loginname, 'jane@example.com')
 
     def testConflictWithPloneAccount(self):
-        view = self.get_register_view()
-        view.errors = {}
-        view.request.form["email"] = self.portal._owner[1]
-        view.request.form["password1"] = "secret"
-        view.request.form["password2"] = "secret"
-        self.assertEqual(view._tryRegistration(), False)
-        self.failUnless("email" in view.errors)
+        with self._get_view('register', self.portal.client) as view:
+            view.errors = {}
+            view.request.form["email"] = self.portal._owner[1]
+            view.request.form["password1"] = "secret"
+            view.request.form["password2"] = "secret"
+            self.assertEqual(view._tryRegistration(), False)
+            self.failUnless("email" in view.errors)
 
     def testBasicEmailVerification(self):
-        view = self.get_register_view()
-        view.errors = {}
-        view.request.form["email"] = "wichert"
-        view.request.form["password1"] = "secret"
-        view.request.form["password2"] = "secret"
-        self.assertEqual(view._tryRegistration(), False)
-        self.failUnless("email" in view.errors)
+        with self._get_view('register', self.portal.client) as view:
+            view.errors = {}
+            view.request.form["email"] = "wichert"
+            view.request.form["password1"] = "secret"
+            view.request.form["password2"] = "secret"
+            self.assertEqual(view._tryRegistration(), False)
+            self.failUnless("email" in view.errors)
 
-        view.errors.clear()
-        view.request.form["email"] = "wichert@wiggy net"
-        self.assertEqual(view._tryRegistration(), False)
-        self.failUnless("email" in view.errors)
+            view.errors.clear()
+            view.request.form["email"] = "wichert@wiggy net"
+            self.assertEqual(view._tryRegistration(), False)
+            self.failUnless("email" in view.errors)
 
-        view.errors.clear()
-        view.request.form["email"] = "wichert@wiggy.net"
-        self.assertNotEqual(view._tryRegistration(), False)
+            view.errors.clear()
+            view.request.form["email"] = "wichert@wiggy.net"
+            self.assertNotEqual(view._tryRegistration(), False)
 
 
 class ReminderTests(EuphorieFunctionalTestCase):

--- a/src/euphorie/client/tests/test_survey_integration.py
+++ b/src/euphorie/client/tests/test_survey_integration.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+from datetime import datetime
+from euphorie.client import model
+from euphorie.client.tests.utils import addAccount
+from euphorie.client.tests.utils import addSurvey
+from euphorie.content.tests.utils import BASIC_SURVEY
+from euphorie.testing import EuphorieIntegrationTestCase
+from lxml import html
+from time import sleep
+
+
+class TestSurveyViews(EuphorieIntegrationTestCase):
+
+    def test_survey_publication_date_views(self):
+        ''' We have some views to display and set the published column
+        for a survey session
+        '''
+        survey = addSurvey(self.portal, BASIC_SURVEY)
+        account = addAccount(password='secret')
+        survey_session = model.SurveySession(
+            title=u'Dummy session',
+            created=datetime(2012, 4, 22, 23, 5, 12),
+            modified=datetime(2012, 4, 23, 11, 50, 30),
+            zodb_path='nl/ict/software-development',
+            account=account,
+            company=model.Company(
+                country='nl', employees='1-9', referer='other'
+            )
+        )
+        model.Session.add(survey_session)
+        survey = self.portal.client.nl.ict['software-development']
+
+        with self._get_view(
+            'publication_date', survey, survey_session
+        ) as view:  # noqa: E501
+            session = view.session
+            # The view is not callable but as traversable  allowed attributes
+            self.assertRaises(TypeError, view)
+            self.assertEqual(session.published, None)
+            self.assertEqual(session.review_state, 'private')
+            # Calling set_date will reult in having this session published
+            # and the publication time will be recorded
+            # If no referer is set the methods will redirect to the context url
+            self.assertEqual(view.set_date(), survey.absolute_url())
+            self.assertIsInstance(session.published, datetime)
+            self.assertEqual(session.review_state, 'published')
+            old_published = session.published
+            # Changing the HTTP_REFERER will redirect there
+            # and calling reset_date will update the published date
+            view.request.set('HTTP_REFERER', 'foo')
+            # We need to wait at least one second because the datetime
+            # is stored with that accuracy
+            sleep(1)
+            self.assertEqual(view.reset_date(), 'foo')
+            self.assertTrue(session.published > old_published)
+            # Calling unset_date will restore the publication date to None
+            self.assertEqual(view.unset_date(), 'foo')
+            self.assertEqual(session.published, None)
+            self.assertEqual(session.review_state, 'private')
+
+        # We also have a menu view
+        with self._get_view(
+            'publication_menu', survey, survey_session
+        ) as view:  # noqa: E501
+            soup = html.fromstring(view())
+            self.assertListEqual(
+                ['publication_date/set_date#content'],
+                [
+                    el.attrib['action'].rpartition('@@')[-1]
+                    for el in soup.cssselect('form')
+                ],
+            )
+            # We trigger the session to be private
+            survey_session.published = 'foo'
+            soup = html.fromstring(view())
+            self.assertListEqual(
+                [
+                    'publication_date/unset_date#content',
+                    'publication_date/reset_date#content',
+                ],
+                [
+                    el.attrib['action'].rpartition('@@')[-1]
+                    for el in soup.cssselect('form')
+                ],
+            )

--- a/src/euphorie/testing.py
+++ b/src/euphorie/testing.py
@@ -1,5 +1,8 @@
 # coding=utf-8
+from contextlib import contextmanager
 from euphorie.client.interfaces import IClientSkinLayer
+from euphorie.client.utils import getRequest
+from euphorie.client.utils import setRequest
 from plone import api
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -121,6 +124,7 @@ EUPHORIE_FUNCTIONAL_TESTING = FunctionalTesting(
 
 class EuphorieIntegrationTestCase(TestCase):
     layer = EUPHORIE_INTEGRATION_TESTING
+    request_layer = IClientSkinLayer
 
     def setUp(self):
         self.app = self.layer['app']
@@ -135,6 +139,17 @@ class EuphorieIntegrationTestCase(TestCase):
 
     def logout(self):
         return logout()
+
+    @contextmanager
+    def _get_view(self, name, obj):
+        old_request = getRequest()
+        request = self.request.clone()
+        alsoProvides(request, IClientSkinLayer)
+        try:
+            setRequest(request)
+            yield api.content.get_view(name, obj, request)
+        finally:
+            setRequest(old_request)
 
     def get_client_request(self, client=None):
         request = self.request.clone()

--- a/src/euphorie/testing.py
+++ b/src/euphorie/testing.py
@@ -141,9 +141,14 @@ class EuphorieIntegrationTestCase(TestCase):
         return logout()
 
     @contextmanager
-    def _get_view(self, name, obj):
+    def _get_view(self, name, obj, survey_session=None):
+        ''' Get's a view with a proper fresh request.
+        If survey_session is set the SessionManager will be configured
+        '''
         old_request = getRequest()
         request = self.request.clone()
+        if survey_session is not None:
+            request.other["euphorie.session"] = survey_session
         alsoProvides(request, IClientSkinLayer)
         try:
             setRequest(request)


### PR DESCRIPTION
This PR adds two views:

- `publication_menu`
- `publication_date`

The publication menu is used to display the tooltip with the form to publish/refresh/unpublish the survey session.
The publication_date is the endpoint for the publication menu form action.

This feature is toggled off in the UI and can be turned on by providing a `publication_badge` traversable that loads the tooltip.
