### PR TITLE
Plone5 categorised Survey templates

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,9 @@ Changelog
   of the tree needs to be updated: we now also check if the risk_type
   was changed, since that info determines display behaviour.
 - Translation update FR
+- New behavior for Survey that makes it possible to assign one or more categories
+  to it. If set, the "new session" modal in the client will display that survey
+  under its categories
 
 
 10.0.4 (2018-12-11)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "zope.i18nmessageid",
         "zope.interface",
         "zope.schema",
-        "NuPlone >=1.4.0",
+        "NuPlone >=1.6.0",
         "plone.uuid",
         "pyrtf-ng",
         "z3c.appconfig >=1.0",

--- a/src/euphorie/client/browser/templates/new-session-test.pt
+++ b/src/euphorie/client/browser/templates/new-session-test.pt
@@ -14,26 +14,49 @@
             <form method="post" action="${request/URL}" class="wizard-box" tal:condition="view/allow_guest_accounts">
             <input type="hidden" name="action" value="new"/>
             <div class="panel-body"
-              tal:define="surveys view/surveys;
+              tal:define="root view/get_survey_templates_tree_root;
                           threshold view/tools_threshold">
                 <article class="pat-rich">
                     <p i18n:translate="label_select_new_session">Start a new session by choosing one of the following sectoral tools:</p>
                 </article>
-                <fieldset class="tool-list">
-                    <fieldset class="tools pat-checklist radio"
-                        tal:condition="python:len(surveys) <= threshold">
-                      <label class="tool" tal:repeat="survey view/surveys">
+
+              <fieldset class="tool-list" tal:condition="python:view.template_count <= threshold">
+                <metal:templates define-macro="templates">
+                  <tal:surveys define="surveys root/survey_templates">
+                    <fieldset class="tools pat-checklist radio">
+                      <label class="tool" tal:repeat="survey surveys">
                         <input type="radio" name="survey" value="${survey/id}">
                         <strong class="field name">${survey/title}</strong>
                       </label>
                     </fieldset>
-                    <fieldset class="tools"
-                     tal:condition="python:len(surveys) > threshold">
-                        <select name="survey">
-                            <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
-                        </select>
-                    </fieldset>
-                </fieldset>
+                  </tal:surveys>
+                </metal:templates>
+                <tal:categories repeat="child root/categories">
+                  <fieldset class="department">
+                    <legend>${child/title}</legend>
+                    <tal:survey define="root child">
+                      <metal:node use-macro="template/macros/templates" />
+                    </tal:survey>
+                  </fieldset>
+                </tal:categories>
+              </fieldset>
+
+              <label class="tool-list-many" tal:condition="python:view.template_count > threshold">
+                <select name="survey">
+                  <metal:templates define-macro="templates_many">
+                    <tal:surveys define="surveys root/survey_templates">
+                      <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
+                    </tal:surveys>
+                  </metal:templates>
+                  <tal:categories repeat="child root/categories">
+                    <optgroup label="${child/title}">
+                      <tal:survey define="root child">
+                        <metal:node use-macro="template/macros/templates_many" />
+                      </tal:survey>
+                    </optgroup>
+                  </tal:categories>
+                </select>
+              </label>
 
                 <p>
                     <tal:span i18n:translate="testsession_benefits_limitations">Read here about the <strong i18n:name="benefits" i18n:translate="benefits">benefits</strong><sup i18n:name="tooltip_benefits"><a href="${base_url}/tooltips#test-session-benefits" class="icon-help-circle iconified pat-tooltip" data-pat-tooltip="source: ajax; position-list: lt; class: rich info">Info</a></sup> and <strong i18n:name="limitations" i18n:translate="limitations">limitations</strong><sup i18n:name="tooltip_limitations"><a href="${base_url}/tooltips#test-session-limitations" class="icon-help-circle iconified pat-tooltip" data-pat-tooltip="source: ajax; position-list: lt; class: rich info">Info</a></sup> of a test session.</tal:span>

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -18,25 +18,40 @@
             data-pat-switch="selector: body; remove: focus-*; add: focus-document && selector: body; add: sidebar-off; remove: sidebar-on">
             <input type="hidden" name="action" value="new"/>
             <div class="panel-body"
-              tal:define="surveys view/surveys;
+              tal:define="
+                          root view/get_survey_templates_tree_root;
                           threshold view/tools_threshold">
               <article class="pat-rich">
                 <p i18n:translate="label_select_new_session">Start a new session by choosing one of the following sectoral tools.</p>
               </article>
               <fieldset class="tool-list">
-                <fieldset class="tools pat-checklist radio"
-                  tal:condition="python:len(surveys) <= threshold">
-                  <label class="tool" tal:repeat="survey surveys">
-                    <input type="radio" name="survey" value="${survey/id}">
-                    <strong class="field name">${survey/title}</strong>
-                  </label>
-                </fieldset>
-                <fieldset class="tools"
-                 tal:condition="python:len(surveys) > threshold">
-                    <select name="survey">
-                        <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
-                    </select>
-                </fieldset>
+                <metal:templates define-macro="templates">
+                  <tal:surveys define="surveys root/survey_templates">
+                    <fieldset class="tools pat-checklist radio"
+                      tal:condition="python:view.template_count <= threshold">
+                      <label class="tool" tal:repeat="survey surveys">
+                        <input type="radio" name="survey" value="${survey/id}">
+                        <strong class="field name">${survey/title}</strong>
+                      </label>
+                    </fieldset>
+                    <fieldset class="tools"
+                     tal:condition="python:view.template_count > threshold">
+                        <select name="survey">
+                            <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
+                        </select>
+                    </fieldset>
+                  </tal:surveys>
+                </metal:templates>
+
+                <tal:categories repeat="child root/categories">
+                  <fieldset class="department">
+                    <legend>${child/title}</legend>
+                    <tal:survey define="root child">
+                      <metal:node use-macro="template/macros/templates" />
+                    </tal:survey>
+                  </fieldset>
+                </tal:categories>
+
               </fieldset>
 
             </div>

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -24,25 +24,18 @@
               <article class="pat-rich">
                 <p i18n:translate="label_select_new_session">Start a new session by choosing one of the following sectoral tools.</p>
               </article>
-              <fieldset class="tool-list">
+
+              <fieldset class="tool-list" tal:condition="python:view.template_count <= threshold">
                 <metal:templates define-macro="templates">
                   <tal:surveys define="surveys root/survey_templates">
-                    <fieldset class="tools pat-checklist radio"
-                      tal:condition="python:view.template_count <= threshold">
+                    <fieldset class="tools pat-checklist radio">
                       <label class="tool" tal:repeat="survey surveys">
                         <input type="radio" name="survey" value="${survey/id}">
                         <strong class="field name">${survey/title}</strong>
                       </label>
                     </fieldset>
-                    <fieldset class="tools"
-                     tal:condition="python:view.template_count > threshold">
-                        <select name="survey">
-                            <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
-                        </select>
-                    </fieldset>
                   </tal:surveys>
                 </metal:templates>
-
                 <tal:categories repeat="child root/categories">
                   <fieldset class="department">
                     <legend>${child/title}</legend>
@@ -51,8 +44,24 @@
                     </tal:survey>
                   </fieldset>
                 </tal:categories>
-
               </fieldset>
+
+              <label class="tool-list-many" tal:condition="python:view.template_count > threshold">
+                <select name="survey">
+                  <metal:templates define-macro="templates_many">
+                    <tal:surveys define="surveys root/survey_templates">
+                      <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
+                    </tal:surveys>
+                  </metal:templates>
+                  <tal:categories repeat="child root/categories">
+                    <optgroup label="${child/title}">
+                      <tal:survey define="root child">
+                        <metal:node use-macro="template/macros/templates_many" />
+                      </tal:survey>
+                    </optgroup>
+                  </tal:categories>
+                </select>
+              </label>
 
             </div>
             <div class="buttons panel-footer">

--- a/src/euphorie/content/behaviors/__init__.py
+++ b/src/euphorie/content/behaviors/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/src/euphorie/content/behaviors/configure.zcml
+++ b/src/euphorie/content/behaviors/configure.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    >
+
+  <plone:behavior
+      title="Tool Category"
+      description="Add a tool category"
+      provides=".toolcategory.IToolCategory"
+      />
+
+</configure>

--- a/src/euphorie/content/behaviors/toolcategory.py
+++ b/src/euphorie/content/behaviors/toolcategory.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from euphorie.content import MessageFactory as _
+from euphorie.content.vocabularies import RegistryValueVocabulary
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from zope import schema
+from zope.interface import provider
+
+
+@provider(IFormFieldProvider)
+class IToolCategory(model.Schema):
+
+    tool_category = schema.List(
+        title=_("title_tool_category", default=u"Tool category"),
+        description=_(
+            "description_tool_category",
+            default=u"Select one or more categories to which this OiRA tool "
+            u"is relevant. The user will then find this tool under the chosen"
+            u" categories."),
+        required=False,
+        value_type=schema.Choice(
+            source=RegistryValueVocabulary(
+                'euphorie.content.vocabularies.toolcategories',
+            ),
+        )
+    )

--- a/src/euphorie/content/configure.zcml
+++ b/src/euphorie/content/configure.zcml
@@ -16,6 +16,7 @@
     <include package="plone.uuid" />
     <include package="htmllaundry" />
     <include package=".api" />
+    <include package=".behaviors" />
 
     <browser:resourceDirectory
         name="euphorie.static"

--- a/src/euphorie/content/export.py
+++ b/src/euphorie/content/export.py
@@ -10,6 +10,7 @@ View name: @@export
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from euphorie.client.utils import HasText
+from euphorie.content.behaviors.toolcategory import IToolCategory
 from euphorie.content.module import IModule
 from euphorie.content.profilequestion import IProfileQuestion
 from euphorie.content.risk import IKinneyEvaluation
@@ -17,6 +18,7 @@ from euphorie.content.risk import IRisk
 from euphorie.content.solution import ISolution
 from euphorie.content.survey import get_tool_type
 from euphorie.content.survey import ISurvey
+from euphorie.content.upload import COMMA_REPLACEMENT
 from euphorie.content.upload import NSMAP
 from euphorie.content.upload import ProfileQuestionLocationFields
 from euphorie.content.utils import StripMarkup
@@ -91,6 +93,11 @@ class ExportSurvey(grok.View):
                 aq_parent(survey).evaluation_algorithm
         etree.SubElement(node, "evaluation-optional").text = \
                 "true" if survey.evaluation_optional else "false"
+        if IToolCategory.providedBy(survey):
+            etree.SubElement(node, "tool-category").text = ", ".join([
+                x.replace(",", COMMA_REPLACEMENT)
+                for x in IToolCategory(survey).tool_category
+            ])
 
         for child in survey.values():
             if IProfileQuestion.providedBy(child):

--- a/src/euphorie/content/profiles/default/registry/vocabularies.xml
+++ b/src/euphorie/content/profiles/default/registry/vocabularies.xml
@@ -1,0 +1,9 @@
+<registry>
+  <record name="euphorie.content.vocabularies.toolcategories">
+    <field type="plone.registry.field.Tuple">
+      <title>Available tool categories</title>
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value purge="false" />
+  </record>
+</registry>

--- a/src/euphorie/content/upload.py
+++ b/src/euphorie/content/upload.py
@@ -17,6 +17,7 @@ from .sector import ISector
 from .user import LoginField
 from .user import validLoginValue
 from Acquisition import aq_inner
+from euphorie.content.behaviors.toolcategory import IToolCategory
 from euphorie.content.utils import IToolTypesInfo
 from five import grok
 from plone.dexterity.utils import createContentInContainer
@@ -45,6 +46,7 @@ ProfileQuestionLocationFields = [
 
 NSMAP = {None: "http://xml.simplon.biz/euphorie/survey/1.0"}
 XMLNS = "{%s}" % NSMAP[None]
+COMMA_REPLACEMENT = "__COMMA__"
 
 
 def attr_unicode(node, attr, default=None):
@@ -329,6 +331,11 @@ class SurveyImporter(object):
         survey.tool_type = el_string(node, "tool_type", tti.default_tool_type)
         survey.evaluation_optional = el_bool(node, "evaluation-optional")
         survey.external_id = attr_unicode(node, "external-id")
+        if IToolCategory.providedBy(survey):
+            IToolCategory(survey).tool_category = ([
+                x.replace(COMMA_REPLACEMENT, ",").strip()
+                for x in el_unicode(node, 'tool-category').split(",")
+            ])
         for child in node.iterchildren():
             if child.tag == XMLNS + "profile-question":
                 self.ImportProfileQuestion(child, survey)

--- a/src/euphorie/content/vocabularies.py
+++ b/src/euphorie/content/vocabularies.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from zope.interface import implementer
+from zope.schema.interfaces import IContextSourceBinder
+from plone.app.vocabularies.terms import safe_simplevocabulary_from_values
+from plone import api
+
+
+@implementer(IContextSourceBinder)
+class RegistryValueVocabulary(object):
+
+    def __init__(self, value_name):
+        self.value_name = value_name
+
+    def __len__(self):
+        return len(self.values)
+
+    @property
+    def values(self):
+        return api.portal.get_registry_record(self.value_name, default=[])
+
+    def __call__(self, context):
+        return safe_simplevocabulary_from_values(self.values)

--- a/src/euphorie/deployment/profiles/default/metadata.xml
+++ b/src/euphorie/deployment/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>21</version>
+  <version>22</version>
   <dependencies>
     <dependency>profile-plonetheme.nuplone:default</dependency>
     <dependency>profile-euphorie.content:default</dependency>

--- a/src/euphorie/deployment/upgrade/configure.zcml
+++ b/src/euphorie/deployment/upgrade/configure.zcml
@@ -340,4 +340,12 @@
       import_profile="euphorie.deployment.upgrade:to_0021"
       />
 
+  <genericsetup:upgradeDepends
+      source="21"
+      destination="22"
+      profile="euphorie.deployment:default"
+      title="Add vocabulary for optional tool category"
+      import_profile="euphorie.deployment.upgrade:to_0022"
+      />
+
 </configure>

--- a/src/euphorie/deployment/upgrade/profiles.zcml
+++ b/src/euphorie/deployment/upgrade/profiles.zcml
@@ -22,4 +22,13 @@
       directory="profiles/to_0021"
       />
 
+  <genericsetup:registerProfile
+      name="to_0022"
+      title="Upgrade profile that includes registry record for tool category vocabulary"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      directory="profiles/to_0022"
+      />
+
 </configure>

--- a/src/euphorie/deployment/upgrade/profiles/to_0022/registry.xml
+++ b/src/euphorie/deployment/upgrade/profiles/to_0022/registry.xml
@@ -1,0 +1,9 @@
+<registry>
+  <record name="euphorie.content.vocabularies.toolcategories">
+    <field type="plone.registry.field.Tuple">
+      <title>Available tool categories</title>
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value purge="false" />
+  </record>
+</registry>

--- a/versions.cfg
+++ b/versions.cfg
@@ -3,6 +3,7 @@ extends = versions-plone-5.1.4.cfg
 
 [versions]
 Euphorie =
+NuPlone = 1.6.1
 
 # Buildout bits
 setuptools = 39.0.1


### PR DESCRIPTION
New behavior for Survey that makes it possible to assign one or more categories to it. If set, the "new session" modal in the client will display that survey under its categories.

TODO:
-  [x]  adjust "new test session" modal