### PR TITLE
Date picker i18n

### DIFF
--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -13,6 +13,14 @@
       />
 
   <browser:page
+      name="date-picker-i18n.json"
+      for="*"
+      permission="zope.Public"
+      class="euphorie.client.browser.webhelpers.WebHelpers"
+      attribute="date_picker_i18n_json"
+      />
+
+  <browser:page
       name="appendix"
       for="*"
       permission="zope.Public"

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -751,12 +751,18 @@ class WebHelpers(BrowserView):
                data-pat-date-picker="...; i18n: ${portal_url}/@@date-picker-i18n.json; ..."
                />
         """
+        # For these translations, use the base language in case we get a
+        # country-specific language code. We know for example that there
+        # are no plonelocales available for nl_BE, so we play it safe.
+        lang = getattr(self.request, 'LANGUAGE', 'en')
+        if "-" in lang:
+            lang = lang.split("-")[0]
         json = dumps(
             {
                 "previousMonth": self.translate(pae_message("prev_month_link")),
                 "nextMonth": self.translate(pae_message("next_month_link")),
                 "months": [
-                    self.translate(pl_message(month))
+                    self.translate(pl_message(month), target_language=lang)
                     for month in [
                         "month_jan",
                         "month_feb",
@@ -773,7 +779,7 @@ class WebHelpers(BrowserView):
                     ]
                 ],
                 "weekdays": [
-                    self.translate(pl_message(weekday))
+                    self.translate(pl_message(weekday), target_language=lang)
                     for weekday in [
                         "weekday_sun",
                         "weekday_mon",
@@ -785,7 +791,7 @@ class WebHelpers(BrowserView):
                     ]
                 ],
                 "weekdaysShort": [
-                    self.translate(pl_message(weekday_abbr))
+                    self.translate(pl_message(weekday_abbr), target_language=lang)
                     for weekday_abbr in [
                         "weekday_sun_abbr",
                         "weekday_mon_abbr",

--- a/src/euphorie/client/tests/test_utils.py
+++ b/src/euphorie/client/tests/test_utils.py
@@ -147,6 +147,11 @@ class WebhelperTests(EuphorieIntegrationTestCase):
         )
         self.assertEqual(view.is_iphone, True)
 
+    def test_date_picker_i18n_json(self):
+        with self._get_view("date-picker-i18n.json", self.portal) as view:
+            view.request.LANGUAGE = "it"
+            self.assertIn("settembre", view.date_picker_i18n_json())
+
 
 class HasTextTests(unittest.TestCase):
 

--- a/src/euphorie/client/utils.py
+++ b/src/euphorie/client/utils.py
@@ -190,67 +190,6 @@ def IsBright(colour):
     return l > 0.50
 
 
-class I18nJSONView(grok.View):
-    """ Provide the translated month and weekday names for pat-datepicker
-    """
-    grok.context(Interface)
-    grok.layer(IClientSkinLayer)
-    grok.name('date-picker-i18n.json')
-
-    def render(self):
-        lang = getattr(self.request, 'LANGUAGE', 'en')
-        if "-" in lang:
-            lang = lang.split("-")[0]
-        json = dumps({
-            "months": [
-                translate(
-                    pl_message(month),
-                    target_language=lang) for month in [
-                        "month_jan",
-                        "month_feb",
-                        "month_mar",
-                        "month_apr",
-                        "month_may",
-                        "month_jun",
-                        "month_jul",
-                        "month_aug",
-                        "month_sep",
-                        "month_oct",
-                        "month_nov",
-                        "month_dec",
-                ]
-            ],
-            "weekdays": [
-                translate(
-                    pl_message(weekday),
-                    target_language=lang) for weekday in [
-                        "weekday_sun",
-                        "weekday_mon",
-                        "weekday_tue",
-                        "weekday_wed",
-                        "weekday_thu",
-                        "weekday_fri",
-                        "weekday_sat",
-                ]
-            ],
-            "weekdaysShort": [
-                translate(
-                    pl_message(weekday_abbr),
-                    target_language=lang) for weekday_abbr in [
-                        "weekday_sun_abbr",
-                        "weekday_mon_abbr",
-                        "weekday_tue_abbr",
-                        "weekday_wed_abbr",
-                        "weekday_thu_abbr",
-                        "weekday_fri_abbr",
-                        "weekday_sat_abbr",
-                ]
-            ],
-        })
-
-        return json
-
-
 class DefaultIntroduction(grok.View):
     """
         Browser view that displays the default introduction text for a Suvey.


### PR DESCRIPTION
Added a ploneintranet inspired @@date-picker-i18n.json view that can be used
to provide translations for the calendar picker.

Example usage:
```
<input class="pat-date-picker"
       data-pat-date-picker="...; i18n: ${portal_url}/@@date-picker-i18n.json; ..."
/>
```