### PR TITLE
Fix for initial state of optional modules

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Changelog
 -------------------
 
 - Fix standard report: use custom description on Omega risks
+- All optional modules default to "skip". The user needs to actively decide that
+  the module is relevant for them.
 
 11.0.4 (2019-08-22)
 -------------------

--- a/src/euphorie/client/profile.py
+++ b/src/euphorie/client/profile.py
@@ -67,8 +67,10 @@ def AddToTree(
         child.has_description = HasText(node.description)
         if IModule.providedBy(node):
             child.solution_direction = HasText(node.solution_direction)
+            # All optional modules default to "skip". The user needs to
+            # actively decide that the module is relevant for them.
             if node.optional:
-                child.skip_children = False
+                child.skip_children = True
                 child.has_description = True
             else:
                 child.postponed = False


### PR DESCRIPTION
All optional modules default to "skip". The user needs to actively decide that the module is relevant for them.