### PR TITLE
feat: better account and group filters

### DIFF
--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -786,13 +786,13 @@ class WebHelpers(BrowserView):
             A falsish value means do not filter.
             Otherwise try to interpret the user input:
             a string or an int means the account_id should be that value,
-            an object account will be use to extract the account id,
+            an object account will be used to extract the account id,
             from an iterable we will try to extract the account ids
         :param filter_by_group: True means current account group,
             A falsish value means do not filter.
             Otherwise try to interpret the user input:
             a string or an int means the group_id should be that value,
-            an object account will be use to extract the group id,
+            an object group will be used to extract the group id,
             and from an iterable we will try to extract the group ids
         """
         table = self.survey_session_model

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -880,6 +880,13 @@ class SurveySession(BaseObject):
     @classmethod
     def get_account_filter(cls, account=None):
         """ Filter only the sessions for the given account
+
+        :param acount: True means current account.
+            A falsish value means do not filter.
+            Otherwise try to interpret the user input:
+            a string or an int means the account_id should be that value,
+            an object account will be used to extract the account id,
+            from an iterable we will try to extract the account ids
         """
         if account is True:
             account = get_current_account()
@@ -916,6 +923,13 @@ class SurveySession(BaseObject):
     @classmethod
     def get_group_filter(cls, group=None):
         """ Filter only the sessions for the given group
+
+        :param group: True means the current account's group.
+            A falsish value means do not filter.
+            Otherwise try to interpret the user input:
+            a string or an int means the group_id should be that value,
+            an object group will be used to extract the group id,
+            and from an iterable we will try to extract the group ids
         """
         if group is True:
             group = getattr(get_current_account(), "group_id", None)

--- a/src/euphorie/client/tests/test_webhelpers.py
+++ b/src/euphorie/client/tests/test_webhelpers.py
@@ -9,7 +9,7 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
     def test_get_sessions_query_anonymous(self):
         with self._get_view("webhelpers", self.portal.client) as view:
             # anonymous does not see anything
-            self.assertTrue(str(view.get_sessions_query()).endswith("WHERE 0 = 1"))
+            self.assertIn("WHERE 0 = 1", str(view.get_sessions_query()))
 
     def _get_query_filters(self, query):
         """ Return the filters of a SQLAlchemy query

--- a/src/euphorie/client/tests/test_webhelpers.py
+++ b/src/euphorie/client/tests/test_webhelpers.py
@@ -98,3 +98,43 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
                         "ORDER BY session.modified DESC, session.title"
                     ),
                 )
+                self.assertEqual(
+                    self._get_query_filters(
+                        view.get_sessions_query(
+                            filter_by_account=False, filter_by_group=foo_group
+                        )
+                    ),
+                    (
+                        "WHERE session.zodb_path IN (?) AND "
+                        "session.group_id = ? AND "
+                        "(session.archived >= ? OR session.archived IS NULL) "
+                        "ORDER BY session.modified DESC, session.title"
+                    ),
+                )
+                self.assertEqual(
+                    self._get_query_filters(
+                        view.get_sessions_query(
+                            filter_by_account=False, filter_by_group=[foo_group]
+                        )
+                    ),
+                    (
+                        "WHERE session.zodb_path IN (?) AND "
+                        "session.group_id = ? AND "
+                        "(session.archived >= ? OR session.archived IS NULL) "
+                        "ORDER BY session.modified DESC, session.title"
+                    ),
+                )
+                bar_group = model.Group(group_id=u"bar")
+                self.assertEqual(
+                    self._get_query_filters(
+                        view.get_sessions_query(
+                            filter_by_account=False, filter_by_group=[foo_group, bar_group]
+                        )
+                    ),
+                    (
+                        "WHERE session.zodb_path IN (?) AND "
+                        "session.group_id IN (?, ?) AND "
+                        "(session.archived >= ? OR session.archived IS NULL) "
+                        "ORDER BY session.modified DESC, session.title"
+                    ),
+                )

--- a/src/euphorie/client/tests/test_webhelpers.py
+++ b/src/euphorie/client/tests/test_webhelpers.py
@@ -11,7 +11,7 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
             # anonymous does not see anything
             self.assertTrue(str(view.get_sessions_query()).endswith("WHERE 0 = 1"))
 
-    def _get_query_filters(sefl, query):
+    def _get_query_filters(self, query):
         """ Return the filters of a SQLAlchemy query
         """
         return str(query).partition("\nFROM session \n")[-1]
@@ -37,6 +37,7 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
                         "ORDER BY session.modified DESC, session.title"
                     ),
                 )
+
                 self.assertEqual(
                     self._get_query_filters(
                         view.get_sessions_query(include_archived=True)
@@ -64,11 +65,12 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
                 model.Session.flush()
                 self.assertEqual(
                     self._get_query_filters(
-                        view.get_sessions_query(include_group=True)
+                        view.get_sessions_query(filter_by_group=True)
                     ),
                     (
                         "WHERE session.zodb_path IN (?) AND "
-                        "(session.account_id = ? OR session.group_id IN (?)) AND "
+                        "session.account_id = ? AND "
+                        "session.group_id = ? AND "
                         "(session.archived >= ? OR session.archived IS NULL) "
                         "ORDER BY session.modified DESC, session.title"
                     ),
@@ -79,6 +81,19 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
                     ),
                     (
                         "WHERE session.zodb_path IN (?) AND "
+                        "(session.archived >= ? OR session.archived IS NULL) "
+                        "ORDER BY session.modified DESC, session.title"
+                    ),
+                )
+                self.assertEqual(
+                    self._get_query_filters(
+                        view.get_sessions_query(
+                            filter_by_account=False, filter_by_group=True
+                        )
+                    ),
+                    (
+                        "WHERE session.zodb_path IN (?) AND "
+                        "session.group_id = ? AND "
                         "(session.archived >= ? OR session.archived IS NULL) "
                         "ORDER BY session.modified DESC, session.title"
                     ),


### PR DESCRIPTION
BREAKING CHANGE: the include_group parameter is removed and replaced
with filter_by_group parameter which has more flexibility

This PR makes it possible to optionally filter sessions by account or group,
it is also possible to filter for lists of users or groups.

Refs. and replaces #224