### PR TITLE
Rework login

### DIFF
--- a/src/euphorie/client/browser/login.py
+++ b/src/euphorie/client/browser/login.py
@@ -6,18 +6,18 @@ Register new users, login/logout, create a "Guest user" account and convert
 existing guest accounts to normal accounts.
 """
 
-from euphorie.client import MessageFactory as _
 from ..conditions import approvedTermsAndConditions
 from ..conditions import checkTermsAndConditions
 from ..country import IClientCountry
 from ..utils import setLanguage
-from AccessControl import getSecurityManager
 from Acquisition import aq_chain
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from euphorie.client import config
+from euphorie.client import MessageFactory as _
 from euphorie.client import model
 from euphorie.client.browser.country import SessionsView
+from euphorie.client.model import get_current_account
 from euphorie.content.survey import ISurvey
 from plone import api
 from plone.memoize.view import memoize
@@ -85,7 +85,7 @@ class Login(BrowserView):
         """
         if not account_id:
             return
-        account = getSecurityManager().getUser()
+        account = get_current_account()
         sessions = (
             Session.query(model.SurveySession)
             .filter(model.SurveySession.account_id == account_id)
@@ -104,7 +104,7 @@ class Login(BrowserView):
         else:
             came_from = aq_parent(context).absolute_url()
 
-        account = getSecurityManager().getUser()
+        account = get_current_account()
         appconfig = component.getUtility(IAppConfig)
         settings = appconfig.get('euphorie')
         self.allow_guest_accounts = asBool(
@@ -281,7 +281,7 @@ class Register(BrowserView):
 
         guest_account_id = self.request.form.get('guest_account_id')
         if guest_account_id:
-            account = getSecurityManager().getUser()
+            account = get_current_account()
             account.loginname = loginname
             account.password = reply.get("password1")
             account.account_type = config.CONVERTED_ACCOUNT

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collections import defaultdict
@@ -776,7 +775,7 @@ class Report(SessionMixin, BrowserView):
             ):
                 url = "%s/@@report_view" % self.context.absolute_url()
 
-            user = getSecurityManager().getUser()
+            user = get_current_account()
             if getattr(user, "account_type", None) == config.GUEST_ACCOUNT:
                 url = "%s/@@register?report_blurb=1&came_from=%s" % (
                     self.context.absolute_url(),

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -141,7 +141,7 @@ class WebHelpers(BrowserView):
     @property
     @memoize
     def _user(self):
-        return getSecurityManager().getUser()
+        return self.get_current_account()
 
     @property
     @memoize

--- a/src/euphorie/client/conditions.py
+++ b/src/euphorie/client/conditions.py
@@ -1,7 +1,7 @@
-from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from euphorie.client import CONDITIONS_VERSION
 from euphorie.client.interfaces import IClientSkinLayer
+from euphorie.client.model import get_current_account
 from five import grok
 from z3c.appconfig.interfaces import IAppConfig
 from z3c.appconfig.utils import asBool
@@ -30,7 +30,7 @@ def checkTermsAndConditions():
 
 def approvedTermsAndConditions(account=None):
     if account is None:
-        account = getSecurityManager().getUser()
+        account = get_current_account()
     return account.tc_approved is not None and \
             account.tc_approved == CONDITIONS_VERSION
 
@@ -51,7 +51,7 @@ class TermsAndConditions(grok.View):
             # If came_from is both in the querystring and the form data
             self.came_from = self.came_from[0]
 
-        self.account = getSecurityManager().getUser()
+        self.account = get_current_account()
         if self.request.environ["REQUEST_METHOD"] == "POST":
             self.account.tc_approved = CONDITIONS_VERSION
 

--- a/src/euphorie/client/country.py
+++ b/src/euphorie/client/country.py
@@ -10,8 +10,8 @@ URL: https://client-oiranew.syslab.com/eu
 """
 
 from .. import MessageFactory as _
-from AccessControl import getSecurityManager
 from euphorie.client.interfaces import IClientSkinLayer
+from euphorie.client.model import get_current_account
 from euphorie.client.model import SurveySession
 from five import grok
 from plone.app.dexterity.behaviors.metadata import IBasic
@@ -86,7 +86,7 @@ class RenameSession(form.SchemaForm):
             session_id = int(self.request.get("id"))
         except (ValueError, TypeError):
             raise KeyError("Invalid session id")
-        user = getSecurityManager().getUser()
+        user = get_current_account()
         session = (
             object_session(user).query(SurveySession)
             .filter(SurveySession.account == user)

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1454,15 +1454,13 @@ def get_current_account():
     :return: The current Account instance if a user can be found,
              otherwise None
     '''
-    username = api.user.get_current().getUserName()
+    user_id = api.user.get_current().getId()
     try:
         return Session.query(Account).filter(
-            Account.loginname == username).first()
+            Account.id == user_id).first()
     except:
         log.warning("Unable to fetch account for username:")
-        log.warning(username)
-        return Session.query(Account).filter(
-            Account.loginname == safe_unicode(username)).first()
+        log.warning(user_id)
 
 
 class DefaultView(BrowserView):

--- a/src/euphorie/client/settings.py
+++ b/src/euphorie/client/settings.py
@@ -5,13 +5,13 @@ Settings
 Change a user's password/email or delete an account.
 """
 from .. import MessageFactory as _
-from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from euphorie.client.client import IClient
 from euphorie.client.country import IClientCountry
 from euphorie.client.interfaces import IClientSkinLayer
 from euphorie.client.model import Account
 from euphorie.client.model import AccountChangeRequest
+from euphorie.client.model import get_current_account
 from euphorie.client.utils import CreateEmailTo
 from euphorie.client.utils import randomString
 from five import grok
@@ -97,7 +97,7 @@ class AccountSettings(form.SchemaForm):
         if errors:
             return
 
-        user = getSecurityManager().getUser()
+        user = get_current_account()
         if not data["new_password"]:
             flash(_(u"There were no changes to be saved."), "notice")
             return
@@ -143,13 +143,12 @@ class DeleteAccount(form.SchemaForm):
         if errors:
             return
 
-        user = getSecurityManager().getUser()
+        user = get_current_account()
         if not user.verify_password(data["password"]):
             raise WidgetActionExecutionError(
                 "password", Invalid(_(u"Invalid password"))
             )
 
-        user = getSecurityManager().getUser()
         Session.delete(user)
         self.logout()
         self.request.response.redirect(self.request.client.absolute_url())
@@ -192,7 +191,7 @@ class NewEmail(form.SchemaForm):
         self.widgets["password"].addClass("password")
 
     def getContent(self):
-        user = getSecurityManager().getUser()
+        user = get_current_account()
         directlyProvides(user, EmailChangeSchema)
         return user
 
@@ -279,7 +278,7 @@ class NewEmail(form.SchemaForm):
             return
         url = self.context.absolute_url()
 
-        user = getSecurityManager().getUser()
+        user = get_current_account()
         if not user.verify_password(data["password"]):
             raise WidgetActionExecutionError(
                 "password", Invalid(_(u"Invalid password"))


### PR DESCRIPTION
We have seen the using `getSecurityManager().getUser()`, which _should_ return the current `model.Account` can lead to unexpected results in registration and conversion of guest accounts.