### PR TITLE
Use timezone-aware dates for pat-display-time

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,8 +4,8 @@ Changelog
 11.1.14 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Fix bug that caused users in different timezones to see strange dates
+ ("Last saved in 2 hours")
 
 11.1.13 (2020-01-07)
 --------------------

--- a/src/euphorie/client/browser/templates/publication_menu.pt
+++ b/src/euphorie/client/browser/templates/publication_menu.pt
@@ -24,7 +24,7 @@
           <strong><tal:i18n i18n:translate="label_published">Published</tal:i18n>
             <time class="pat-display-time"
                   data-pat-display-time="from-now: true; locale: ${language}"
-                  tal:define="value session/published/isoformat|nothing;"
+                  tal:define="value python:webhelpers.timezoned_date(session.published);"
                   datetime="${value}"
             >${value}</time>
             <tal:publisher condition="last_publisher">

--- a/src/euphorie/client/browser/templates/session-browser-sidebar.pt
+++ b/src/euphorie/client/browser/templates/session-browser-sidebar.pt
@@ -122,7 +122,7 @@
                         datetime="${value}"
                         data-pat-display-time="from-now: true; locale: ${language}"
                         tal:define="
-                          value session/modified/isoformat|nothing;
+                          value python:webhelpers.timezoned_date(session.modified);
                         "
                   >${value}</time
                 ></span>
@@ -133,7 +133,7 @@
                           datetime="${value}"
                           data-pat-display-time="from-now: true; locale: ${language}"
                           tal:define="
-                            value session/published/isoformat|nothing;
+                            value python:webhelpers.timezoned_date(session.published);
                           "
                     >${value}</time
                   ></span

--- a/src/euphorie/client/browser/templates/tool_sessions.pt
+++ b/src/euphorie/client/browser/templates/tool_sessions.pt
@@ -50,7 +50,7 @@
                           <time class="pat-display-time"
                               datetime="${value}"
                               data-pat-display-time="from-now: true; locale: ${language}"
-                              tal:define="value session/modified/isoformat|nothing;"
+                              tal:define="value python:webhelpers.timezoned_date(session.modified);"
                           >${value}</time>
                         </span>
                       </p>

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -5,6 +5,7 @@ from Acquisition import aq_chain
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from datetime import datetime
+from dateutil import tz
 from euphorie import MessageFactory as _
 from euphorie.client import config
 from euphorie.client.adapters.session_traversal import ITraversedSurveySession
@@ -84,6 +85,11 @@ class WebHelpers(BrowserView):
     bundle_name_min = "bundle.min.js"
     group_model = Group
     survey_session_model = SurveySession
+
+    @property
+    @memoize
+    def server_timezone(self):
+        return datetime.now(tz.tzlocal()).tzname()
 
     @property
     @memoize
@@ -558,6 +564,12 @@ class WebHelpers(BrowserView):
         calendar = self.request.locale.dates.calendars['gregorian']
         months = calendar.monthContexts['format'].months[length]
         return sorted(months.items())
+
+    def timezoned_date(self, mydate=None):
+        if mydate is None:
+            return None
+        utc = tz.gettz(self.server_timezone)
+        return mydate.replace(tzinfo=utc)
 
     @property
     @memoize


### PR DESCRIPTION
In all locations where we use pat-display-time, make sure that the datetime used for it has a timezone set.
We fetch the timezone to be used from the host (server).