### PR TITLE
Enhance tools portlet

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 11.1.17 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Improve starting a new session for the "many tools" case
 
 
 11.1.16 (2020-02-25)

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -74,50 +74,9 @@ class Node(NodeMixin):
         return _repr(self, args=args, nameblacklist=["context"])
 
 
-class SessionsView(BrowserView):
-
+class SurveyTemplatesMixin(object):
     # switch from radio buttons to dropdown above this number of tools
     tools_threshold = 12
-    variation_class = "variation-dashboard"
-    _portlet_names = ["portlet-my-ras", "portlet-available-tools"]
-
-    @property
-    @memoize
-    def webhelpers(self):
-        return api.content.get_view("webhelpers", self.context, self.request)
-
-    @property
-    @memoize
-    def survey_session_model(self):
-        return self.webhelpers.survey_session_model
-
-    @property
-    @memoize
-    def portlets(self):
-        return [
-            api.content.get_view(name, self.context, self.request)
-            for name in self._portlet_names
-        ]
-
-    @property
-    @memoize
-    def my_context(self):
-        if IClientCountry.providedBy(self.context):
-            return "country"
-        elif ISurvey.providedBy(self.context):
-            return "survey"
-
-    @property
-    @memoize_contextless
-    def portal(self):
-        return api.portal.get()
-
-    @property
-    @memoize_contextless
-    def account(self):
-        """ The currently authenticated account
-        """
-        return get_current_account()
 
     # Here, we assemble the list of available tools for starting a new session
 
@@ -187,6 +146,50 @@ class SessionsView(BrowserView):
                 for category in categories:
                     survey_items.append((category, survey, id))
         return sorted(survey_items, key=lambda x: (x[0], x[1].title))
+
+
+class SessionsView(BrowserView, SurveyTemplatesMixin):
+
+    variation_class = "variation-dashboard"
+    _portlet_names = ["portlet-my-ras", "portlet-available-tools"]
+
+    @property
+    @memoize
+    def webhelpers(self):
+        return api.content.get_view("webhelpers", self.context, self.request)
+
+    @property
+    @memoize
+    def survey_session_model(self):
+        return self.webhelpers.survey_session_model
+
+    @property
+    @memoize
+    def portlets(self):
+        return [
+            api.content.get_view(name, self.context, self.request)
+            for name in self._portlet_names
+        ]
+
+    @property
+    @memoize
+    def my_context(self):
+        if IClientCountry.providedBy(self.context):
+            return "country"
+        elif ISurvey.providedBy(self.context):
+            return "survey"
+
+    @property
+    @memoize_contextless
+    def portal(self):
+        return api.portal.get()
+
+    @property
+    @memoize_contextless
+    def account(self):
+        """ The currently authenticated account
+        """
+        return get_current_account()
 
     def _updateSurveys(self):
         self.surveys = []
@@ -435,6 +438,6 @@ class MyRAsPortlet(PortletBase):
         return capitalize(label)
 
 
-class AvailableToolsPortlet(PortletBase):
+class AvailableToolsPortlet(PortletBase, SurveyTemplatesMixin):
 
     pass

--- a/src/euphorie/client/browser/templates/new-session-test.pt
+++ b/src/euphorie/client/browser/templates/new-session-test.pt
@@ -50,8 +50,9 @@
 
               <fieldset class="vertical" tal:condition="python:template_count > threshold">
               <label class="tool-list-many">
-                <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0">
+                <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0" placeholder="Select an OiRA tool" i18n:attributes="placeholder label_select_oira_tool">
                   <metal:templates define-macro="templates_many">
+                    <option value="">&nbsp;</option>
                     <tal:surveys define="surveys root/survey_templates">
                       <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
                     </tal:surveys>
@@ -77,7 +78,7 @@
             </div>
             <div class="buttons panel-footer">
               <div class="container">
-                <button type="submit" class="pat-button close-panel" i18n:translate="button_start_session">Start session</button>
+                <button type="submit" class="pat-button pat-depends close-panel" i18n:translate="button_start_session" data-pat-depends="condition: survey; action: enable">Start session</button>
                 <button type="button" class="pat-button close-panel" i18n:translate="button_cancel">Cancel</button>
               </div>
             </div>

--- a/src/euphorie/client/browser/templates/new-session-test.pt
+++ b/src/euphorie/client/browser/templates/new-session-test.pt
@@ -51,8 +51,8 @@
               <fieldset class="vertical" tal:condition="python:template_count > threshold">
               <label class="tool-list-many">
                 <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0" placeholder="Select an OiRA tool" i18n:attributes="placeholder label_select_oira_tool">
+                  <option value="">&nbsp;</option>
                   <metal:templates define-macro="templates_many">
-                    <option value="">&nbsp;</option>
                     <tal:surveys define="surveys root/survey_templates">
                       <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
                     </tal:surveys>

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -51,8 +51,9 @@
 
               <fieldset class="vertical" tal:condition="python:template_count > threshold">
               <label class="tool-list-many">
-                <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0">
+                <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0" placeholder="Select an OiRA tool" i18n:attributes="placeholder label_select_oira_tool">
                   <metal:templates define-macro="templates_many">
+                    <option value="">&nbsp;</option>
                     <tal:surveys define="surveys root/survey_templates">
                       <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
                     </tal:surveys>
@@ -72,7 +73,7 @@
 
             <div class="buttons panel-footer">
               <div class="container">
-                <button type="submit" name="next" class="pat-button close-panel" i18n:translate="button_start_session">Start session</button>
+                <button type="submit" name="next" class="pat-button pat-depends close-panel" i18n:translate="button_start_session" data-pat-depends="condition: survey; action: enable">Start session</button>
                 <button type="button" class="pat-button close-panel" i18n:translate="button_cancel">Cancel</button>
               </div>
             </div>

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -52,8 +52,8 @@
               <fieldset class="vertical" tal:condition="python:template_count > threshold">
               <label class="tool-list-many">
                 <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0" placeholder="Select an OiRA tool" i18n:attributes="placeholder label_select_oira_tool">
+                  <option value="">&nbsp;</option>
                   <metal:templates define-macro="templates_many">
-                    <option value="">&nbsp;</option>
                     <tal:surveys define="surveys root/survey_templates">
                       <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
                     </tal:surveys>

--- a/src/euphorie/client/browser/templates/portlet-available-tools.pt
+++ b/src/euphorie/client/browser/templates/portlet-available-tools.pt
@@ -1,89 +1,119 @@
 <tal:portlet i18n:domain="euphorie">
-<div class="portlet span-1"
-     id="portlet-available-tools"
-     tal:define="root view/get_survey_templates_tree_root;
-                 threshold view/tools_threshold;
-                 template_count python:len(view.get_survey_templates());"
-     tal:condition="template_count"
->
-  <div class="content">
-    <article class="portlet-intro">
-      <header class="portlet-title-group">
-        <h2 class="portlet-title"
-            i18n:translate=""
-        >
-          Available OiRA tools
-        </h2>
-      </header>
-    </article>
-    <div class="portlet-body"
-         id="portlet-body-available-tools"
+  <div class="portlet span-1"
+       id="portlet-available-tools"
+       tal:define="
+         root view/get_survey_templates_tree_root;
+         threshold view/tools_threshold;
+         template_count python:len(view.get_survey_templates());
+       "
+       tal:condition="template_count"
+  >
+    <div class="content">
+      <article class="portlet-intro">
+        <header class="portlet-title-group">
+          <h2 class="portlet-title"
+              i18n:translate=""
           >
-      <form class="pat-inject"
-            action="${here/absolute_url}/@@new-session.html"
+          Available OiRA tools
+          </h2>
+        </header>
+      </article>
+      <div class="portlet-body"
+           id="portlet-body-available-tools"
       >
-        <article class="pat-rich">
-          <p i18n:translate="label_select_new_session">
+        <form class="pat-inject"
+              action="${here/absolute_url}/@@new-session.html"
+        >
+          <article class="pat-rich">
+            <p i18n:translate="label_select_new_session">
             Start a new session by choosing one of the following sectoral tools.
-          </p>
-        </article>
+            </p>
+          </article>
 
-              <fieldset class="tool-list" tal:condition="python:template_count <= threshold">
-                <metal:templates define-macro="templates">
-                  <tal:surveys define="surveys root/survey_templates">
-                    <fieldset class="tools pat-checklist radio">
-                      <label class="tool" tal:repeat="survey surveys">
-                        <input type="radio" name="survey" value="${survey/id}">
-                        <strong class="field name">${survey/title}</strong>
-                      </label>
-                    </fieldset>
+          <fieldset class="tool-list"
+                    tal:condition="python:template_count &lt;= threshold"
+          >
+            <metal:templates define-macro="templates">
+              <tal:surveys define="
+                             surveys root/survey_templates;
+                           "
+              >
+                <fieldset class="tools pat-checklist radio">
+                  <label class="tool"
+                         tal:repeat="survey surveys"
+                  >
+                    <input name="survey"
+                           type="radio"
+                           value="${survey/id}"
+                    />
+                    <strong class="field name">${survey/title}</strong>
+                  </label>
+                </fieldset>
+              </tal:surveys>
+            </metal:templates>
+            <tal:categories repeat="child root/categories">
+              <fieldset class="department">
+                <legend>${child/title}</legend>
+                <tal:survey define="
+                              root child;
+                            "
+                >
+                  <metal:node use-macro="template/macros/templates" />
+                </tal:survey>
+              </fieldset>
+            </tal:categories>
+          </fieldset>
+
+          <fieldset class="vertical"
+                    tal:condition="python:template_count &gt; threshold"
+          >
+            <label class="tool-list-many">
+              <select class="pat-autosuggest"
+                      name="survey"
+                      placeholder="Select an OiRA tool"
+                      data-pat-autosuggest="minimum-input-length:0"
+                      i18n:attributes="placeholder label_select_oira_tool"
+              >
+                <metal:templates define-macro="templates_many">
+                  <option value="">&nbsp;</option>
+                  <tal:surveys define="
+                                 surveys root/survey_templates;
+                               "
+                  >
+                    <option value="${survey/id}"
+                            tal:repeat="survey surveys"
+                    >${survey/title}</option>
                   </tal:surveys>
                 </metal:templates>
                 <tal:categories repeat="child root/categories">
-                  <fieldset class="department">
-                    <legend>${child/title}</legend>
-                    <tal:survey define="root child">
-                      <metal:node use-macro="template/macros/templates" />
+                  <optgroup label="${child/title}">
+                    <tal:survey define="
+                                  root child;
+                                "
+                    >
+                      <metal:node use-macro="template/macros/templates_many" />
                     </tal:survey>
-                  </fieldset>
+                  </optgroup>
                 </tal:categories>
-              </fieldset>
+              </select>
+            </label>
+          </fieldset>
 
-              <fieldset class="vertical" tal:condition="python:template_count > threshold">
-                <label class="tool-list-many">
-                  <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0" placeholder="Select an OiRA tool" i18n:attributes="placeholder label_select_oira_tool">
-                    <metal:templates define-macro="templates_many">
-                      <option value="">&nbsp;</option>
-                      <tal:surveys define="surveys root/survey_templates">
-                        <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
-                      </tal:surveys>
-                    </metal:templates>
-                    <tal:categories repeat="child root/categories">
-                      <optgroup label="${child/title}">
-                        <tal:survey define="root child">
-                          <metal:node use-macro="template/macros/templates_many" />
-                        </tal:survey>
-                      </optgroup>
-                    </tal:categories>
-                  </select>
-                </label>
-              </fieldset>
+          <p class="button-bar">
+            <button class="small pat-button pat-depends"
+                    type="submit"
+                    data-pat-depends="condition: survey; action: enable"
+                    i18n:translate="button_start_session"
+            >Start session</button>
+          </p>
 
-        <p class="button-bar">
-          <button class="small pat-button pat-depends"
-                  type="submit"
-                  data-pat-depends="condition: survey; action: enable"
-                  i18n:translate="button_start_session"
-          >Start session</button>
-        </p>
+          <input name="action"
+                 type="hidden"
+                 value="new"
+          />
 
-        <input name="action"
-               type="hidden"
-               value="new"
-        />
-
-      </form>
+        </form>
+      </div>
     </div>
   </div>
-</div>
 </tal:portlet>

--- a/src/euphorie/client/browser/templates/portlet-available-tools.pt
+++ b/src/euphorie/client/browser/templates/portlet-available-tools.pt
@@ -1,8 +1,10 @@
 <tal:portlet i18n:domain="euphorie">
 <div class="portlet span-1"
      id="portlet-available-tools"
-     tal:define="surveys view/surveys"
-     tal:condition="surveys"
+     tal:define="root view/get_survey_templates_tree_root;
+                 threshold view/tools_threshold;
+                 template_count python:len(view.get_survey_templates());"
+     tal:condition="template_count"
 >
   <div class="content">
     <article class="portlet-intro">
@@ -16,7 +18,7 @@
     </article>
     <div class="portlet-body"
          id="portlet-body-available-tools"
-    >
+          >
       <form class="pat-inject"
             action="${here/absolute_url}/@@new-session.html"
       >
@@ -26,21 +28,46 @@
           </p>
         </article>
 
-        <fieldset class="tool-list">
-          <fieldset class="department">
-            <fieldset class="tools pat-checklist radio">
-              <label class="tool"
-                     tal:repeat="survey surveys"
-              >
-                <input name="survey"
-                       type="radio"
-                       value="${survey/aq_parent/id}/${survey/id}"
-                />
-                <strong class="field name">${survey/title}</strong>
-              </label>
-            </fieldset>
-          </fieldset>
-        </fieldset>
+              <fieldset class="tool-list" tal:condition="python:template_count <= threshold">
+                <metal:templates define-macro="templates">
+                  <tal:surveys define="surveys root/survey_templates">
+                    <fieldset class="tools pat-checklist radio">
+                      <label class="tool" tal:repeat="survey surveys">
+                        <input type="radio" name="survey" value="${survey/id}">
+                        <strong class="field name">${survey/title}</strong>
+                      </label>
+                    </fieldset>
+                  </tal:surveys>
+                </metal:templates>
+                <tal:categories repeat="child root/categories">
+                  <fieldset class="department">
+                    <legend>${child/title}</legend>
+                    <tal:survey define="root child">
+                      <metal:node use-macro="template/macros/templates" />
+                    </tal:survey>
+                  </fieldset>
+                </tal:categories>
+              </fieldset>
+
+              <fieldset class="vertical" tal:condition="python:template_count > threshold">
+                <label class="tool-list-many">
+                  <select name="survey" class="pat-autosuggest" data-pat-autosuggest="minimum-input-length:0" placeholder="Select an OiRA tool" i18n:attributes="placeholder label_select_oira_tool">
+                    <metal:templates define-macro="templates_many">
+                      <option value="">&nbsp;</option>
+                      <tal:surveys define="surveys root/survey_templates">
+                        <option tal:repeat="survey surveys" value="${survey/id}">${survey/title}</option>
+                      </tal:surveys>
+                    </metal:templates>
+                    <tal:categories repeat="child root/categories">
+                      <optgroup label="${child/title}">
+                        <tal:survey define="root child">
+                          <metal:node use-macro="template/macros/templates_many" />
+                        </tal:survey>
+                      </optgroup>
+                    </tal:categories>
+                  </select>
+                </label>
+              </fieldset>
 
         <p class="button-bar">
           <button class="small pat-button pat-depends"

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -258,7 +258,7 @@ msgstr "Сигурни ли сте, че желаете да продължит�
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "наличните OiRA инструменти"
 
@@ -422,7 +422,7 @@ msgstr "Необходима ли е подготовка?"
 msgid "Documentation"
 msgstr "Документация"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Случвали се на много места?"
 
@@ -450,7 +450,7 @@ msgstr "Изтегляне на  обзор на мерките"
 msgid "Download the risks overview"
 msgstr "Изтегляне на преглед на рисковете"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Електронна поща"
@@ -479,11 +479,11 @@ msgstr "Редактиране на Профилиращ въпрос"
 msgid "Email address/account name"
 msgstr "Имейл адрес/име на акаунт"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Посочете името на местонахождението"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Посочете името на всяко местонахождение"
 
@@ -560,7 +560,7 @@ msgstr ""
 "разполагате, а по-късно, при възможност,  да продължите от мястото, където "
 "сте прекъснали."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Искам да споделя следното с вас"
 
@@ -586,7 +586,7 @@ msgstr "Информация"
 msgid "Information"
 msgstr "Информация"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Невалиден формат на файла на изображението. Моля, използвайте PNG, JPEG или "
@@ -618,16 +618,15 @@ msgid "Kosovo"
 msgstr "Косово"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "запазено"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Научете повече за този инструмент…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -852,7 +851,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Прегледайте примерите под формуляра."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Отложено разглеждане"
@@ -1009,11 +1007,11 @@ msgstr "Информация за сектор и групиране за кли
 msgid "Sector workflow"
 msgstr "Работен поток на сектор"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Сесия `${name}` е заличена."
 
@@ -1025,7 +1023,7 @@ msgstr "Името на сесията е променено на ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Споделете инструмента за ОiRA"
 
@@ -1059,7 +1057,7 @@ msgid "Started"
 msgstr "публикуван"
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1122,7 +1120,7 @@ msgstr ""
 "Основната структура на Инструмента за онлайн интерактивна оценка на риска се "
 "състои от:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1160,7 +1158,7 @@ msgstr "Онлайн клиентът."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1172,7 +1170,7 @@ msgstr "Посоченият цвят не е валиден."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Оценката се извършва на четири основни етапа:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1180,7 +1178,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Нямаше направени промени, които да бъдат запазени."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Този инструмент OiRA Ви беше предложен от ${external_site}"
 
@@ -1229,7 +1227,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Този инструмент заслужава да бъде познат в цял свят! Споделете го!"
 
@@ -1251,7 +1249,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Без отговор"
@@ -1576,7 +1573,7 @@ msgstr "Създадено от ${EU-OSHA}."
 msgid "based on"
 msgstr "въз основа на"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "предимства"
 
@@ -1645,8 +1642,8 @@ msgid "button_cancel"
 msgstr "Отменяне"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "затвори"
 
@@ -1730,9 +1727,9 @@ msgid "button_start_new_session"
 msgstr "Започнете нова сесия с този инструмент."
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Начало на сесия"
 
@@ -2199,17 +2196,17 @@ msgid "error_password_mismatch"
 msgstr "Паролите не съвпадат"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Тази дата трябва да съвпада или да е след началната дата."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Тази дата трябва да е преди или да съвпада с крайната дата."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Тази стойност трябва да е положително цяло число."
 
@@ -2324,7 +2321,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2442,12 +2439,12 @@ msgid "header_additional_content"
 msgstr "Допълнителна информация"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Допълнителни ресурси за оценка на риска"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Допълнителни ресурси за този модул"
 
@@ -2531,6 +2528,7 @@ msgstr "Лицензи"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Вход"
 
@@ -2640,11 +2638,6 @@ msgstr "Фази на проекта"
 msgid "header_publish"
 msgstr "Публикуване на OiRA инструмента"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Въпроси, на които е отговорено, за модул"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2658,7 +2651,7 @@ msgid "header_reporting"
 msgstr "Докладване"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Pесурси"
 
@@ -2787,13 +2780,12 @@ msgid "header_why_oira"
 msgstr "Защо беше създаден проектът OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Коментари"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Високо приоритетен риск"
 
@@ -2991,7 +2983,7 @@ msgstr ""
 "започнете с копие на съществуващ OiRA инструмент.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Посочете колко често този риск се среща в нормална ситуация."
 
@@ -3003,12 +2995,12 @@ msgstr ""
 "подразбиране. Той/тя все пак ще може да промени приоритета."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Посочете колко вероятно е този риск да се срещне в нормална ситуация."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Посочете сериозността, ако този риск възникне."
 
@@ -3367,7 +3359,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Тестова сесия"
 
@@ -3611,7 +3602,7 @@ msgid "label_body"
 msgstr "Съдържание на страница"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "пропускане"
 
@@ -3647,7 +3638,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Моля, оставете коментарите, които може да имате по горния въпрос, в това "
@@ -3809,11 +3800,6 @@ msgstr "Забравих паролата си"
 msgid "label_format"
 msgstr "Формат"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Обща информация"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3892,7 +3878,7 @@ msgid "label_language"
 msgstr "Език"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Правни източници и източници от политики"
@@ -3945,11 +3931,6 @@ msgstr "Конкретни действия, които се изискват, �
 msgid "label_measure_requirements"
 msgstr "Експертно ниво и/или изисквания, които са необходими"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3987,38 +3968,34 @@ msgstr "Нова тестова сесия"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Напред"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Не"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Няма риск"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Няма риск"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Няма риск"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Няма риск"
 
@@ -4038,12 +4015,12 @@ msgid "label_old_password"
 msgstr "Текуща парола"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Номер на страница"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "от общо"
 
@@ -4075,9 +4052,9 @@ msgid "label_preview"
 msgstr "Преглед"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Назад"
 
@@ -4095,7 +4072,7 @@ msgstr "Въпрос"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Публикуван"
 
@@ -4113,7 +4090,7 @@ msgstr "По кой канал научихте за този инструмен
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "регистрирайте се"
 
@@ -4186,49 +4163,41 @@ msgstr "Вид на риска"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Риск без набелязани мерки"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Риск без набелязани мерки"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Риск без набелязани мерки"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Риск без набелязани мерки"
 
@@ -4269,13 +4238,20 @@ msgstr "Име на сектор."
 msgid "label_select_measure"
 msgstr "Изберете една или повече от предлаганите общи мерки."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Започнете нова сесия, като изберете един от следните секторни инструменти"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4318,14 +4294,9 @@ msgid "label_start_identification"
 msgstr "Стартиране на определянето на риска"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Стартиране"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "публикуван"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4361,6 +4332,11 @@ msgstr "Име на версия"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Име на импортирания OiRA инструмент"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4404,11 +4380,6 @@ msgstr "Вид OiRA инструмент"
 msgid "label_tryout"
 msgstr "изпълнение на тестова сесия"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4428,11 +4399,6 @@ msgstr "Име за версията на OiRA инструмента"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Използван инструмент"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4455,7 +4421,7 @@ msgid "label_workers_participated"
 msgstr "Работниците бяха поканени да участват в оценката на риска"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Да"
@@ -4488,18 +4454,17 @@ msgstr ""
 "публикувани. Кликнете върху иконата за актуализация, за да публикувате "
 "всички промени"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "ограничения"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Вход"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4712,7 +4677,7 @@ msgstr "Настройки"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Статус"
 
@@ -4814,7 +4779,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr "Вашата парола за потвърждение"
 
@@ -4842,7 +4807,7 @@ msgid "portlet_header_versions"
 msgstr "Версии"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4884,6 +4849,11 @@ msgstr "Средна"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Малка"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5198,7 +5168,7 @@ msgstr ""
 "условия внимателно преди да продължите."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Тук ще намерите информация за предимствата на тестовата сесия и разясненията "
@@ -5206,7 +5176,7 @@ msgstr ""
 "и разясненията към нея ${limitations}${tooltip_limitations}."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Или вместо това се регистрирайте ${register_link}. Научете ползите от "
@@ -5304,14 +5274,9 @@ msgstr "Възстановяване на парола"
 msgid "title_sectors"
 msgstr "Сектори"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Статус на ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Онлайн интерактивна оценка на риска"
@@ -5330,11 +5295,6 @@ msgstr "Премахване на публикация \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "OiRA инструментът беше актуализиран"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Статус на ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5450,6 +5410,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Да"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Въпроси, на които е отговорено, за модул"
+
+#~ msgid "label_general_information"
+#~ msgstr "Обща информация"
+
+#~ msgid "label_started"
+#~ msgstr "публикуван"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Използван инструмент"
+
+#~ msgid "title_status_of"
+#~ msgstr "Статус на ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Статус на ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Не са направени промени в мерките във Вашия план за действие."

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -237,7 +237,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -259,7 +259,7 @@ msgstr "Esteu segur que voleu continuar?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Eines OiRA disponibles"
 
@@ -424,7 +424,7 @@ msgstr "Necessito algun tipus de preparació prèvia?"
 msgid "Documentation"
 msgstr "Documentació"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Aquest fet succeeix en diversos llocs?"
 
@@ -452,7 +452,7 @@ msgstr "Descarregar la visió general sobre les mesures"
 msgid "Download the risks overview"
 msgstr "Descarregar la visió general sobre els riscos"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Correu electrònic"
@@ -481,11 +481,11 @@ msgstr "Editar Pregunta de perfil"
 msgid "Email address/account name"
 msgstr "Adreça electrònica/nom del compte"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Introduïu el nom del lloc"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Introduïu els noms de cada lloc"
 
@@ -561,7 +561,7 @@ msgstr ""
 "Tanmateix, podeu utilitzar les estones de què disposeu i reprendre "
 "l’avaluació en un altre moment en el mateix punt en què la vareu deixar."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Voldria compartir el següent enllaç"
 
@@ -587,7 +587,7 @@ msgstr "Informació"
 msgid "Information"
 msgstr "Informació"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "El format de fitxer de l’imatge no és vàlid. Si us plau, utilitzeu PNG, JPEG "
@@ -618,16 +618,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "desada"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Obteniu més informació sobre aquesta eina…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -854,7 +853,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Si us plau, consulteu els exemples a la part inferior:"
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Posposat"
@@ -1009,11 +1007,11 @@ msgstr "Agrupació i informació del sector del client."
 msgid "Sector workflow"
 msgstr "Flux de treball del sector"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "La sessió `${name}` s'ha eliminat."
 
@@ -1025,7 +1023,7 @@ msgstr "El títol de la sessió ha canviat a ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Compartiu aquesta eina OiRA"
 
@@ -1059,7 +1057,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1122,7 +1120,7 @@ msgstr ""
 "L’estructura bàsica d’una avaluació de riscos interactiva en línia "
 "consisteix en:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1160,7 +1158,7 @@ msgstr "El client en línia."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1172,7 +1170,7 @@ msgstr "El color especificat no és vàlid."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "El procés d’avaluació consta de quatre etapes principals:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1180,7 +1178,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "No hi ha cap canvi per desar."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Va conèixer aquesta eina OIRA mitjançant ${external_site}"
 
@@ -1229,7 +1227,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Aquesta eina cal que arribi a tothom. Compartiu-la!"
 
@@ -1251,7 +1249,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "No respost"
@@ -1566,7 +1563,7 @@ msgstr "Creat per l'${EU-OSHA}."
 msgid "based on"
 msgstr "basada en"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "Avantatges"
 
@@ -1635,8 +1632,8 @@ msgid "button_cancel"
 msgstr "Cancel·lar"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Tancar"
 
@@ -1720,9 +1717,9 @@ msgid "button_start_new_session"
 msgstr "Iniciar una nova sessió amb aquesta eina"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Iniciar sessió"
 
@@ -2186,17 +2183,17 @@ msgid "error_password_mismatch"
 msgstr "Les contrasenyes no coincideixen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Aquesta data ha de ser la data final o una data posterior."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Aquesta data ha de ser la data final o una data anterior."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Aquest valor ha de ser un número enter positiu."
 
@@ -2312,7 +2309,7 @@ msgid "explanation_risk_always_present"
 msgstr ""
 "Aquest risc s’ha establert com a existent per defecte. No es pot canviar."
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2428,12 +2425,12 @@ msgid "header_additional_content"
 msgstr "Contingut addicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Recursos addicionals per avaluar el risc"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Recursos additionals per a aquest mòdul"
 
@@ -2519,6 +2516,7 @@ msgstr "Llicències"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Inici de sessió"
 
@@ -2628,11 +2626,6 @@ msgstr "Fases del projecte"
 msgid "header_publish"
 msgstr "Publicar l'eina OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Preguntes respostes per mòdul"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2646,7 +2639,7 @@ msgid "header_reporting"
 msgstr "Informes"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Recursos"
 
@@ -2777,13 +2770,12 @@ msgid "header_why_oira"
 msgstr "Motius de la creació del projecte OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Comentaris"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Riscos d'alta prioritat"
 
@@ -2982,7 +2974,7 @@ msgstr ""
 "una còpia d'una eina OiRA existent."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indiqui amb quina freqüència es produeix aquest risc en una situació normal."
@@ -2995,13 +2987,13 @@ msgstr ""
 "així, l'usuari final podrà modificar-la."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indiqui la probabilitat que es produeixi aquest risc en una situació normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indiqui la gravetat en cas de produir-se aquest risc."
 
@@ -3359,7 +3351,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Sessió de prova"
 
@@ -3600,7 +3591,7 @@ msgid "label_body"
 msgstr "Contingut de la pàgina"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Ometre"
 
@@ -3636,7 +3627,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Si us plau, deixeu en aquest camp qualsevol comentari que pugueu tenir sobre "
@@ -3798,11 +3789,6 @@ msgstr "He oblidat la contrasenya"
 msgid "label_format"
 msgstr "Format"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Informació general"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3881,7 +3867,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referències legals i sobre polítiques"
@@ -3934,11 +3920,6 @@ msgstr "Accions concretes requerides per implementar aquest enfocament"
 msgid "label_measure_requirements"
 msgstr "Nivell de competència i/o requisits necessaris"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3974,38 +3955,34 @@ msgstr "Nova sessió de prova"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Següent"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "No"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "No hi ha cap risc"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "No hi ha cap riscos"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "No hi ha cap riscos"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "No hi ha cap riscos"
 
@@ -4025,12 +4002,12 @@ msgid "label_old_password"
 msgstr "Contrasenya actual"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Pàgina"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "de"
 
@@ -4062,9 +4039,9 @@ msgid "label_preview"
 msgstr "Previsualitzar"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
 
@@ -4082,7 +4059,7 @@ msgstr "Pregunta"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Publicat"
 
@@ -4099,7 +4076,7 @@ msgstr "Per quin mitjà s'ha assabentat de l'existència d'aquesta eina?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registrar-se"
 
@@ -4172,49 +4149,41 @@ msgstr "Tipus de risc"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Risc amb mesura/es"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Risc sense mesura"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Riscos amb mesura/es"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Riscos amb mesura/es"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riscos amb mesura/es"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Riscos sense mesura"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Riscos sense mesura"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riscos sense mesura"
 
@@ -4255,12 +4224,19 @@ msgstr "Títol del sector."
 msgid "label_select_measure"
 msgstr "Seleccioni una o més de les mesures comunes facilitades."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Iniciar una sessió nova escollint una de les eines sectorials següents"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4303,14 +4279,9 @@ msgid "label_start_identification"
 msgstr "Iniciar la identificació de riscos"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Iniciar"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "Iniciada"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4346,6 +4317,11 @@ msgstr "Nom de versió "
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Títol de l'eina OiRA importada"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4389,11 +4365,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr "Fer una sessió de prova"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4413,11 +4384,6 @@ msgstr "Nom de la versió de l'eina OiRA"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Eina utilitzada"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4440,7 +4406,7 @@ msgid "label_workers_participated"
 msgstr "S'ha convidat els treballadors a participar a l'avaluació de riscos"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Sí"
@@ -4472,18 +4438,17 @@ msgstr ""
 "${label} = Aquesta versió té canvis no publicats actualment. Faci clic a la "
 "icona d'actualització per activar tots els canvis"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "Limitacions"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Iniciar sessió"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4694,7 +4659,7 @@ msgstr "Configuració"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Grau d’emplenament"
 
@@ -4796,7 +4761,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4827,7 +4792,7 @@ msgid "portlet_header_versions"
 msgstr "Versions"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4869,6 +4834,11 @@ msgstr "Mitjana"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Baixa"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5177,14 +5147,14 @@ msgstr ""
 "atentament les condicions generals noves abans de continuar."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Aquí podeu consultar els ${benefits}${tooltip_benefits} i "
 "${limitations}${tooltip_limitations} d'una sessió de prova."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "O bé ${register_link}. Descobriu per què us hauríeu de registrar"
@@ -5282,14 +5252,9 @@ msgstr "Recuperar la contrasenya"
 msgid "title_sectors"
 msgstr "Sectors"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Estat de ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA: avaluació de riscos interactiva en línia"
@@ -5308,11 +5273,6 @@ msgstr "Despublicar \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "L'eina OiRA s'ha actualitzat"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Estat d’${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5425,6 +5385,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sí"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Preguntes respostes per mòdul"
+
+#~ msgid "label_general_information"
+#~ msgstr "Informació general"
+
+#~ msgid "label_started"
+#~ msgstr "Iniciada"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Eina utilitzada"
+
+#~ msgid "title_status_of"
+#~ msgstr "Estat de ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Estat d’${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "No s’han fet canvis en les mesures al vostre pla d’acció."

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -256,7 +256,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Dostupné nástroje OiRA"
 
@@ -416,7 +416,7 @@ msgstr "Musím se nějak připravit?"
 msgid "Documentation"
 msgstr "Dokumentace"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Dochází k tomu na více místech?"
 
@@ -444,7 +444,7 @@ msgstr "Stáhnout přehled opatření"
 msgid "Download the risks overview"
 msgstr "Stáhnout přehled rizik"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -473,11 +473,11 @@ msgstr "Editovat Profilová otázka"
 msgid "Email address/account name"
 msgstr "E-mailová adresa/název účtu"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Uveďte název místa"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Uveďte názvy všech míst"
 
@@ -554,7 +554,7 @@ msgstr ""
 "máte k dispozici, a poté se k němu v příhodnou chvíli vrátit a začít tam, "
 "kde jste minule skončili."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Chci se s vámi podělit o následující informace"
 
@@ -580,7 +580,7 @@ msgstr "Informace"
 msgid "Information"
 msgstr "Informace"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -609,16 +609,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "uloženo"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Další informace o tomto nástroji…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -842,7 +841,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Viz příklady uvedené pod formulářem."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Odloženo"
@@ -998,11 +996,11 @@ msgstr "Informace o sektoru a skupině pro klienta."
 msgid "Sector workflow"
 msgstr "Pracovní postup sektoru"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Modul `${name}` byla smazán."
 
@@ -1014,7 +1012,7 @@ msgstr "Název relace byl změněn na ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Sdílejte tento nástroj OiRA"
 
@@ -1048,7 +1046,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1109,7 +1107,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Základní struktura on-line interaktivního hodnocení rizik obsahuje:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1147,7 +1145,7 @@ msgstr "Online klient."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1159,7 +1157,7 @@ msgstr "Uvedená barva není platná."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Postup hodnocení rizik sestává ze čtyř hlavních etap:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1167,7 +1165,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Nebyly uloženy žádné změny."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Tento nástroj OiRA vám poskytuje ${external_site}"
 
@@ -1215,7 +1213,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Svět by se měl o tomto nástroji dozvědět! Sdílejte jej!"
 
@@ -1237,7 +1235,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Nezodpovězeno"
@@ -1541,7 +1538,7 @@ msgstr "Vytvořil ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "výhodách"
 
@@ -1609,8 +1606,8 @@ msgid "button_cancel"
 msgstr "Zrušit"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1694,9 +1691,9 @@ msgid "button_start_new_session"
 msgstr "Začněte s tímto nástrojem novou relaci."
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Spustit modul"
 
@@ -2145,17 +2142,17 @@ msgid "error_password_mismatch"
 msgstr "Hesla se neshodují"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Toto datum musí být k počátečnímu datu nebo po něm."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Toto datum musí být před datem ukončení."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Tato hodnota musí být kladné celé číslo."
 
@@ -2268,7 +2265,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2385,12 +2382,12 @@ msgid "header_additional_content"
 msgstr "Další obsah"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Další zdroje pro hodnocení rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Dodatečné zdroje pro tento modul"
 
@@ -2474,6 +2471,7 @@ msgstr "Licence"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Přihlášení"
 
@@ -2583,11 +2581,6 @@ msgstr "Fáze projektu"
 msgid "header_publish"
 msgstr "Publikovat nástroj OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Zodpovězené otázky na jeden modul"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2601,7 +2594,7 @@ msgid "header_reporting"
 msgstr "Podávání zpráv"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Zdroje"
 
@@ -2730,13 +2723,12 @@ msgid "header_why_oira"
 msgstr "Proč projekt OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Připomínky"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Rizika s vysokou prioritou"
 
@@ -2932,7 +2924,7 @@ msgstr ""
 "kopií stávajícího nástroje OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Uveďte, jak často se riziko objevuje v běžné situaci."
 
@@ -2944,13 +2936,13 @@ msgstr ""
 "může prioritu změnit."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, jak moc je pravděpodobné, že se toto riziko objeví v běžné situaci."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Uveďte závažnost, pokud se toto riziko vyskytne."
 
@@ -3293,7 +3285,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Testovací modul"
 
@@ -3526,7 +3517,7 @@ msgid "label_body"
 msgstr "Obsah stránky"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Přeskočit"
 
@@ -3562,7 +3553,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Prosíme o případné připomínky k problematice uvedené v otázce výše Tyto "
@@ -3724,11 +3715,6 @@ msgstr "Zapomněl jsem své heslo"
 msgid "label_format"
 msgstr "Formát"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3807,7 +3793,7 @@ msgid "label_language"
 msgstr "Jazyk"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Odkazy na právní předpisy a postupy"
@@ -3860,11 +3846,6 @@ msgstr "Specifický/é krok/y požadované k implementaci tohoto přístupu"
 msgid "label_measure_requirements"
 msgstr "Míra potřebných znalostí a/nebo požadavků"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3902,38 +3883,34 @@ msgstr "Nový testovací modul"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Další"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Žádné riziko"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Žádné riziko"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Žádné riziko"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Žádné riziko"
 
@@ -3953,12 +3930,12 @@ msgid "label_old_password"
 msgstr "Současné heslo"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Strana"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "z"
 
@@ -3990,9 +3967,9 @@ msgid "label_preview"
 msgstr "Náhled"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Předchozí"
 
@@ -4010,7 +3987,7 @@ msgstr "Otázka"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Zveřejněná"
 
@@ -4027,7 +4004,7 @@ msgstr "Jakým kanálem jste se o tomto nástroji dozvěděl/a?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registrujte"
 
@@ -4098,49 +4075,41 @@ msgstr "Typ rizika"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Riziko bez opatření"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Riziko bez opatření"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Riziko bez opatření"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riziko bez opatření"
 
@@ -4181,12 +4150,19 @@ msgstr "Název sektoru."
 msgid "label_select_measure"
 msgstr "Zvolte jeden z uvedených známých a běžných kroků."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Zahajte nový modul zvolením následujících sektorových nástrojů"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4229,14 +4205,9 @@ msgid "label_start_identification"
 msgstr "Zahájit identifikaci rizik"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Start"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4272,6 +4243,11 @@ msgstr "Název verze"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Název importovaného nástroje OiRA"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4315,11 +4291,6 @@ msgstr "Druh nástroje OiRA"
 msgid "label_tryout"
 msgstr "spustit testovací modul"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4338,11 +4309,6 @@ msgstr "Název pro verzi nástroje OiRA"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4366,7 +4332,7 @@ msgid "label_workers_participated"
 msgstr "Zveme zaměstnance k účasti na vyhodnocení rizik"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Ano"
@@ -4398,18 +4364,17 @@ msgstr ""
 "${label} = Tato verze obsahuje změny, které nejsou v současné době "
 "publikované. Pro aktivaci všech změn klikněte na ikonu aktualizace"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "omezeních"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Přihlaste se"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4619,7 +4584,7 @@ msgstr "Nastavení"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Status"
 
@@ -4721,7 +4686,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4749,7 +4714,7 @@ msgid "portlet_header_versions"
 msgstr "Verze"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4791,6 +4756,11 @@ msgstr "Střední"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Malá"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5100,14 +5070,14 @@ msgstr ""
 "pečlivě si prosím přečtěte nové podmínky."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Zde si můžete přečíst o ${benefits}${tooltip_benefits} "
 "a ${limitations}${tooltip_limitations} testovacího modulu."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Nebo se můžete ${register_link}. Zjistěte, proč byste se měli zaregistrovat "
@@ -5205,14 +5175,9 @@ msgstr "Obnova hesla"
 msgid "title_sectors"
 msgstr "Sektory"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Stav ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Online interaktivní vyhodnocení rizik"
@@ -5231,11 +5196,6 @@ msgstr "Zrušit publikování \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Nástroj OiRA byl aktualizován"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Stav ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5345,6 +5305,15 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ano"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Zodpovězené otázky na jeden modul"
+
+#~ msgid "title_status_of"
+#~ msgstr "Stav ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Stav ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Ve vašem akčním plánu nebyly provedeny žádné změny."

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -450,11 +450,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -579,16 +579,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Lær mere om dette værktøj…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -789,7 +788,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -933,11 +931,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -949,7 +947,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Del dette OiRA-værktøj"
 
@@ -983,7 +981,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1038,7 +1036,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1071,7 +1069,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1083,7 +1081,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1091,7 +1089,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1138,7 +1136,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Alle bør have glæde af dette værktøj. Del det med andre."
 
@@ -1160,7 +1158,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1414,7 +1411,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1481,8 +1478,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1566,9 +1563,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1946,17 +1943,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2050,7 +2047,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2161,12 +2158,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2250,6 +2247,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2359,11 +2357,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2377,7 +2370,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2505,13 +2498,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2701,7 +2693,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2711,12 +2703,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3005,7 +2997,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3201,7 +3192,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3237,7 +3228,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3397,11 +3388,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3480,7 +3466,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3533,11 +3519,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3573,38 +3554,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3624,12 +3601,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3661,9 +3638,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3681,7 +3658,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3698,7 +3675,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3769,49 +3746,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3852,11 +3821,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3900,13 +3876,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3942,6 +3913,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3986,11 +3962,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4009,11 +3980,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4037,7 +4003,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4067,18 +4033,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4274,7 +4239,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4376,7 +4341,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4401,7 +4366,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4442,6 +4407,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4735,12 +4705,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4836,14 +4806,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4861,11 +4826,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-10 14:56+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -238,7 +238,7 @@ msgstr ""
 "Sind Sie sicher, dass Sie forfahren wollen? Dieser Vorgang kann nicht "
 "rückgängig gemacht werden."
 
-#: euphorie/client/browser/risk.py:855
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Vorhandene OiRA Tools"
 
@@ -457,7 +457,7 @@ msgstr "Übersicht der Maßnahmen herunterladen"
 msgid "Download the risks overview"
 msgstr "Übersicht der Gefährdungen herunterladen"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-Mail"
@@ -565,7 +565,7 @@ msgstr ""
 "Allerdings können Sie eine Gefährdungsbeurteilung jederzeit unterbrechen und "
 "dann fortführen, wenn es Ihre Zeit erlaubt."
 
-#: euphorie/client/browser/webhelpers.py:700
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Ich würde Ihnen gerne folgendes Tool empfehlen"
 
@@ -591,7 +591,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informationen"
 
-#: euphorie/client/browser/risk.py:522
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Falsches Dateiformat für das Bild. Bitte verwenden Sie PNG oder JPEG."
 
@@ -624,11 +624,11 @@ msgstr ""
 msgid "Last saved"
 msgstr "Zuletzt gespeichert"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Erfahren Sie mehr über diese GBU-Vorlage…"
 
-#: euphorie/client/templates/shell.pt:303
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr "Die Sitzung wurde in “${name}” umbenannt."
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Dieses OiRA-Tool weitergeben"
 
@@ -1061,7 +1061,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Die generelle Struktur eines OiRA-Tools besteht aus:"
 
-#: euphorie/client/browser/risk.py:859
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1162,7 +1162,7 @@ msgstr "Der Online-Client."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:656
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Dieses Tool verdient es, überall bekannt zu werden! Geben Sie es weiter!"
@@ -1591,7 +1591,7 @@ msgstr "Produziert von ${EU-OSHA}."
 msgid "based on"
 msgstr "basiert auf"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "Vorteile"
 
@@ -1660,8 +1660,8 @@ msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:697
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Schließen"
 
@@ -1745,9 +1745,9 @@ msgid "button_start_new_session"
 msgstr "Neue GBU mit dieser Vorlage beginnen"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Sitzung beginnen"
 
@@ -2226,17 +2226,17 @@ msgid "error_password_mismatch"
 msgstr "Die Passwörter stimmen nicht überein."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:868
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Dieses Datum muss nach dem Startdatum liegen."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:864
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Dieses Datum muss vor dem Enddatum liegen."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Dieser Wert muss eine ganze positive Zahl sein."
 
@@ -2548,6 +2548,7 @@ msgstr "Lizenzen"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Anmelden"
 
@@ -3005,7 +3006,7 @@ msgstr ""
 "Sie dies basierend auf der Kopie eines bestehenden OiRA-Tools tun möchten ..."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:317 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Geben Sie an, wie oft diese Gefährdung unter normalen Bedingungen auftritt."
@@ -3018,14 +3019,14 @@ msgstr ""
 "unterstützen. Er/sie hat die Möglichkeit, die Priorität zu ändern."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:312 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geben Sie an, wie wahrscheinlich das Auftreten der Gefährdung unter normalen "
 "Bedingungen ist."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Geben Sie den Schweregrad für das Eintreten dieser Gefährdung an."
 
@@ -3396,7 +3397,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Test-Sitzung"
 
@@ -4060,12 +4060,12 @@ msgid "label_old_password"
 msgstr "Aktuelles Passwort"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:827
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Seite"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:830
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "von"
 
@@ -4134,7 +4134,7 @@ msgstr "Wo haben Sie von diesem Tool erfahren?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registrieren"
 
@@ -4284,14 +4284,21 @@ msgstr ""
 "Wählen Sie eine oder mehrere der angebotenen bekannten, allgemeinen "
 "Maßnahmen."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Neue Sitzung durch Auswahl eines der folgenden branchenspezifischen Tools "
 "starten"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr "GBU-Vorlage auswählen"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4334,7 +4341,7 @@ msgid "label_start_identification"
 msgstr "Gefährdungsermittlung starten"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Starten"
 
@@ -4372,6 +4379,11 @@ msgstr "Versionsname"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Name des importierten OiRA-Tools"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4490,18 +4502,17 @@ msgstr ""
 "Änderungen. Klicken Sie auf das Aktualisieren-Symbol, um alle Änderungen "
 "live zu schalten."
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "Einschränkungen"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Anmelden"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4826,7 +4837,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Ihr Passwort muss aus mindestens 5 Zeichen bestehen, davon ein "
@@ -4858,7 +4869,7 @@ msgid "portlet_header_versions"
 msgstr "Versionen"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:600
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4902,7 +4913,7 @@ msgid "probability_small"
 msgstr "Niedrig"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:245
+#: euphorie/client/browser/webhelpers.py:251
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Vollständig"
 
@@ -5221,14 +5232,14 @@ msgstr ""
 "fortfahren."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Hier können Sie sich über die ${benefits}${tooltip_benefits} und "
 "${limitations}${tooltip_limitations} einer Test-Sitzung informieren."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Oder ${register_link} Sie sich stattdessen. Lesen Sie hier warum sich eine "
@@ -5327,8 +5338,8 @@ msgid "title_sectors"
 msgstr "Branchen"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -249,7 +249,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -273,7 +273,7 @@ msgstr "Θέλετε να συνεχίσετε;"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Διαθέσιμα εργαλεία OiRA"
 
@@ -442,7 +442,7 @@ msgstr "Χρειάζεται ειδική προετοιμασία;"
 msgid "Documentation"
 msgstr "Έγγραφα"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Συμβαίνει αυτό σε πολλούς χώρους;"
 
@@ -470,7 +470,7 @@ msgstr "Μεταφόρτωση του καταλόγου επισκόπησης 
 msgid "Download the risks overview"
 msgstr "Μεταφόρτωση του καταλόγου επισκόπησης όλων των κινδύνων"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Ηλεκτρονικό ταχυδρομείο"
@@ -499,11 +499,11 @@ msgstr "Επεξεργασία Ερώτηση προφίλ"
 msgid "Email address/account name"
 msgstr "Διεύθυνση email/όνομα λογαριασμού "
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Εισαγωγή ονομασίας τοποθεσίας"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Εισαγωγή ονομασίας κάθε τοποθεσίας"
 
@@ -586,7 +586,7 @@ msgstr ""
 "άλλη στιγμή το θελήσετε στο μέλλον, συνεχίζοντας από το σημείο όπου "
 "σταματήσατε. "
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Θέλω να μοιραστώ μαζί σας τα παρακάτω"
 
@@ -612,7 +612,7 @@ msgstr "Πληροφορίες"
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Μη αποδεκτός τύπος αρχείου εικόνας. Αποδεκτοί τύποι αρχείων εικόνας PNG, "
@@ -645,16 +645,15 @@ msgid "Kosovo"
 msgstr "Κοσσυφοπέδιο"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "αποθηκεύτηκε"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Μάθετε περισσότερα σχετικά με αυτό το εργαλείο…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -884,7 +883,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Βλέπε τα παραδείγματα κάτω από το έντυπο"
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Κίνδυνος σε εκκρεμότητα"
@@ -1042,11 +1040,11 @@ msgstr "Πληροφορίες τομέα και κατάταξη για τον 
 msgid "Sector workflow"
 msgstr "Ροή εργασίας τομέα"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Η μελέτη Εκτίμησης Κινδύνου `${name}` διαγράφηκε."
 
@@ -1058,7 +1056,7 @@ msgstr "Ο τίτλος της ενότητας άλλαξε σε ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Μοιραστείτε αυτό το εργαλείο OiRA"
 
@@ -1092,7 +1090,7 @@ msgid "Started"
 msgstr "ημερομηνία έναρξης"
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1156,7 +1154,7 @@ msgstr ""
 "Η βασική αρχιτεκτονική μιας επιγραμμικής διαδραστικής εκτίμησης κινδύνου "
 "αποτελείται από:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1196,7 +1194,7 @@ msgstr "Ο online πελάτης."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1210,7 +1208,7 @@ msgstr ""
 "Υπάρχουν τέσσερα βασικά στάδια για την ολοκλήρωση της διαδικασίας εκπόνησης "
 "μιας μελέτης εκτίμησης των επαγγελματικών κινδύνων:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1218,7 +1216,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Δεν υπάρχουν αλλαγές για αποθήκευση."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Το παρόν εργαλείο OiRA σάς παρέχεται από ${external_site}"
 
@@ -1269,7 +1267,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Αυτό το εργαλείο αξίζει να γίνει γνωστό σε όλο τον κόσμο! Μοιραστείτε το!"
@@ -1292,7 +1290,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Υπό εξέταση κίνδυνος"
@@ -1616,7 +1613,7 @@ msgstr "Δημιουργία ${EU-OSHA}."
 msgid "based on"
 msgstr "με βάση το"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "οφέλη"
 
@@ -1684,8 +1681,8 @@ msgid "button_cancel"
 msgstr "Άκυρο"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "κλείσιμο"
 
@@ -1769,9 +1766,9 @@ msgid "button_start_new_session"
 msgstr "Έναρξη νέας συνόδου με αυτό το εργαλείο"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Έναρξη της μελέτης Εκτίμησης Κινδύνου"
 
@@ -2244,19 +2241,19 @@ msgid "error_password_mismatch"
 msgstr "Οι κωδικοί πρόσβασης δεν είναι ίδιοι"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας έναρξης."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας λήξης."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Αυτή η τιμή πρέπει να είναι θετικός ακέραιος αριθμός."
 
@@ -2380,7 +2377,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2497,12 +2494,12 @@ msgid "header_additional_content"
 msgstr "Συμπληρωματικό περιεχόμενο"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Πρόσθετο πληροφοριακό υλικό για την εκτίμηση του κινδύνου"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Πρόσθετη πληροφόρηση γι’ αυτή τη θεματική ενότητα"
 
@@ -2588,6 +2585,7 @@ msgstr "Άδειες χρήσης"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Σύνδεση"
 
@@ -2698,11 +2696,6 @@ msgstr "Φάσεις έργου"
 msgid "header_publish"
 msgstr "Δημοσίευση Εργαλείου OiRA "
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Ερωτήσεις που απαντήθηκαν ανά ενότητα"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2716,7 +2709,7 @@ msgid "header_reporting"
 msgstr "Σύνταξη έκθεσης"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Πηγές Πληροφόρησης"
 
@@ -2845,13 +2838,12 @@ msgid "header_why_oira"
 msgstr "Γιατί το έργο OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Σχόλια / Υφιστάμενα μέτρα (αν υπάρχουν)"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Κίνδυνοι υψηλής επικινδυνότητας"
 
@@ -3052,7 +3044,7 @@ msgstr ""
 "αρχίσετε με ένα αντίγραφο κάποιου υπάρχοντος Εργαλείου OiRA. "
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο συχνά εκτίθενται οι εργαζόμενοι στον "
@@ -3066,14 +3058,14 @@ msgstr ""
 "προτεραιότητα. Ο χρήστης μπορεί να αλλάξει την προτεραιότητα."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο πιθανό είναι να εκδηλωθεί ο κίνδυνος "
 "αυτός σε φυσιολογικές συνθήκες."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο σοβαρές μπορεί να είναι οι επιπτώσεις "
@@ -3446,7 +3438,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Αυτή η έκδοση του εργαλείου είναι δοκιμαστική."
 
@@ -3695,7 +3686,7 @@ msgid "label_body"
 msgstr "Περιεχόμενο σελίδας"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Παράλειψη"
 
@@ -3731,7 +3722,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Παρακαλώ υποβάλλετε στο πεδίο αυτό τυχόν σχόλια σχετικά με την παραπάνω "
@@ -3893,11 +3884,6 @@ msgstr "Ξέχασα τον κωδικό πρόσβασης"
 msgid "label_format"
 msgstr "Τύπος"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Γενικές πληροφορίες"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3976,7 +3962,7 @@ msgid "label_language"
 msgstr "Γλώσσα"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Νομικές αναφορές και αναφορές πολιτικής"
@@ -4031,11 +4017,6 @@ msgstr "Απαιτείται ειδική ενέργεια(-ες) για την 
 msgid "label_measure_requirements"
 msgstr "Απαιτήσεις"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -4073,38 +4054,34 @@ msgstr "Νέα μελέτη Εκτίμησης Κινδύνου με τη δοκ
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Επόμενο"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Όχι"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
@@ -4124,12 +4101,12 @@ msgid "label_old_password"
 msgstr "Τρέχων κωδικός πρόσβασης "
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Σελίδα"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "από"
 
@@ -4161,9 +4138,9 @@ msgid "label_preview"
 msgstr "Προεπισκόπηση"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Προηγούμενο"
 
@@ -4181,7 +4158,7 @@ msgstr "Ερώτηση"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Δημοσιεύτηκε"
 
@@ -4198,7 +4175,7 @@ msgstr "Πληροφορηθήκατε για αυτό το εργαλείο α�
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "εγγραφείτε"
 
@@ -4273,49 +4250,41 @@ msgstr "Τύπος κινδύνου"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
@@ -4358,14 +4327,21 @@ msgstr ""
 "Επιλέξτε ένα ή περισσότερα από τα γνωστά και κοινώς αποδεκτά μέτρα που "
 "προτείνονται."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Αρχίστε μια νέα μελέτη Εκτίμησης Κινδύνου, επιλέγοντας ένα από τα παρακάτω "
 "κλαδικά εργαλεία"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4408,14 +4384,9 @@ msgid "label_start_identification"
 msgstr "Ξεκίνησε την Αναγνώριση των Κινδύνων"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Έναρξη"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "ημερομηνία έναρξης"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4451,6 +4422,11 @@ msgstr "Όνομα έκδοσης"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Τίτλος εισαχθέντος εργαλείου OiRA"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4494,11 +4470,6 @@ msgstr "Τύπος εργαλείου OiRA"
 msgid "label_tryout"
 msgstr "εκτελέσετε τη δοκιμαστική έκδοση του εργαλείου"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4518,11 +4489,6 @@ msgstr "Όνομα για την έκδοση του Εργαλείου OiRA"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Εργαλείο που χρησιμοποιήθηκε ως βάση"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4545,7 +4511,7 @@ msgid "label_workers_participated"
 msgstr "Προσκλήθηκαν εργαζόμενοι για να μετάσχουν στην εκτίμηση κινδύνου:"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Ναι"
@@ -4578,18 +4544,17 @@ msgstr ""
 "συγκεκριμένη στιγμή. Κάντε κλικ στο εικονίδιο ενημέρωσης για να εμφανιστούν "
 "όλες οι αλλαγές"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "περιορισμοί"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Σύνδεση"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4810,7 +4775,7 @@ msgstr "Ρυθμίσεις"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Παρούσα Κατάσταση"
 
@@ -4912,7 +4877,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4944,7 +4909,7 @@ msgid "portlet_header_versions"
 msgstr "Εκδόσεις"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4986,6 +4951,11 @@ msgstr "Μέτρια"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Χαμηλή"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5302,14 +5272,14 @@ msgstr ""
 "συνεχίσετε."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Διαβάστε εδώ για τα ${benefits}${tooltip_benefits} και τους "
 "${limitations}${tooltip_limitations} της δοκιμαστικής έκδοσης του εργαλείου."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Ή, αντ' αυτού, κάνετε ${register_link}. Μάθετε γιατί είναι καλό να "
@@ -5407,14 +5377,9 @@ msgstr "Ανάκτηση Κωδικού Πρόσβασης"
 msgid "title_sectors"
 msgstr "Κλάδοι"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Παρούσα κατάσταση της μελέτης Εκτίμησης Κινδύνου ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Online διαδραστική Αξιολόγηση Κινδύνων"
@@ -5433,11 +5398,6 @@ msgstr "Αναίρεση δημοσίευσης \"${title} "
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Το Εργαλείο OiRA έχει ενημερωθεί"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Παρούσα κατάσταση της μελέτης Εκτίμησης Κινδύνου ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5555,6 +5515,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ναι"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Ερωτήσεις που απαντήθηκαν ανά ενότητα"
+
+#~ msgid "label_general_information"
+#~ msgstr "Γενικές πληροφορίες"
+
+#~ msgid "label_started"
+#~ msgstr "ημερομηνία έναρξης"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Εργαλείο που χρησιμοποιήθηκε ως βάση"
+
+#~ msgid "title_status_of"
+#~ msgstr "Παρούσα κατάσταση της μελέτης Εκτίμησης Κινδύνου ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Παρούσα κατάσταση της μελέτης Εκτίμησης Κινδύνου ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr ""
@@ -444,11 +444,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -520,7 +520,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -573,16 +573,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -783,7 +782,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -927,11 +925,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -943,7 +941,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr ""
 
@@ -977,7 +975,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1032,7 +1030,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1065,7 +1063,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1077,7 +1075,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1085,7 +1083,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1132,7 +1130,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 
@@ -1154,7 +1152,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1408,7 +1405,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1475,8 +1472,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1560,9 +1557,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1938,17 +1935,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2042,7 +2039,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2153,12 +2150,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2242,6 +2239,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2351,11 +2349,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2369,7 +2362,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2497,13 +2490,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2693,7 +2685,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2703,12 +2695,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2996,7 +2988,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3192,7 +3183,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3228,7 +3219,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3388,11 +3379,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3471,7 +3457,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3524,11 +3510,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3564,38 +3545,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3615,12 +3592,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3652,9 +3629,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3672,7 +3649,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3689,7 +3666,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3760,49 +3737,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3843,11 +3812,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3891,13 +3867,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3933,6 +3904,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3977,11 +3953,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4000,11 +3971,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4028,7 +3994,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4058,18 +4024,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4265,7 +4230,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4367,7 +4332,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4392,7 +4357,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4433,6 +4398,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4730,12 +4700,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4831,14 +4801,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4856,11 +4821,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab-fr-evaluation-5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -259,7 +259,7 @@ msgstr "¿Está seguro que quiere continuar?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Herramientas OiRA disponibles"
 
@@ -423,7 +423,7 @@ msgstr "¿Necesito algún tipo de preparación previa?"
 msgid "Documentation"
 msgstr "Documentación"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "¿Sucede esto en varios lugares?"
 
@@ -451,7 +451,7 @@ msgstr "Descargar el resumen de las medidas"
 msgid "Download the risks overview"
 msgstr "Descargar el resumen de riesgos"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Correo electrónico"
@@ -480,11 +480,11 @@ msgstr "Editar Pregunta de perfil"
 msgid "Email address/account name"
 msgstr "Dirección de correo electrónico/nombre de la cuenta"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Introduzca el nombre de la ubicación"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Introduzca el nombre de cada ubicación"
 
@@ -560,7 +560,7 @@ msgstr ""
 "Sin embargo, puede seguir con la evaluación el tiempo de que disponga y "
 "después continuar en el mismo punto en que lo dejó."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Deseo compartir el siguiente enlace"
 
@@ -586,7 +586,7 @@ msgstr "Información"
 msgid "Information"
 msgstr "Información"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Formato de archivo inválido para imagen. Por favor utilice PNG, JPEG o GIF."
@@ -618,16 +618,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "Guardado"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Aprenda más sobre esta herramienta…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -851,7 +850,6 @@ msgid "Please refer to the examples below the form."
 msgstr " Por favor, consulte los ejemplos debajo del formulario."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Pospuesto"
@@ -1009,11 +1007,11 @@ msgstr "Información de sector y grupo del cliente."
 msgid "Sector workflow"
 msgstr "Flujo de trabajo de sector"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Se ha borrado la sesión «${name}»."
 
@@ -1025,7 +1023,7 @@ msgstr "El título de la sesión se ha cambiado a ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Comparta esta herramienta OiRA"
 
@@ -1059,7 +1057,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1122,7 +1120,7 @@ msgstr ""
 "La arquitectura básica de una herramienta interactiva de  evaluación de "
 "riesgos en línea, consiste en:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1160,7 +1158,7 @@ msgstr "El cliente online."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1172,7 +1170,7 @@ msgstr "El color especificado no es válido."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "El proceso de evaluación consta de cuatro etapas principales: "
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1180,7 +1178,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Ningún cambio que guardar."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Esta herramienta OiRA ha sido creada por ${external_site}"
 
@@ -1230,7 +1228,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Esta herramienta merece llegar al conocimiento de una audiencia mundial. "
@@ -1254,7 +1252,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Sin respuesta"
@@ -1569,7 +1566,7 @@ msgstr "Producido por ${EU-OSHA}."
 msgid "based on"
 msgstr "basada en"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "ventajas "
 
@@ -1638,8 +1635,8 @@ msgid "button_cancel"
 msgstr "Cancelar"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Cerrar"
 
@@ -1723,9 +1720,9 @@ msgid "button_start_new_session"
 msgstr "Iniciar una nueva sesión con esta herramienta"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Iniciar sesión"
 
@@ -2191,17 +2188,17 @@ msgid "error_password_mismatch"
 msgstr "Las contraseñas no coinciden"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Esta fecha debe ser igual o posterior a la fecha de inicio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Esta fecha debe ser igual o anterior a la fecha de finalización."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "El valor debe ser un número entero positivo."
 
@@ -2316,7 +2313,7 @@ msgstr ""
 "Este riesgo se ha establecido como existente por defecto. No se puede "
 "cambiar."
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2433,12 +2430,12 @@ msgid "header_additional_content"
 msgstr "Contenido adicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Recursos adicionales para evaluar el riesgo"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Recursos adicionales para este módulo"
 
@@ -2522,6 +2519,7 @@ msgstr "Licencias"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Entrar"
 
@@ -2631,11 +2629,6 @@ msgstr "Fases del proyecto"
 msgid "header_publish"
 msgstr "Publicar herramienta OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Preguntas respondidas por módulo"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2649,7 +2642,7 @@ msgid "header_reporting"
 msgstr "Informes"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Recursos"
 
@@ -2778,13 +2771,12 @@ msgid "header_why_oira"
 msgstr "El motivo del proyecto OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Comentarios"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Riesgos de prioridad alta"
 
@@ -2985,7 +2977,7 @@ msgstr ""
 "empezar con una copia de una herramienta OiRA existente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indicar con qué frecuencia se produce el riesgo en una situación normal."
@@ -2998,13 +2990,13 @@ msgstr ""
 "usuario podrá seguir cambiando la prioridad."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indicar la probabilidad de que ocurra este riesgo en una situación normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indique la gravedad si este riesgo se produce."
 
@@ -3359,7 +3351,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Sesión de prueba"
 
@@ -3605,7 +3596,7 @@ msgid "label_body"
 msgstr "Contenido de página"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Omitir"
 
@@ -3641,7 +3632,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Por favor, deje cualquier comentario que tenga sobre la pregunta anterior en "
@@ -3803,11 +3794,6 @@ msgstr "Olvidé mi contraseña"
 msgid "label_format"
 msgstr "Formato"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Información general"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3886,7 +3872,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referencias legales y de política"
@@ -3939,11 +3925,6 @@ msgstr "Acciones específicas necesarias para implantar este enfoque"
 msgid "label_measure_requirements"
 msgstr "Nivel de experiencia y/o requisitos necesarios"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3981,38 +3962,34 @@ msgstr "Nueva sesión de prueba"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Siguiente"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "No"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Sin riesgo"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Sin riesgo"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Sin riesgo"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Sin riesgo"
 
@@ -4032,12 +4009,12 @@ msgid "label_old_password"
 msgstr "Contraseña actual"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Página"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "de"
 
@@ -4069,9 +4046,9 @@ msgid "label_preview"
 msgstr "Vista previa"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
 
@@ -4089,7 +4066,7 @@ msgstr "Pregunta"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Publicada"
 
@@ -4106,7 +4083,7 @@ msgstr "¿Cómo conoció esta herramienta?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registrarse"
 
@@ -4179,49 +4156,41 @@ msgstr "Tipo de riesgo"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Riesgo con medida(s)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Riesgo sin medidas"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Riesgos con medida(s)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Riesgos con medida(s)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riesgos con medida(s)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Riesgos sin medidas"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Riesgos sin medidas"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riesgos sin medidas"
 
@@ -4262,14 +4231,21 @@ msgstr "Título del sector"
 msgid "label_select_measure"
 msgstr "Seleccione una o varias de las medidas habituales indicadas."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Inicie una nueva sesión mediante la selección de una de las siguientes "
 "herramientas sectoriales"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4312,14 +4288,9 @@ msgid "label_start_identification"
 msgstr "Iniciar la identificación de Riesgos"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Iniciar"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "iniciada"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4355,6 +4326,11 @@ msgstr "Nombre de la versión"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Título de la herramienta OiRA importada"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4398,11 +4374,6 @@ msgstr "Tipo de herramienta OiRA "
 msgid "label_tryout"
 msgstr "efectuar una sesión de prueba"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4422,11 +4393,6 @@ msgstr "Nombre de la versión de la herramienta OiRA"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Herramienta utilizada"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4449,7 +4415,7 @@ msgid "label_workers_participated"
 msgstr "Se ha invitado a los usuarios a participar en la evaluación de riesgos"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Sí"
@@ -4481,18 +4447,17 @@ msgstr ""
 "${label} = Esta versión tiene cambios sin publicar. Haga clic en el icono de "
 "actualizar para publicar todos los cambios"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "limitaciones"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Identifíquese"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4703,7 +4668,7 @@ msgstr "Ajustes"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Grado de cumplimentación"
 
@@ -4805,7 +4770,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr "Contraseña de confirmación"
 
@@ -4835,7 +4800,7 @@ msgid "portlet_header_versions"
 msgstr "Versiones"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4877,6 +4842,11 @@ msgstr "Media"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Pequeña"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5189,14 +5159,14 @@ msgstr ""
 "nuevos términos y condiciones detenidamente antes de continuar."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Infórmese aquí sobre las ${benefits}${tooltip_benefits} y las "
 "${limitations}${tooltip_limitations} de una sesión de prueba."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "O bien ${register_link}. Sepa por qué debería registrarse "
@@ -5294,14 +5264,9 @@ msgstr "Recuperar la contraseña"
 msgid "title_sectors"
 msgstr "Sectores"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Estado de ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Evaluación de riesgos interactiva en línea"
@@ -5320,11 +5285,6 @@ msgstr "No publicar \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Se ha actualizado la herramienta OiRA"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Estado de ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5438,6 +5398,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sí"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Preguntas respondidas por módulo"
+
+#~ msgid "label_general_information"
+#~ msgstr "Información general"
+
+#~ msgid "label_started"
+#~ msgstr "iniciada"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Herramienta utilizada"
+
+#~ msgid "title_status_of"
+#~ msgstr "Estado de ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Estado de ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-post"
@@ -450,11 +450,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -579,16 +579,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Lisateave selle tööriista kohta…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -789,7 +788,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -933,11 +931,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -949,7 +947,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Jagage seda OiRA vahendit"
 
@@ -983,7 +981,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1038,7 +1036,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1071,7 +1069,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1083,7 +1081,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1091,7 +1089,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1138,7 +1136,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "See vahend väärib tutvustamist maailmale! Jagage seda!"
 
@@ -1160,7 +1158,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1414,7 +1411,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1481,8 +1478,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1566,9 +1563,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1946,17 +1943,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2050,7 +2047,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2161,12 +2158,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2250,6 +2247,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2359,11 +2357,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2377,7 +2370,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2505,13 +2498,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2701,7 +2693,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2711,12 +2703,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3004,7 +2996,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3200,7 +3191,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3236,7 +3227,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3396,11 +3387,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3479,7 +3465,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3532,11 +3518,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3572,38 +3553,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3623,12 +3600,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3660,9 +3637,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3680,7 +3657,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3697,7 +3674,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3768,49 +3745,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3851,11 +3820,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3899,13 +3875,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3941,6 +3912,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3985,11 +3961,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4008,11 +3979,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4036,7 +4002,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4066,18 +4032,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4273,7 +4238,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4375,7 +4340,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4400,7 +4365,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4441,6 +4406,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4734,12 +4704,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4835,14 +4805,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4860,11 +4825,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid "Are you sure you want to delete this measure? This action can not be reverted."
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr ""
@@ -422,11 +422,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "However, you can spend whatever time you have available on an assessment and then return to it when convenient to pick up from the same point you left off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -546,16 +546,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -739,7 +738,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -874,11 +872,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -890,7 +888,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr ""
 
@@ -924,7 +922,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -973,7 +971,7 @@ msgstr ""
 msgid "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid "The current text in the fields 'Action plan', 'Prevention plan' and 'Requirements' of this measure will be overwritten. This action cannot be reverted. Are you sure you want to continue?"
 msgstr ""
 
@@ -997,7 +995,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1009,7 +1007,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1017,7 +1015,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1061,7 +1059,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 
@@ -1083,7 +1081,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1324,7 +1321,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1391,8 +1388,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1476,9 +1473,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1862,17 +1859,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -1966,7 +1963,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2078,12 +2075,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2167,6 +2164,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2276,11 +2274,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2294,7 +2287,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2422,13 +2415,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2619,7 +2611,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318
+#: euphorie/client/browser/risk.py:321
 #: euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
@@ -2630,13 +2622,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313
+#: euphorie/client/browser/risk.py:316
 #: euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322
+#: euphorie/client/browser/risk.py:325
 #: euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
@@ -2929,7 +2921,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3130,7 +3121,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3168,7 +3159,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3338,11 +3329,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68
 #: euphorie/content/templates/help_view.pt:33
@@ -3433,7 +3419,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120
 #: euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
@@ -3492,11 +3478,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51
 #: euphorie/content/page.py:19
@@ -3534,13 +3515,13 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94
 #: euphorie/client/templates/report_company.pt:70
 msgid "label_no"
@@ -3548,25 +3529,21 @@ msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3586,12 +3563,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3624,9 +3601,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3645,7 +3622,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3663,7 +3640,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3735,49 +3712,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3818,11 +3787,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3866,13 +3842,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3909,6 +3880,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3954,11 +3930,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -3977,11 +3948,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4006,7 +3972,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93
 #: euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
@@ -4037,18 +4003,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4244,7 +4209,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4346,7 +4311,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4371,7 +4336,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4412,6 +4377,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4713,12 +4683,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4815,14 +4785,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4840,11 +4805,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.1.1dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -255,7 +255,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Saatavilla olevat OiRA-työkalut"
 
@@ -414,7 +414,7 @@ msgstr "Miten valmistaudun?"
 msgid "Documentation"
 msgstr "Dokumentaatio"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Tapahtuuko tätä useammassa paikassa?"
 
@@ -442,7 +442,7 @@ msgstr "Lataa yhteenveto toimenpiteistä."
 msgid "Download the risks overview"
 msgstr "Lataa yhteenveto riskeistä"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Sähköposti"
@@ -471,11 +471,11 @@ msgstr "Muokkaa Profiilikysymys"
 msgid "Email address/account name"
 msgstr "Sähköpostiosoite/tilinimi"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Esitä sijaintipaikan nimi"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Esitä jokaisen sijaintipaikan nimi"
 
@@ -551,7 +551,7 @@ msgstr ""
 "Voit kulloinkin käyttää arviointiin aikaa sen verran kuin sinulla sitä on, "
 "ja myöhemmin palata siihen kohtaan, johon viimeksi jäit. "
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Haluan jakaa seuraavan kanssasi"
 
@@ -577,7 +577,7 @@ msgstr "Tiedot"
 msgid "Information"
 msgstr "Tiedot"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -606,16 +606,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "tallennettu"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Lisätietoja tästä työkalusta…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -839,7 +838,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Ota huomioon kaavakkeen alla olevat esimerkit."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "arvioimatta"
@@ -999,11 +997,11 @@ msgstr "Toimialatiedot ja ryhmitys asiakkaalle."
 msgid "Sector workflow"
 msgstr "Toimialan työnkulku"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Riskinarviointi \"${name}\" on poistettu."
 
@@ -1015,7 +1013,7 @@ msgstr "Istunnon nimi on muutettu muotoon ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Jaa tämä OiRA-työkalu"
 
@@ -1049,7 +1047,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1112,7 +1110,7 @@ msgstr ""
 "Online-muotoisen vuorovaikutteisen riskinarvioinnin perusarkkitehtuuri "
 "koostuu seuraavista tekijöistä :"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1150,7 +1148,7 @@ msgstr "Online-asiakas."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1162,7 +1160,7 @@ msgstr "Määritetty väri ei ole kelvollinen."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Riskinarviointimenettelyssä on neljää keskeistä vaihetta:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1170,7 +1168,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Tallennettavia muutoksia ei ollut."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Tämän OiRA-työvälineen tarjosi sinulle ${external_site}"
 
@@ -1220,7 +1218,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Kaikkien kannattaa tutustua tähän työkaluun! Jaa se!"
 
@@ -1242,7 +1240,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "vastaus puuttuu"
@@ -1574,7 +1571,7 @@ msgstr "Valmistaja ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "hyödyt"
 
@@ -1652,8 +1649,8 @@ msgid "button_cancel"
 msgstr "Peruuta"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 #, fuzzy
 msgid "button_close"
 msgstr "Sulje"
@@ -1750,9 +1747,9 @@ msgid "button_start_new_session"
 msgstr "Aloita uusi istunto."
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 #, fuzzy
 msgid "button_start_session"
 msgstr "Aloita"
@@ -2268,19 +2265,19 @@ msgid "error_password_mismatch"
 msgstr "Salasanat eivät täsmää"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 #, fuzzy
 msgid "error_validation_after_start_date"
 msgstr "Päivämäärän on oltava sama kuin alkamispäivä tai sitä myöhempi."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 #, fuzzy
 msgid "error_validation_before_end_date"
 msgstr "Päivämäärän on oltava sama kuin päättymispäivä tai sitä aiempi."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 #, fuzzy
 msgid "error_validation_positive_whole_number"
 msgstr "Kohtaan on merkittävä positiivinen kokonaisluku."
@@ -2414,7 +2411,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2550,13 +2547,13 @@ msgid "header_additional_content"
 msgstr "Ylimääräinen sisältö"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 #, fuzzy
 msgid "header_additional_resources"
 msgstr "Lisämateriaalia riskinarviointia varten."
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 #, fuzzy
 msgid "header_additional_resources_module"
 msgstr "Lisämateriaalia tähán osioon"
@@ -2652,6 +2649,7 @@ msgstr "Lisenssit"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 #, fuzzy
 msgid "header_login"
 msgstr "Kirjaudu sisään"
@@ -2778,12 +2776,6 @@ msgstr "Projektin vaiheet"
 msgid "header_publish"
 msgstr "OiRA-työkalun julkaisu"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-#, fuzzy
-msgid "header_questions_answered"
-msgstr "Vastatut väittämät ryhmiteltynä osioittain."
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2799,7 +2791,7 @@ msgid "header_reporting"
 msgstr "Raportointi"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Lisätietoa"
 
@@ -2947,13 +2939,12 @@ msgid "header_why_oira"
 msgstr "Miksi OiRA-projekti"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Kommentit"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 #, fuzzy
 msgid "heading_high_prio_risks"
 msgstr "Riskit, joiden riskitaso on korkea."
@@ -3188,7 +3179,7 @@ msgstr ""
 "olemassa olevan OiRA-työkalun kopiolla."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 #, fuzzy
 msgid "help_default_frequency"
 msgstr "Ilmoita, kuinka usein riski esiintyy normaalissa tilanteessa."
@@ -3202,7 +3193,7 @@ msgstr ""
 "vaihtaa prioriteetin."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 #, fuzzy
 msgid "help_default_probability"
 msgstr ""
@@ -3210,7 +3201,7 @@ msgstr ""
 "tilanteessa."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 #, fuzzy
 msgid "help_default_severity"
 msgstr "Ilmoita vakavuusaste tämän riskin ilmentyessä."
@@ -3611,7 +3602,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Tämä on kokeiluversio"
 
@@ -3881,7 +3871,7 @@ msgid "label_body"
 msgstr "Sivun sisältö"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Ohita"
 
@@ -3922,7 +3912,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 #, fuzzy
 msgid "label_comment"
 msgstr ""
@@ -4110,11 +4100,6 @@ msgstr "Olen unohtanut salasanani"
 msgid "label_format"
 msgstr "Formaatti"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 #, fuzzy
@@ -4208,7 +4193,7 @@ msgid "label_language"
 msgstr "Kieli"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 #, fuzzy
 msgid "label_legal_reference"
@@ -4273,11 +4258,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr "Tarvittava asiantuntemus ja/tai ulkopuolisen tuen tarve"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -4319,14 +4299,14 @@ msgstr "Uusi kokeilupohja"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 #, fuzzy
 msgid "label_next"
 msgstr "Seuraava"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 #, fuzzy
 msgid "label_no"
@@ -4334,28 +4314,24 @@ msgstr "Ei"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 #, fuzzy
 msgid "label_no_risk"
 msgstr "Ei riskiä"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 #, fuzzy
 msgid "label_no_risks_2"
 msgstr "Ei riskejä"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 #, fuzzy
 msgid "label_no_risks_3_4"
 msgstr "Ei riskejä"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 #, fuzzy
 msgid "label_no_risks_5_or_more"
 msgstr "Ei riskejä"
@@ -4378,13 +4354,13 @@ msgid "label_old_password"
 msgstr "Nykyinen salasana"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 #, fuzzy
 msgid "label_page"
 msgstr "Sivu"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 #, fuzzy
 msgid "label_page_of"
 msgstr "/"
@@ -4422,9 +4398,9 @@ msgid "label_preview"
 msgstr "Esikatselu"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 #, fuzzy
 msgid "label_previous"
 msgstr "Edellinen"
@@ -4445,7 +4421,7 @@ msgstr "Kysymys"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 #, fuzzy
 msgid "label_published"
 msgstr "Julkaistu"
@@ -4466,7 +4442,7 @@ msgstr "Minkä kautta olet tutustunut tähän työkaluun?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 #, fuzzy
 msgid "label_register"
 msgstr "rekisteröidy"
@@ -4547,56 +4523,48 @@ msgstr "Riskityyppi"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 #, fuzzy
 msgid "label_risk_with_measure"
 msgstr "Riski, johon on määritetty toimenpiteitä"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 #, fuzzy
 msgid "label_risk_without_measure"
 msgstr "Riski, josta puuttuu toimenpiteet"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 #, fuzzy
 msgid "label_risks_with_measure_2"
 msgstr "Riskit, joihin on määritetty toimenpiteitä"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 #, fuzzy
 msgid "label_risks_with_measure_3_4"
 msgstr "Riskit, joihin on määritetty toimenpiteitä"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 #, fuzzy
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riskit, joihin on määritetty toimenpiteitä"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 #, fuzzy
 msgid "label_risks_without_measure_2"
 msgstr "Riskit, joista puuttuvat toimenpiteet"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 #, fuzzy
 msgid "label_risks_without_measure_3_4"
 msgstr "Riskit, joista puuttuvat toimenpiteet"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 #, fuzzy
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riskit, joista puuttuvat toimenpiteet"
@@ -4643,13 +4611,20 @@ msgstr "Toimialan nimitys"
 msgid "label_select_measure"
 msgstr "Valitse yksi tai useampi tunnetuista yleisistä toimenpiteistä."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 #, fuzzy
 msgid "label_select_new_session"
 msgstr "Valitse yksi seuraavista toimialatyökaluista"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4700,15 +4675,10 @@ msgid "label_start_identification"
 msgstr "Aloita riskien tunnistaminen"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 #, fuzzy
 msgid "label_start_survey"
 msgstr "Aloita"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4751,6 +4721,11 @@ msgstr "Version nimi"
 #, fuzzy
 msgid "label_surveygroup_title"
 msgstr "Tuodun OiRA-työkalun otsikko"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4801,11 +4776,6 @@ msgstr "OIRA-välineen tyyppi"
 msgid "label_tryout"
 msgstr "testaa kokeiluversiota"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 #, fuzzy
@@ -4827,11 +4797,6 @@ msgstr "OiRA-työkaluversion nimi"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4859,7 +4824,7 @@ msgid "label_workers_participated"
 msgstr "Työntekijöitä oli pyydetty osallistumaan riskinarviointiin"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 #, fuzzy
 msgid "label_yes"
@@ -4895,18 +4860,17 @@ msgstr ""
 "${label} = Tässä versiossa on muutoksia, joita ei ole vielä julkaistu. "
 "Julkaise muutokset painamalla päivityskuvaketta"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "rajoitukset"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Kirjaudu sisään"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 #, fuzzy
@@ -5149,7 +5113,7 @@ msgstr "Asetukset"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 #, fuzzy
 msgid "navigation_status"
 msgstr "Riskinarvioinnin tila"
@@ -5263,7 +5227,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 #, fuzzy
 msgid "password_policy_conditions"
 msgstr ""
@@ -5298,7 +5262,7 @@ msgid "portlet_header_versions"
 msgstr "Versiot"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -5346,6 +5310,11 @@ msgstr "Keskitasoinen"
 #, fuzzy
 msgid "probability_small"
 msgstr "Pieni"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5703,7 +5672,7 @@ msgstr ""
 "käyttöehdot huolellisesti, ennen kuin jatkat."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 #, fuzzy
 msgid "testsession_benefits_limitations"
 msgstr ""
@@ -5711,7 +5680,7 @@ msgstr ""
 "${limitations}${tooltip_limitations} ."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 #, fuzzy
 msgid "testsession_register"
 msgstr ""
@@ -5824,15 +5793,9 @@ msgstr "Unohtunut salasana?"
 msgid "title_sectors"
 msgstr "Toimialat"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-#, fuzzy
-msgid "title_status_of"
-msgstr "\"${survey_title}\" riskinarvioinnin eteneminen"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 #, fuzzy
 msgid "title_tool"
@@ -5854,12 +5817,6 @@ msgstr "Peruuta julkaisu \"${title}\""
 #, fuzzy
 msgid "title_updated"
 msgstr "OiRA-työkalu on päivitetty"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-#, fuzzy
-msgid "title_with_vowel_status_of"
-msgstr "\"${survey_title}\" riskinarvioinnin eteneminen"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5988,6 +5945,18 @@ msgstr ""
 #, fuzzy
 msgid "yes"
 msgstr "Kyllä"
+
+#, fuzzy
+#~ msgid "header_questions_answered"
+#~ msgstr "Vastatut väittämät ryhmiteltynä osioittain."
+
+#, fuzzy
+#~ msgid "title_status_of"
+#~ msgstr "\"${survey_title}\" riskinarvioinnin eteneminen"
+
+#, fuzzy
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "\"${survey_title}\" riskinarvioinnin eteneminen"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Toimintasuunnitelmassa oleviin toimenpiteisiin ei tehty muutoksia."

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -243,7 +243,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Outils Oira disponibles"
 
@@ -431,7 +431,7 @@ msgstr "Dois-je me préparer?"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Cela se produit-il à plusieurs endroits?"
 
@@ -459,7 +459,7 @@ msgstr "Télécharger la vue d'ensemble des mesures"
 msgid "Download the risks overview"
 msgstr "Télécharger la vue d'ensemble des risques "
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Adresse électronique"
@@ -488,11 +488,11 @@ msgstr "Editer Question de profil"
 msgid "Email address/account name"
 msgstr "Adresse email/nom de compte"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Entrer le nom du lieu"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Entrer les noms de chaque lieu"
 
@@ -569,7 +569,7 @@ msgstr ""
 "limité puis y revenir lorsque vous le désirez pour reprendre là où vous vous "
 "étiez arrêté. "
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 "Je souhaite vous faire découvrir cet outil d'aide à l'évaluation des risques"
@@ -596,7 +596,7 @@ msgstr "Information"
 msgid "Information"
 msgstr "Information"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -626,16 +626,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "Sauvegardé"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "En savoir plus sur cet outil…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -857,7 +856,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Veuillez vous référer aux exemples présentés en dessous du formulaire."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "A faire"
@@ -1013,11 +1011,11 @@ msgstr "Informations secteur et regroupement pour le client. "
 msgid "Sector workflow"
 msgstr "Workflow du secteur"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "La session «${name}» a été supprimée."
 
@@ -1029,7 +1027,7 @@ msgstr "Le titre de la session a été modifié ainsi: ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Partager cet outil OiRA"
 
@@ -1063,7 +1061,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1126,7 +1124,7 @@ msgstr ""
 "L’architecture de base d’une évaluation des risques interactive en ligne est "
 "la suivante:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1164,7 +1162,7 @@ msgstr "Le client en ligne. "
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1176,7 +1174,7 @@ msgstr "La couleur indiquée n'est pas valide."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "La procédure d’évaluation comprend quatre étapes principales: "
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1184,7 +1182,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Aucun changement à enregistrer."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Cet outil OiRA vous est proposé par ${external_site}"
 
@@ -1234,7 +1232,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Tout le monde doit connaître cet outil! Partagez-le!"
 
@@ -1256,7 +1254,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Sans réponse"
@@ -1585,7 +1582,7 @@ msgstr "Produit par ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "avantages"
 
@@ -1654,8 +1651,8 @@ msgid "button_cancel"
 msgstr "Annuler "
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Fermer"
 
@@ -1739,9 +1736,9 @@ msgid "button_start_new_session"
 msgstr "Lancez une nouvelle session avec cet outil"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Commencer la session"
 
@@ -2215,17 +2212,17 @@ msgid "error_password_mismatch"
 msgstr "Les mots de passe ne correspondent pas "
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Cette date doit se situer après la date de début."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Cette date doit se situer avant la date de fin."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Cette valeur doit être un nombre entier positif."
 
@@ -2355,7 +2352,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2471,12 +2468,12 @@ msgid "header_additional_content"
 msgstr "Contenu supplémentaire"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Ressources supplémentaires pour évaluer le risque"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Ressources supplémentaires pour ce module"
 
@@ -2560,6 +2557,7 @@ msgstr "Licences"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Connexion"
 
@@ -2669,11 +2667,6 @@ msgstr "Phases du projet"
 msgid "header_publish"
 msgstr "Publier l'outil OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Questions ayant reçu une réponse par module"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2687,7 +2680,7 @@ msgid "header_reporting"
 msgstr "Rapport"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Ressources"
 
@@ -2818,13 +2811,12 @@ msgid "header_why_oira"
 msgstr "Pourquoi le projet OiRA "
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Commentaires"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Risque hautement prioritaire"
 
@@ -3023,7 +3015,7 @@ msgstr ""
 "souhaitez démarrer avec une copie d'un outil OiRA existant."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indiquez la fréquence de l’apparition de ce risque dans une situation "
@@ -3037,14 +3029,14 @@ msgstr ""
 "défaut. Il / Elle peut toujours changer la priorité."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indiquez le degré de probabilité de l’apparition de ce risque dans une "
 "situation normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indiquer la gravité si ce risque se produit."
 
@@ -3406,7 +3398,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Session d'essai"
 
@@ -3678,7 +3669,7 @@ msgid "label_body"
 msgstr "Contenu de la page "
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Passer"
 
@@ -3714,7 +3705,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Vous pouvez écrire ici tout commentaire se rapportant à cette question. Vous "
@@ -3876,11 +3867,6 @@ msgstr "J'ai oublié mon mot de passe"
 msgid "label_format"
 msgstr "Format"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3959,7 +3945,7 @@ msgid "label_language"
 msgstr "Langue"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Références légales et de politique"
@@ -4015,11 +4001,6 @@ msgstr ""
 "Indiquez les compétences spécifiques nécessaires ou précisez quelle(s) "
 "fonction(s) de l'entreprise est (sont) à mobiliser."
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -4055,38 +4036,34 @@ msgstr "Nouvelle session d'essai"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Suivant"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Non"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Pas de risque"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Pas de risque"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Pas de risque"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Pas de risque"
 
@@ -4106,12 +4083,12 @@ msgid "label_old_password"
 msgstr "Mot de passe actuel"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Page"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "sur"
 
@@ -4143,9 +4120,9 @@ msgid "label_preview"
 msgstr "Précédent"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Précédent"
 
@@ -4163,7 +4140,7 @@ msgstr "Question"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Publiée"
 
@@ -4180,7 +4157,7 @@ msgstr "Au travers de quel canal avez-vous connu cet outil ?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "vous inscrire"
 
@@ -4251,49 +4228,41 @@ msgstr "Type de risque"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Risque avec mesure(s)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Risque sans mesure"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Risques avec mesure(s)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Risques avec mesure(s)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risques avec mesure(s)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Risques sans mesure"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Risques sans mesure"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risques sans mesure"
 
@@ -4334,12 +4303,19 @@ msgstr "Titre du secteur."
 msgid "label_select_measure"
 msgstr "Sélectionner une ou plusieurs des mesures communes connues fournies."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Choisissez votre secteur dans le menu déroulant ci-dessous"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4382,14 +4358,9 @@ msgid "label_start_identification"
 msgstr "Commencer l'identification des risques"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Commencer"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4425,6 +4396,11 @@ msgstr "Nom de version"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Titre de l'Outil OiRA importé"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4468,11 +4444,6 @@ msgstr "Type d’outil OiRA"
 msgid "label_tryout"
 msgstr "démarrer une session d'essai"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4491,11 +4462,6 @@ msgstr "Nom de la version de l'outil OiRA"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4519,7 +4485,7 @@ msgid "label_workers_participated"
 msgstr "Des salariés ont été invités à participer à l'évaluation des risques."
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Oui"
@@ -4553,18 +4519,17 @@ msgstr ""
 "Cliquez sur l’icône de mise à jour pour prendre en compte toutes les "
 "modifications"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "limites"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Connexion"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4776,7 +4741,7 @@ msgstr "Paramètres"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Avancement"
 
@@ -4878,7 +4843,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4910,7 +4875,7 @@ msgid "portlet_header_versions"
 msgstr "Versions"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4952,6 +4917,11 @@ msgstr "Moyenne"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Faible"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5266,14 +5236,14 @@ msgstr ""
 "lire les nouveaux termes et conditions attentivement avant de continuer."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Veuillez consulter ici les ${benefits}${tooltip_benefits} et les "
 "${limitations}${tooltip_limitations} d'une session d'essai."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Ou ${register_link} à la place. Découvrez pourquoi vous devriez vous inscrire"
@@ -5371,14 +5341,9 @@ msgstr "Récupération de votre mot de passe"
 msgid "title_sectors"
 msgstr "Secteurs"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Statut de ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Évaluation interactive des risques en ligne"
@@ -5397,11 +5362,6 @@ msgstr "Ne pas publier \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "L'outil OiRA a été actualisé"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Statut d'${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5516,6 +5476,15 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Oui"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Questions ayant reçu une réponse par module"
+
+#~ msgid "title_status_of"
+#~ msgstr "Statut de ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Statut d'${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Les mesures de votre plan d’action n’ont pas été modifiées"

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -257,7 +257,7 @@ msgstr "Jeste li sigurni da želite nastaviti?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Dostupni OiRA alati"
 
@@ -422,7 +422,7 @@ msgstr "Trebam li se pripremiti?"
 msgid "Documentation"
 msgstr "Dokumentacija"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Događa li se ovo na više mjesta?"
 
@@ -450,7 +450,7 @@ msgstr "Preuzimanje pregleda mjera"
 msgid "Download the risks overview"
 msgstr "Preuzimanje pregleda rizika"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-pošta"
@@ -479,11 +479,11 @@ msgstr "Uredi pitanje o profilu"
 msgid "Email address/account name"
 msgstr "Adresa e-pošte / naziv račun"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Unesite naziv lokacije"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Unesite naziv svake lokacije"
 
@@ -559,7 +559,7 @@ msgstr ""
 "procjeni, a zatim se vratiti i nastaviti gdje ste stali kada vam to bude "
 "prikladno."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Želim s vama podijeliti sljedeće"
 
@@ -585,7 +585,7 @@ msgstr "Informacije"
 msgid "Information"
 msgstr "Informacije"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nevažeći format slike. Molimo koristite PNG, JPEG ili GIF."
 
@@ -614,16 +614,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "spremljeno"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Saznajte više o ovom alatu…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -840,7 +839,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Pogledajte primjere ispod obrasca."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Odgođen"
@@ -995,11 +993,11 @@ msgstr "Informacije o sektoru i grupiranju za klijenta."
 msgid "Sector workflow"
 msgstr "Tijek rada sektora"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sesija `${name}` je izbrisana."
 
@@ -1011,7 +1009,7 @@ msgstr "Naslov sesije je promijenjen u ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Podijeli ovaj alat OiRA"
 
@@ -1045,7 +1043,7 @@ msgid "Started"
 msgstr "Započeto"
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1107,7 +1105,7 @@ msgid ""
 msgstr ""
 "Osnovna arhitektura Internetske interaktivne procjene rizika sastoji se od:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1149,7 +1147,7 @@ msgstr "Mrežni klijent."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1161,7 +1159,7 @@ msgstr "Određena boja nije valjana."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Postoje četiri faze za završetak procesa procjene:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1169,7 +1167,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Nema promjena za spremanje."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Ponuda ovog OiRA alata stigla vam je s ${external_site}"
 
@@ -1221,7 +1219,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Ovaj alat zaslužuje da se zna za njega! Podijelite ga!"
 
@@ -1243,7 +1241,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Neodgovoren"
@@ -1545,7 +1542,7 @@ msgstr "Izdanje objavljuje ${EU-OSHA}."
 msgid "based on"
 msgstr "na temelju"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "pogodnostima"
 
@@ -1614,8 +1611,8 @@ msgid "button_cancel"
 msgstr "Odustani"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Zatvori"
 
@@ -1699,9 +1696,9 @@ msgid "button_start_new_session"
 msgstr "Započnite novu sesiju ovim alatom"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Pokreni sesiju"
 
@@ -2161,17 +2158,17 @@ msgid "error_password_mismatch"
 msgstr "Lozinke se ne podudaraju"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Ovaj datum mora biti isti ili veći od datuma početka."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Ovaj datum mora biti isti ili manji od datuma kraja."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Ova vrijednost mora biti pozitivan cijeli broj."
 
@@ -2285,7 +2282,7 @@ msgstr ""
 "Ovaj je rizik automatski bio postavljen kao postojeći. Ovo ne možete "
 "promijeniti."
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2400,12 +2397,12 @@ msgid "header_additional_content"
 msgstr "Dodatni sadržaj"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Dodatni resursi za procjenu rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Dodatni resursi za ovaj modul"
 
@@ -2489,6 +2486,7 @@ msgstr "Licence"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prijava"
 
@@ -2598,11 +2596,6 @@ msgstr "Faze projekta"
 msgid "header_publish"
 msgstr "Objavi OiRA alat"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Odgovorena pitanja po modulu"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2616,7 +2609,7 @@ msgid "header_reporting"
 msgstr "Izvješćivanje"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Propisi i dodatne informacije"
 
@@ -2745,13 +2738,12 @@ msgid "header_why_oira"
 msgstr "Zašto OiRA projekt"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Komentari"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Rizici visokog prioriteta"
 
@@ -2950,7 +2942,7 @@ msgstr ""
 "započeti s kopijom postojećeg OiRA alata."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Navodi koliko se često ovaj rizik pojavljuje u normalnoj situaciji."
 
@@ -2962,13 +2954,13 @@ msgstr ""
 "uvijek može promijeniti prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Navodi kolika je vjerojatnost pojave ovog rizika u normalnoj situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Navodi ozbiljnost u slučaju da dođe do ovog rizika."
 
@@ -3314,7 +3306,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Ovo je probna sesija"
 
@@ -3551,7 +3542,7 @@ msgid "label_body"
 msgstr "Sadržaj stranice"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Preskoči"
 
@@ -3587,7 +3578,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Ovdje možete ostaviti komentar na postavljeno pitanje. Komentar će se "
@@ -3749,11 +3740,6 @@ msgstr "Zaboravio(la) sam svoju lozinku"
 msgid "label_format"
 msgstr "Oblik"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Opće informacije"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3832,7 +3818,7 @@ msgid "label_language"
 msgstr "Jezik"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Pravila i pravne reference"
@@ -3885,11 +3871,6 @@ msgstr "Konkretna(e) aktivnost(i) potrebna(e) za implementaciju ovog pristupa"
 msgid "label_measure_requirements"
 msgstr "Razina stručnosti i/ili potrebni zahtjevi"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3925,38 +3906,34 @@ msgstr "Nova probna sesija"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Sljedeće"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Nema rizika"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Nema rizika"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Nema rizika"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Nema rizika"
 
@@ -3976,12 +3953,12 @@ msgid "label_old_password"
 msgstr "Trenutačna lozinka"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Stranica"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "od"
 
@@ -4013,9 +3990,9 @@ msgid "label_preview"
 msgstr "Pretpregled"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Prethodni"
 
@@ -4033,7 +4010,7 @@ msgstr "Pitanje"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Objavljen"
 
@@ -4050,7 +4027,7 @@ msgstr "Preko kojeg kanala ste saznali o ovom alatu?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "Registrirajte se"
 
@@ -4122,49 +4099,41 @@ msgstr "Vrsta rizika"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Rizik s mjerom(ama)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Rizik bez mjere"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Rizici s mjerom(ama)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Rizici s mjerom(ama)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Rizici s mjerom(ama)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Rizici bez mjere(a)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Rizici bez mjere(a)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Rizici bez mjere(a)"
 
@@ -4205,12 +4174,19 @@ msgstr "Naziv sektora."
 msgid "label_select_measure"
 msgstr "Odaberite jednu ili više poznatih uobičajenih mjera koje su ponuđene."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Pokrenite novu sesiju odabirom nekog od sljedećih sektorskih alata"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4253,14 +4229,9 @@ msgid "label_start_identification"
 msgstr "Započnite procjenu rizika"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Pokrenite"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "započeto"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4296,6 +4267,11 @@ msgstr "Naziv verzije"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Naziv uvezenog OiRA alata"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4339,11 +4315,6 @@ msgstr "Vrsta alata OiRA"
 msgid "label_tryout"
 msgstr "Pokrenite probnu sesiju"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4363,11 +4334,6 @@ msgstr "Naziv za verziju OiRA alata"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Korišteni alat"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4390,7 +4356,7 @@ msgid "label_workers_participated"
 msgstr "Radnici su pozvani na sudjelovanje u procjeni rizika"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Da"
@@ -4422,18 +4388,17 @@ msgstr ""
 "${label} = Ova verzija sadrži izmjene koje trenutačno nisu objavljene. "
 "Kliknite ikonu za ažuriranje kako biste aktivirali sve izmjene."
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "ograničenjima"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Prijava"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4648,7 +4613,7 @@ msgstr "Postavke"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Provjerite svoj napredak"
 
@@ -4750,7 +4715,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Vaša lozinka mora sadržavati najmanje 5 znakova, uključujući najmanje jedno "
@@ -4780,7 +4745,7 @@ msgid "portlet_header_versions"
 msgstr "Verzije"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4822,6 +4787,11 @@ msgstr "Srednja"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Mala"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5130,14 +5100,14 @@ msgstr ""
 "pažljivo pročitajte nove uvjete i odredbe."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Ovdje pročitajte više o ${benefits}${tooltip_benefits} i "
 "${limitations}${tooltip_limitations} probne sesije."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Ili umjesto toga, posjetite ${register_link}. Saznajte zašto se trebate "
@@ -5235,14 +5205,9 @@ msgstr "Oporavak lozinke"
 msgid "title_sectors"
 msgstr "Sektori"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Status ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA – internetska interaktivna procjena rizika"
@@ -5261,11 +5226,6 @@ msgstr "Poništi objavu \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "OiRA alat je ažuriran"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Status ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5378,6 +5338,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Da"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Odgovorena pitanja po modulu"
+
+#~ msgid "label_general_information"
+#~ msgstr "Opće informacije"
+
+#~ msgid "label_started"
+#~ msgstr "započeto"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Korišteni alat"
+
+#~ msgid "title_status_of"
+#~ msgstr "Status ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Status ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "U mjerama vašeg plana mjera nisu unesene promjene."

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -409,7 +409,7 @@ msgstr "Fel kell készülni?"
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -437,7 +437,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -466,11 +466,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -547,7 +547,7 @@ msgstr ""
 "rendelkezésére áll, majd egy későbbi alkalmas időpontban újra megnyithatja, "
 "és ott folytathatja, ahol abbahagyta."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Szeretném megosztani veletek a következőket"
 
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -602,16 +602,15 @@ msgid "Kosovo"
 msgstr "Koszovó"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Tudjon meg többet erről az eszközről…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -825,7 +824,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -971,11 +969,11 @@ msgstr "Ágazatra vonatkozó adatok és csoportosítás az ügyfél részére."
 msgid "Sector workflow"
 msgstr "Ágazat munkafolyamat"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -987,7 +985,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Ossza meg ezt az OiRA-eszközt!"
 
@@ -1021,7 +1019,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1076,7 +1074,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1111,7 +1109,7 @@ msgstr "Az online ügyfél."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1123,7 +1121,7 @@ msgstr "A megadott szín nem érvényes."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Az értékelési folyamat elvégzésének négy fő szakasza van:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1131,7 +1129,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Nincsenek elmentésre váró változtatások."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1178,7 +1176,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Ez az eszköz megérdemli, hogy megismerje a világ! Ossza meg!"
 
@@ -1200,7 +1198,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1490,7 +1487,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1557,8 +1554,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1642,9 +1639,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -2099,17 +2096,17 @@ msgid "error_password_mismatch"
 msgstr "A jelszavak nem egyeznek"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2203,7 +2200,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2314,12 +2311,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2403,6 +2400,7 @@ msgstr "Engedélyek"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2512,11 +2510,6 @@ msgstr "Projekt fázisai"
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Modulonként megválaszolt kérdések"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2530,7 +2523,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2661,13 +2654,12 @@ msgid "header_why_oira"
 msgstr "Miért az OiRA projekt"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2860,7 +2852,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Jelölje, hogy ez a kockázat milyen gyakran fordul elő normál esetben."
 
@@ -2870,13 +2862,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Jelölje, hogy mennyire valószínű a kockázat előfordulása normál helyzetben."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3182,7 +3174,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3380,7 +3371,7 @@ msgid "label_body"
 msgstr "Oldal tartalma"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3416,7 +3407,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3576,11 +3567,6 @@ msgstr "Elfelejetettem a jelszavamat"
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3659,7 +3645,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Hivatkozások jogszabályokra és szabályzatokra"
@@ -3712,11 +3698,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3752,38 +3733,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3803,12 +3780,12 @@ msgid "label_old_password"
 msgstr "Jelenlegi jelszó"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3840,9 +3817,9 @@ msgid "label_preview"
 msgstr "Előnézet"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3860,7 +3837,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Közzétett"
 
@@ -3877,7 +3854,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "regisztráljon"
 
@@ -3948,49 +3925,41 @@ msgstr "Kockázat típusa"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -4031,11 +4000,18 @@ msgstr "Ágazat címe."
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -4079,13 +4055,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -4121,6 +4092,11 @@ msgstr "Verzió neve"
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -4165,11 +4141,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4188,11 +4159,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4216,7 +4182,7 @@ msgid "label_workers_participated"
 msgstr "A dolgozókat felkérték, hogy vegyenek részt a kockázatértékelésben"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4249,18 +4215,17 @@ msgstr ""
 "nincsenek közzétéve. A frissítés ikonra kattintva az összes változtatást "
 "élesítheti"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4460,7 +4425,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4562,7 +4527,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr "Jelszó megerősítése"
 
@@ -4590,7 +4555,7 @@ msgid "portlet_header_versions"
 msgstr "Verziók"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4631,6 +4596,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4926,12 +4896,12 @@ msgstr ""
 "mielőtt továbblépne, figyelmesen olvassa el az új használati feltételeket."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -5027,14 +4997,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr "Ágazatok"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -5052,11 +5017,6 @@ msgstr "Közzététel megszüntetése \"${title}"
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
@@ -5158,6 +5118,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Igen"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Modulonként megválaszolt kérdések"
 
 #~ msgid "label_add_risk"
 #~ msgstr "Másik intézkedés hozzáadása"

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -257,7 +257,7 @@ msgstr "Ertu viss um að þú viljir halda áfram?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "OiRA verkfæri í boði"
 
@@ -421,7 +421,7 @@ msgstr "Þarf sérstakan undirbúning?"
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Er þetta framkvæmt á fleiri en einum stað?"
 
@@ -449,7 +449,7 @@ msgstr "Sækja yfirlit yfir úrbætur"
 msgid "Download the risks overview"
 msgstr "Sækja fullyrðingar verkfærisins"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr ""
@@ -478,11 +478,11 @@ msgstr "Breyta spurningu um starfsemi"
 msgid "Email address/account name"
 msgstr "Tölvupóstfang/Notendaheiti"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Færið heiti staðar"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Færið heiti hvers staðar"
 
@@ -558,7 +558,7 @@ msgstr ""
 "Þú getur byrjað og hætt hvenær sem er. Hægt að halda áfram með fyrra mat og "
 "breyta að vild."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -584,7 +584,7 @@ msgstr "Upplýsingar"
 msgid "Information"
 msgstr "Upplýsingar"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Get ekki lesið myndskrá. Vinsamlegast notið PNG, JPEG eða GIF skrár."
 
@@ -614,16 +614,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "Síðast vistað"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Lærðu meira um þetta verkfæri…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -845,7 +844,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Vinsamlegast athugaðu dæmin hér að aftan"
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Frestað"
@@ -997,11 +995,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Áhættumatinu `${name}` hefur verið eytt."
 
@@ -1013,7 +1011,7 @@ msgstr "Heiti áhættumatsins hefur verið breytt í ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr ""
 
@@ -1047,7 +1045,7 @@ msgid "Started"
 msgstr "Fyrst framkvæmt"
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1107,7 +1105,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Grunnuppbygging gagnvirks áhættumats á netinu samanstendur af: "
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1146,7 +1144,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1158,7 +1156,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Það þarf að fara í gegnum fjögur þrep:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1166,7 +1164,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Þetta OiRA verkfæri var þér útvegað af ${external_site}"
 
@@ -1217,7 +1215,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 
@@ -1239,7 +1237,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Ekki opnað"
@@ -1519,7 +1516,7 @@ msgstr "Framleitt af ${EU-OSHA}."
 msgid "based on"
 msgstr "byggð á"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "kostir"
 
@@ -1586,8 +1583,8 @@ msgid "button_cancel"
 msgstr "Hætta við"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Loka"
 
@@ -1671,9 +1668,9 @@ msgid "button_start_new_session"
 msgstr "Byrjaðu nýtt áhættumat með þessu verkfæri"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Byrja"
 
@@ -2123,17 +2120,17 @@ msgid "error_password_mismatch"
 msgstr "Lykilorðin eru ekki eins"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir upphafsdagsetningu."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir lokadagsetningu."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Þetta þarf að vera heiltala stærri en núll."
 
@@ -2256,7 +2253,7 @@ msgstr ""
 "Þessi áhætta hefur verið skilgreind sem stöðug áhætta (þ.e. alltaf fyrir "
 "hendi).  Það er ekki hægt að breyta þessari flokkun áhættunar. "
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2372,12 +2369,12 @@ msgid "header_additional_content"
 msgstr "Annað efni"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Viðbótar upplýsingar til að meta áhættuna"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Viðbótar upplýsingar fyrir þennan flokk"
 
@@ -2461,6 +2458,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Innskráning"
 
@@ -2570,11 +2568,6 @@ msgstr ""
 msgid "header_publish"
 msgstr "Birta OiRA verkfærið "
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Hve mörgum spurningum var svarað í hverjum flokki"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2588,7 +2581,7 @@ msgid "header_reporting"
 msgstr "Skýrsla"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Viðbótarupplýsingar"
 
@@ -2722,13 +2715,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Athugasemdir"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "hár áhættuflokkur (forgangur)"
 
@@ -2926,7 +2918,7 @@ msgstr ""
 "viljir byrja með afrit af OiRA verkfæri sem er þegar til staðar."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Tilgreindu hversu oft þessi áhætta kemur upp við venjulegar aðstæður."
 
@@ -2938,12 +2930,12 @@ msgstr ""
 "(forgangsröð). Hann eða hún getur breytt forgangsröðinni að vild."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Hversu líklegt er að þessi áhætta komi upp við venjulegar aðstæður?"
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Hversu alvarlegt verður atvikið ef það gerist?"
 
@@ -3276,7 +3268,6 @@ msgstr "Veldu áhættumat til að ljúka eða endurskoða eða ${start_session}.
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 "Hér er hægt að prófa verkfærið. Það verður að ${link_sign_in} til að gera "
@@ -3512,7 +3503,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Sleppa"
 
@@ -3548,7 +3539,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Settu athugasemdir um spurninguna í þennan reit. Þessar athugasemdir verða "
@@ -3712,11 +3703,6 @@ msgstr "Ég hef gleymt lykilorðinu mínu"
 msgid "label_format"
 msgstr "Snið"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Almennar upplýsingar"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3795,7 +3781,7 @@ msgid "label_language"
 msgstr "Tungumál"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Tilvísanir í önnur gögn s.s. lög, reglur og önnur opinber gögn"
@@ -3850,11 +3836,6 @@ msgstr "Sérstakar aðgerðir til að innleiða úrbæturnar."
 msgid "label_measure_requirements"
 msgstr "Þekking og reynsla sem er nauðsynleg"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3890,38 +3871,34 @@ msgstr "Prófa verkfærið"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Næsta"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Nei"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Áhættan er ekki til staðar"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Áhættan er ekki til staðar"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Áhættan er ekki til staðar"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Áhættan er ekki til staðar"
 
@@ -3941,12 +3918,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Síða"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "af"
 
@@ -3978,9 +3955,9 @@ msgid "label_preview"
 msgstr "Prufuútgáfa"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Fyrra"
 
@@ -3998,7 +3975,7 @@ msgstr "Spurning"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -4015,7 +3992,7 @@ msgstr "Eftir hvaða leiðum fréttir þú af verkfærinu?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "Stofna aðgang"
 
@@ -4086,49 +4063,41 @@ msgstr "Flokkur áhættu"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Áhætta og tilheyrandi úrbótaaðgerð(ir)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Áhætta án tilgreindrar úrbótaaðgerðar"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Áhætta með úrbótaaðgerð(um)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Áhætta með úrbótaaðgerð(um)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Áhætta með úrbótaaðgerð(um)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Áhættur án tilheyrandi úrbótaðgerða"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Áhættur án tilheyrandi úrbótaðgerða"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Áhættur án tilheyrandi úrbótaðgerða"
 
@@ -4169,12 +4138,19 @@ msgstr "Heiti atvinnugreinar"
 msgid "label_select_measure"
 msgstr "Veldu lausn eða lausnir sem eru tilgreindar."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Veljið áhættumatsverkfæri"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4217,14 +4193,9 @@ msgid "label_start_identification"
 msgstr "Byrja áhættugreiningu"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Byrja"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "fyrst framkvæmt"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4260,6 +4231,11 @@ msgstr "Heiti útgáfu"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Nýtt heiti afritaðs OiRA verkfæris"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4303,11 +4279,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr "prófað"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4327,11 +4298,6 @@ msgstr "Nafn á OiRA útgáfunni"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr "Spurðu notandann um (fleiri en eitt) tilvik"
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "OiRA verkfæri notað"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4354,7 +4320,7 @@ msgid "label_workers_participated"
 msgstr "Starfsfólki var boðið að taka þátt í áhættumatinu"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Já"
@@ -4386,18 +4352,17 @@ msgstr ""
 "${label} = Þessi útgáfa er með breytingum sem ekki hafa verið gefnar út. "
 "Hakið við \"uppfæra\" táknið til að virkja breytingarnar."
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "galla"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "stofna aðgang"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4604,7 +4569,7 @@ msgstr "Stillingar"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Staða"
 
@@ -4709,7 +4674,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Lykilorðið þitt verður að innihalda að minnsta kosti 5 tákn/staf. Þar af að "
@@ -4738,7 +4703,7 @@ msgid "portlet_header_versions"
 msgstr "Útgáfur"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4780,6 +4745,11 @@ msgstr "Miðlungs"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Litlar"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5090,14 +5060,14 @@ msgstr ""
 "skilmálana og skilyrðin vandlega áður en haldið er áfram."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Lestu hér um ${benefits}${tooltip_benefits} og "
 "${limitations}${tooltip_limitations} þess að prófa verkfærið."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Stofnaðu aðgang ${register_link}. Kostir þess að stofna aðgang "
@@ -5197,14 +5167,9 @@ msgstr "Endurheimta lykilorð"
 msgid "title_sectors"
 msgstr "Atvinnugreinar"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Staða: ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -5224,11 +5189,6 @@ msgstr "Draga til baka útgáfu á ${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "OiRA verkfærið var uppfært"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Staða: ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5341,6 +5301,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "já "
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Hve mörgum spurningum var svarað í hverjum flokki"
+
+#~ msgid "label_general_information"
+#~ msgstr "Almennar upplýsingar"
+
+#~ msgid "label_started"
+#~ msgstr "fyrst framkvæmt"
+
+#~ msgid "label_used_tool"
+#~ msgstr "OiRA verkfæri notað"
+
+#~ msgid "title_status_of"
+#~ msgstr "Staða: ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Staða: ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Engar breytingar voru gerðar á úrbótaaðgerðum í aðgerðaáætluninni."

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Strumenti OIRA disponibili"
 
@@ -426,7 +426,7 @@ msgstr " "
 msgid "Documentation"
 msgstr "Documentazione"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Ciò avviene in diversi posti?"
 
@@ -454,7 +454,7 @@ msgstr "Scarica la panoramica delle misure"
 msgid "Download the risks overview"
 msgstr "Scarica la panoramica dei rischi"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -483,11 +483,11 @@ msgstr "Modificare la domanda sul profilo"
 msgid "Email address/account name"
 msgstr "Indirizzo e-mail/nome dell'account"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Indicare il nome del luogo"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Indicare i nomi di ogni luogo"
 
@@ -562,7 +562,7 @@ msgstr ""
 "interrompere la compilazione del tool per poi riprenderla in una fase "
 "successiva."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Vorrei condividere con voi ció che segue"
 
@@ -588,7 +588,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informazione"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato dell'immagine non valido, per favore usa PNG, JPEG o GIF."
 
@@ -618,16 +618,15 @@ msgid "Kosovo"
 msgstr "Cossovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "Salvato"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Ulteriori informazioni su questo strumento…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -850,7 +849,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Riferirsi agli esempi in basso al modulo….."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Adempimenti e rischi da completare"
@@ -1009,11 +1007,11 @@ msgstr "Informazione sul settore e raggruppamento per il cliente."
 msgid "Sector workflow"
 msgstr "Settore workflow"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sessione `${name}` cancellata."
 
@@ -1025,7 +1023,7 @@ msgstr "Il titolo della sessione è stato modificato a ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Condividi questo strumento OiRA"
 
@@ -1059,7 +1057,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1123,7 +1121,7 @@ msgstr ""
 "L'architettura di base di una valutazione interattiva online dei rischi "
 "consiste in:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1161,7 +1159,7 @@ msgstr "Il cliente online."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1174,7 +1172,7 @@ msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 "Ci sono quattro fasi principali per completare il processo di valutazione:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1182,7 +1180,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Non sono state salvate le modifiche."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Questo strumento OiRA vi viene offerto da ${external_site}"
 
@@ -1232,7 +1230,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Questo strumento merita di essere conosciuto in tutto il mondo: condividilo!"
@@ -1255,7 +1253,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Non esaminato"
@@ -1560,7 +1557,7 @@ msgstr "Prodotto da ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "vantaggi"
 
@@ -1630,8 +1627,8 @@ msgid "button_cancel"
 msgstr "Annullare"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Chiudi"
 
@@ -1715,9 +1712,9 @@ msgid "button_start_new_session"
 msgstr "Avvia una nuova sessione con questo strumento"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Avvia sessione"
 
@@ -2189,17 +2186,17 @@ msgid "error_password_mismatch"
 msgstr "Le password non coincidono"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Questa data deve essere uguale o successiva alla data di inizio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Questa data deve essere uguale o precedente alla data di fine."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Questo valore deve essere un numero intero positivo."
 
@@ -2305,7 +2302,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2422,12 +2419,12 @@ msgid "header_additional_content"
 msgstr "Contenuti aggiuntivi"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Risorse aggiuntive per la valutazione del rischio"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Risorse aggiuntive per questo modulo"
 
@@ -2515,6 +2512,7 @@ msgstr "Licenze"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
 
@@ -2624,11 +2622,6 @@ msgstr "Fasi del progetto"
 msgid "header_publish"
 msgstr "Pubblicare tool OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Domande e risposte tramite il modulo"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2642,7 +2635,7 @@ msgid "header_reporting"
 msgstr "Report"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Risorse"
 
@@ -2770,13 +2763,12 @@ msgid "header_why_oira"
 msgstr "Perché il progetto OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Commenti"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Rischi con priorità elevata"
 
@@ -2975,7 +2967,7 @@ msgstr ""
 "con una copia di un tool OiRA esistente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indicare la frequenza che questo rischio si verifica in una situazione "
@@ -2989,14 +2981,14 @@ msgstr ""
 "L'utente finale ha poi la possibilità di modificare il grado di priorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indicare quanto sia possibile che questo rischio si verifichi in una "
 "situazione normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indicare la gravità che questo rischio potrebbe comportare."
 
@@ -3351,7 +3343,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Sessione di prova"
 
@@ -3591,7 +3582,7 @@ msgid "label_body"
 msgstr "Contenuto della pagina"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Salta"
 
@@ -3627,7 +3618,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Inserire eventuali commenti e informazioni aggiuntive (ad esempio gli "
@@ -3790,11 +3781,6 @@ msgstr "Ho dimenticato la mia password"
 msgid "label_format"
 msgstr "Formato"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3873,7 +3859,7 @@ msgid "label_language"
 msgstr "Lingua"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Riferimenti normativi"
@@ -3926,11 +3912,6 @@ msgstr "Misura specifica"
 msgid "label_measure_requirements"
 msgstr "Livello di esperienza o requisiti necessari"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3966,20 +3947,19 @@ msgstr "Nuova sessione di prova"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Avanti"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "No"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 "Adempimenti e rischi non applicabili o per i quali non sono previste "
@@ -3987,7 +3967,6 @@ msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 "Adempimenti e rischi non applicabili o per i quali non sono previste "
@@ -3995,7 +3974,6 @@ msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 "Adempimenti e rischi non applicabili o per i quali non sono previste "
@@ -4003,7 +3981,6 @@ msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 "Adempimenti e rischi non applicabili o per i quali non sono previste "
@@ -4027,12 +4004,12 @@ msgid "label_old_password"
 msgstr "Password attuale"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "pagina"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "di"
 
@@ -4064,9 +4041,9 @@ msgid "label_preview"
 msgstr "Anteprima"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Indietro"
 
@@ -4084,7 +4061,7 @@ msgstr "Domanda"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Pubblicato"
 
@@ -4101,7 +4078,7 @@ msgstr "Attraverso quale canale siete venuti a conoscenza di questo strumento?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registrarti"
 
@@ -4174,7 +4151,6 @@ msgstr "Tipo di rischio"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4182,7 +4158,6 @@ msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4190,7 +4165,6 @@ msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4198,7 +4172,6 @@ msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4206,7 +4179,6 @@ msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4214,7 +4186,6 @@ msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4222,7 +4193,6 @@ msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4230,7 +4200,6 @@ msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -4276,13 +4245,20 @@ msgstr ""
 "quindi selezionate in fase di identificazione pertanto non dovrebbero "
 "comparire in questo elenco."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Iniziare una nuova seduta scegliendo uno dei seguenti strumenti settoriali"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4325,14 +4301,9 @@ msgid "label_start_identification"
 msgstr "Inizia l'identificazione dei pericoli"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Inizia"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4368,6 +4339,11 @@ msgstr "Nome della versione"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Titolo del tool OiRA importato"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4411,11 +4387,6 @@ msgstr "Versione dello strumento OIRA"
 msgid "label_tryout"
 msgstr "eseguire una sessione di prova"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4434,11 +4405,6 @@ msgstr "Nome per versione dello strumento OiRA"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4462,7 +4428,7 @@ msgid "label_workers_participated"
 msgstr "I lavoratori sono invitati a partecipare alla valutazione dei rischi"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Sì"
@@ -4496,18 +4462,17 @@ msgstr ""
 "${label} = La versione contiene modifiche che non sono state finora "
 "pubblicate. Cliccare sull'icona di aggiormento per pubblicare le modifiche"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "limiti"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Login"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4721,7 +4686,7 @@ msgstr "Impostazioni"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Stato"
 
@@ -4823,7 +4788,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4854,7 +4819,7 @@ msgid "portlet_header_versions"
 msgstr "Versioni"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4896,6 +4861,11 @@ msgstr "Medio"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Piccolo"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5227,14 +5197,14 @@ msgstr ""
 "procedere."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Leggi qui in merito a ${benefits}${tooltip_benefits} e "
 "${limitations}${tooltip_limitations} di una sessione di prova."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Oppure ${register_link}. Scopri perché è necessario registrarsi"
@@ -5332,14 +5302,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr "Settori"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Stato di ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Online interactive Risk Assessment"
@@ -5358,11 +5323,6 @@ msgstr "Non pubblicato \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Lo strumento OiRA è stato aggiornato"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Stato di ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5475,6 +5435,15 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sì"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Domande e risposte tramite il modulo"
+
+#~ msgid "title_status_of"
+#~ msgstr "Stato di ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Stato di ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -255,7 +255,7 @@ msgstr "Ar tikrai norite tęsti?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Esamos OiRA priemonės"
 
@@ -420,7 +420,7 @@ msgstr "Ar turėčiau pasiruošti?"
 msgid "Documentation"
 msgstr "Dokumentai"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Ar taip atsitinka daugelyje vietų?"
 
@@ -448,7 +448,7 @@ msgstr "Atsisiųskite priemonių apžvalgą"
 msgid "Download the risks overview"
 msgstr "Atsisiųskite rizikų apžvalgą"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E. paštas"
@@ -477,11 +477,11 @@ msgstr "Redaguoti Profilio klausimą"
 msgid "Email address/account name"
 msgstr "El. pašto adresas / paskyros pavadinimas"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Nurodykite vietos pavadinimą"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Nurodykite visų vietų pavadinimus"
 
@@ -555,7 +555,7 @@ msgstr ""
 "Tačiau vertinimui skirkite tiek laiko, kiek jo turite – bet kada galėsite "
 "tęsti nuo tos vietos, kur baigėte praeitą kartą."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Noriu pasidalinti šia informacija su jumis"
 
@@ -581,7 +581,7 @@ msgstr "Informacija"
 msgid "Information"
 msgstr "Informacija"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -610,16 +610,15 @@ msgid "Kosovo"
 msgstr "Kosovas"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "išsaugota"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Sužinokite daugiau apie šį įrankį…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -838,7 +837,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Žr. formos apačioje pateiktus pavyzdžius."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Atidėta"
@@ -993,11 +991,11 @@ msgstr "Ekonominės veiklos informacija ir programos grupvavimas."
 msgid "Sector workflow"
 msgstr "Darbų srautas veiklos srityje"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sesija `${name}` panaikintas."
 
@@ -1009,7 +1007,7 @@ msgstr "Sesijos pavadinimas pakeistas į ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Dalytis šia internetine interaktyviąja rizikos vertinimo priemone"
 
@@ -1043,7 +1041,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1106,7 +1104,7 @@ msgstr ""
 "Pagrindinės internetinės interaktyviosios rizikos vertinimo priemonės "
 "sudedamosios dalys yra šios:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1144,7 +1142,7 @@ msgstr "Internetinė programa."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1156,7 +1154,7 @@ msgstr "Nurodyta spalva yra netinkama."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Yra keturi pagrindiniai rizikos vertinimo proceso etapai. "
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1164,7 +1162,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Jokie pakeitimai išsaugoti nebus."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Šia OiRA priemone jums suteikė galimybę naudotis ${external_site}"
 
@@ -1211,7 +1209,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Pasaulis turi žinoti apie šią priemonę! Dalykitės!"
 
@@ -1233,7 +1231,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Neatsakyta"
@@ -1534,7 +1531,7 @@ msgstr "Sukūrė: ${EU-OSHA}."
 msgid "based on"
 msgstr "pagal"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "nauda"
 
@@ -1602,8 +1599,8 @@ msgid "button_cancel"
 msgstr "Atšaukti"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1687,9 +1684,9 @@ msgid "button_start_new_session"
 msgstr "Pradėti šios priemonės naują seansą"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Pradėti"
 
@@ -2141,17 +2138,17 @@ msgid "error_password_mismatch"
 msgstr "Slaptažodis netinkamas"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Ši data turi sutapti su pradžios data arba būti už ją vėlesnė."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Ši data turi sutapti su pabaigos data arba būti už ją ankstesnė."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Šioje vietoje nurodykite teigiamą sveikąjį skaičių."
 
@@ -2264,7 +2261,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2381,12 +2378,12 @@ msgid "header_additional_content"
 msgstr "Papildomas turinys"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Papildomi rizikos vertinimo šaltiniai"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Papildomi šaltiniai šram modulini"
 
@@ -2470,6 +2467,7 @@ msgstr "Licencijos"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prisijungimo vardas"
 
@@ -2579,11 +2577,6 @@ msgstr "Projekto etapai"
 msgid "header_publish"
 msgstr "Išleisti OiRA priemonę"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Modulyje atsakyti klausimai"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2597,7 +2590,7 @@ msgid "header_reporting"
 msgstr "Ataskaitų ruošimas"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Ištekliai"
 
@@ -2726,13 +2719,12 @@ msgid "header_why_oira"
 msgstr "Kodėl OiRA projektas"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Komentarai"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "didelė rizika"
 
@@ -2934,7 +2926,7 @@ msgstr ""
 "pradėti nuo esamos OiRA priemonės kopijos."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Nurodyti, kaip dažnai rizika pasireiškia normaliose situacijose."
 
@@ -2946,12 +2938,12 @@ msgstr ""
 "prioritetą vis dar gali pakeisti."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Nurodyti, kokia rizikos pasireiškimo normaliose situacijose tikimybė."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Nurodyti atsiradusios rizikos sunkumą."
 
@@ -3307,7 +3299,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Tai yra bandomoji sesija"
 
@@ -3547,7 +3538,7 @@ msgid "label_body"
 msgstr "Puslapio turinys"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Praleisti"
 
@@ -3583,7 +3574,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Šiame laukelyje galite įrašyti norimą komentarą. Šie komentarai bus "
@@ -3745,11 +3736,6 @@ msgstr "Pamiršau slaptažodį"
 msgid "label_format"
 msgstr "formatas"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3828,7 +3814,7 @@ msgid "label_language"
 msgstr "Kalba"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Nuorodos į teisės aktus"
@@ -3882,11 +3868,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr "Reikalingų žinių ir (arba) reikalavimų lygis"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3922,38 +3903,34 @@ msgstr "Nauja bandomoji sesija"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Toliau"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Rizikos nėra (labai maža)"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Rizikos nėra (labai maža)"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Rizikos nėra (labai maža)"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Rizikos nėra (labai maža)"
 
@@ -3973,12 +3950,12 @@ msgid "label_old_password"
 msgstr "Dabartinis slaptažodis"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Puslapis"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "iš"
 
@@ -4010,9 +3987,9 @@ msgid "label_preview"
 msgstr "Peržiūra"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Ankstesnis"
 
@@ -4030,7 +4007,7 @@ msgstr "Klausimas"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Išleistas"
 
@@ -4047,7 +4024,7 @@ msgstr "Kaip sužinojote apie šią priemonę?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registruotis"
 
@@ -4118,49 +4095,41 @@ msgstr "Rizikos tipas"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
@@ -4201,14 +4170,21 @@ msgstr "Ekonominės veiklos pavadinimas."
 msgid "label_select_measure"
 msgstr "Pasirinkite vieną ar kelias iš pateiktų priemonių."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Pradėkite naują rizikos vertinimo sesiją pasirinkdami vieną iš šių OiRA "
 "priemonių"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4251,14 +4227,9 @@ msgid "label_start_identification"
 msgstr "Pradėti rizikų nustatymo procesą"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Pradžia"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "Pradėta"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4294,6 +4265,11 @@ msgstr "Versijos pavadinimas"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Įkeltos OiRA priemonės pavadinimas"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4337,11 +4313,6 @@ msgstr "OiRA priemonės tipas"
 msgid "label_tryout"
 msgstr "pradėkite bandomąją sesiją."
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4360,11 +4331,6 @@ msgstr "OiRA priemonės versijos pavadinimas"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4388,7 +4354,7 @@ msgid "label_workers_participated"
 msgstr "Darbuotojai buvo įtraukti į rizikos vertinimo procesą"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Taip"
@@ -4420,18 +4386,17 @@ msgstr ""
 "${label} = Šioje versijoje yra pakeitimų, kurie nebuvo publikuoti. Norėdami "
 "pakeitimus patvirtinti, paspauskite naujinimo piktogramą"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "apribojimai"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Prisijungimo vardas"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4642,7 +4607,7 @@ msgstr "Parametrai"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Būsena"
 
@@ -4744,7 +4709,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4772,7 +4737,7 @@ msgid "portlet_header_versions"
 msgstr "Versijos"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4814,6 +4779,11 @@ msgstr "Vidutinė"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Nedidelė"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5126,14 +5096,14 @@ msgstr ""
 "atidžiai perskaitykite naujus terminus ir sąlygas."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Čia galite rasti informacijos apie bandomąją sesiją "
 "${benefits}${tooltip_benefits} ir ${limitations}${tooltip_limitations}."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Arba galite registruotis ${register_link}. Sužinokite, kodėl verta "
@@ -5231,14 +5201,9 @@ msgstr "Slaptažodžio atkūrimas"
 msgid "title_sectors"
 msgstr "Ekonominės veiklos"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "${survey_title} statusas"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -5259,11 +5224,6 @@ msgstr "Pašalinti publikaciją \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "OiRA priemonė buvo atnaujinta"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "${survey_title} statusas"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5376,6 +5336,18 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Taip"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Modulyje atsakyti klausimai"
+
+#~ msgid "label_started"
+#~ msgstr "Pradėta"
+
+#~ msgid "title_status_of"
+#~ msgstr "${survey_title} statusas"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "${survey_title} statusas"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Jūsų veiksmų plane nėra padaryta pakeitimų."

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -254,7 +254,7 @@ msgstr "Vai esat pārleicināts, ka gribat turpināt?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Pieejamie OiRA rīki"
 
@@ -417,7 +417,7 @@ msgstr "Vai man jāsagatavojas?"
 msgid "Documentation"
 msgstr "Dokumentācija"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Vai tas raksturīgs vairākās vietās?"
 
@@ -445,7 +445,7 @@ msgstr "Lejuplādēt drīzumā īstenojamo pasākumu sarakstu"
 msgid "Download the risks overview"
 msgstr "Lejuplādēt riska novērtējuma statusu"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-pasts"
@@ -474,11 +474,11 @@ msgstr "Rediģēt Profila jautājums"
 msgid "Email address/account name"
 msgstr "E-pasta adrese / lietotājvārds"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Ievadiet atrašanās vietas nosaukumu"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Ievadiet katras atrašanās vietas nosaukumu"
 
@@ -553,7 +553,7 @@ msgstr ""
 "brīdī, un atgriezties jebkurā laikā, lai turpinātu procesu no vietas, kurā "
 "apstājāties iepriekšējā reizē."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Es vēlos dalīties ar Jums šādos jaunumos"
 
@@ -579,7 +579,7 @@ msgstr "Informācija"
 msgid "Information"
 msgstr "Informācija"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -608,16 +608,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "tika saglabāta"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Uzziniet vairāk par šo rīku…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -836,7 +835,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Lūdzu, aplūkojiet piemērus zem veidlapas."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Atlikts jautājums"
@@ -995,11 +993,11 @@ msgstr "Klientam paredzētā informācija par sektoru un sadalījums grupās."
 msgid "Sector workflow"
 msgstr "Sektora darbplūsma"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sesija `  ${name}` ir dzēsta."
 
@@ -1011,7 +1009,7 @@ msgstr "Sesijas nosaukums ir nomainīts uz ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Kopīgojiet šo OiRA rīku"
 
@@ -1045,7 +1043,7 @@ msgid "Started"
 msgstr "Sākts"
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1105,7 +1103,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Riska interaktīvā novērtēšanas tiešsaistes rīka arhitektūra sastāv no:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1144,7 +1142,7 @@ msgstr "Tiešsaistes klients."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1156,7 +1154,7 @@ msgstr "Norādītā krāsa nav derīga."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Novērtēšanas procesā ietilpst četri galvenie posmi:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1164,7 +1162,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Nebija nekādu saglabājamu izmaiņu."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Šo OiRA rīku jums piedāvā ${external_site}"
 
@@ -1215,7 +1213,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Pasaulei jāuzzina par šo rīku! Dalieties ar to!"
 
@@ -1237,7 +1235,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Neatbildēts"
@@ -1542,7 +1539,7 @@ msgstr "Autors: ${EU-OSHA}."
 msgid "based on"
 msgstr "balstīts uz"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "priekšrocībām"
 
@@ -1610,8 +1607,8 @@ msgid "button_cancel"
 msgstr "Atcelt"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Aizvērt"
 
@@ -1695,9 +1692,9 @@ msgid "button_start_new_session"
 msgstr "Sākt jaunu sesiju ar šo rīku"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Sākt sesiju"
 
@@ -2154,17 +2151,17 @@ msgid "error_password_mismatch"
 msgstr "Paroles nesakrīt."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Šim datumam ir jābūt sākuma datumam vai pēc tā."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Šim datumam ir jābūt beigu datumam vai pirms tā."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Šim lielumam ir jābūt pozitīvam veselam skaitlim."
 
@@ -2277,7 +2274,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2394,12 +2391,12 @@ msgid "header_additional_content"
 msgstr "Papildu saturs"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Papildu resursi riska novērtēšanai"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Papildu resursi šim modulim"
 
@@ -2483,6 +2480,7 @@ msgstr "Licences"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Pieteikšanās"
 
@@ -2592,11 +2590,6 @@ msgstr "Projekta posmi"
 msgid "header_publish"
 msgstr "Publicēt OiRA rīku"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Atbildētie jautājumi katrā modulī"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2610,7 +2603,7 @@ msgid "header_reporting"
 msgstr "Pārskatu veidošana"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Resursi"
 
@@ -2739,13 +2732,12 @@ msgid "header_why_oira"
 msgstr "Kāpēc OiRA projekts ir tik īpašs?"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Komentāri"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Augstas prioritātes riski"
 
@@ -2941,7 +2933,7 @@ msgstr ""
 "ar esoša OiRA rīka kopiju."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Norādiet, cik bieži šāds risks pastāv normālos apstākļos."
 
@@ -2953,12 +2945,12 @@ msgstr ""
 "noklusējuma. Lietotājs tik un tā varēs pats mainīt prioritātes līmeni."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Norādiet, cik ticama ir šī riska rašanās normālos apstākļos."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Norādiet bīstamības pakāpi, ko izraisa šī riska īstenošanās."
 
@@ -3307,7 +3299,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Šī ir testa sesija"
 
@@ -3543,7 +3534,7 @@ msgid "label_body"
 msgstr "Lapas saturs"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Izlaist"
 
@@ -3579,7 +3570,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Šajā laukā lūdzu norādīt papildus komentārus par augstāk minēto jautājumu. "
@@ -3741,11 +3732,6 @@ msgstr "Aizmirsu paroli"
 msgid "label_format"
 msgstr "Formāts"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3824,7 +3810,7 @@ msgid "label_language"
 msgstr "Valoda"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Juridiskās un ar politikas nostādnēm saistītās atsauces"
@@ -3877,11 +3863,6 @@ msgstr "Specifiskas darbības, kas jāveic, lai īstenotu šo pieeju"
 msgid "label_measure_requirements"
 msgstr "Nepieciešamais pieredzes līmenis un/vai prasības"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3917,38 +3898,34 @@ msgstr "Jauna testa sesija"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Tālāk"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Nē"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Riska nav"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Riska nav"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Riska nav"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Riska nav"
 
@@ -3968,12 +3945,12 @@ msgid "label_old_password"
 msgstr "Esošā parole"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr " "
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ". lappuse no"
 
@@ -4005,9 +3982,9 @@ msgid "label_preview"
 msgstr "Priekšskatījums"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Atpakaļ"
 
@@ -4025,7 +4002,7 @@ msgstr "Jautājums"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Publicēta"
 
@@ -4042,7 +4019,7 @@ msgstr "Kas jūs informēja par šāda rīka esamību?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "reģistrēties"
 
@@ -4115,49 +4092,41 @@ msgstr "Riska tips"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Risks bez pasākuma"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Risks bez pasākuma"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Risks bez pasākuma"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risks bez pasākuma"
 
@@ -4198,12 +4167,19 @@ msgstr "Sektora nosaukums."
 msgid "label_select_measure"
 msgstr "Izvēlieties vienu tipveida pasākumu"
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Sāciet jaunu sesiju, atlasot vienu no tālāk minētajiem sektoru rīkiem"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4246,14 +4222,9 @@ msgid "label_start_identification"
 msgstr "Sākt risku identificēšanu"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Sākt"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "sākts"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4289,6 +4260,11 @@ msgstr "Versijas nosaukums"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Importētā OiRA rīka nosaukums"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4332,11 +4308,6 @@ msgstr "OiRA rīka veids"
 msgid "label_tryout"
 msgstr "sākt testa sesiju"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4355,11 +4326,6 @@ msgstr "OiRA rīka versijas nosaukums"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4383,7 +4349,7 @@ msgid "label_workers_participated"
 msgstr "Vai darbinieki tika aicināti piedalīties riska novērtēšanā?"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Jā"
@@ -4416,18 +4382,17 @@ msgstr ""
 "Noklikšķiniet uz atjaunināšanas ikonas, lai visas izmaiņas publicētu "
 "tiešsaistē."
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "ierobežojumiem"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Pieteikšanās"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4637,7 +4602,7 @@ msgstr "Iestatījumi"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Statuss"
 
@@ -4739,7 +4704,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4769,7 +4734,7 @@ msgid "portlet_header_versions"
 msgstr "Versijas"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4811,6 +4776,11 @@ msgstr "Vidēja"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Neliela"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5123,14 +5093,14 @@ msgstr ""
 "turpināt, lūdzu, rūpīgi izlasiet jaunos noteikumus un nosacījumus."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Lasiet šeit par testa sesijas ${benefits}${tooltip_benefits} un "
 "${limitations}${tooltip_limitations} ."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Vai ${register_link} tā vietā. Uzziniet, kāpēc vajadzētu reģistrēties"
@@ -5228,14 +5198,9 @@ msgstr "Paroles atgūšana"
 msgid "title_sectors"
 msgstr "Sektori"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "${survey_title} statuss"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - riska interaktīvā novērtēšana tiešsaistē"
@@ -5254,11 +5219,6 @@ msgstr "Atsaukt šīs aptaujas publikāciju: ${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "OiRA rīks tika atjaunināts."
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "${survey_title} statuss"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5368,6 +5328,18 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Jā"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Atbildētie jautājumi katrā modulī"
+
+#~ msgid "label_started"
+#~ msgstr "sākts"
+
+#~ msgid "title_status_of"
+#~ msgstr "${survey_title} statuss"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "${survey_title} statuss"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Pasākumu plānā netika veiktas izmaiņas."

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -263,7 +263,7 @@ msgstr "Inti żgur li trid tkompli?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Għodod tal-OiRA disponibbli"
 
@@ -428,7 +428,7 @@ msgstr "Għandi bżonn inħejji ruħi?"
 msgid "Documentation"
 msgstr "Dokumentazzjoni"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Dan jiġri f'diversi postijiet?"
 
@@ -456,7 +456,7 @@ msgstr "Niżżel il-ħarsa ġenerali tal-miżuri"
 msgid "Download the risks overview"
 msgstr "Niżżel il-ħarsa ġenerali tar-riskji"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Posta elettronika"
@@ -485,11 +485,11 @@ msgstr "mistoqsija Editja l-Profil"
 msgid "Email address/account name"
 msgstr "Indirizz elettroniku/isem il-kont"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Daħħal l-isem tal-post"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Daħħal l-ismijiet ta' kull post"
 
@@ -565,7 +565,7 @@ msgstr ""
 "tiegħek fuq valutazzjoni, u mbagħad tista' tmur lura għaliha meta jkun komdu "
 "għalik u terġa' taqbadha minn fejn ħallejtha."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Nixtieq naqsam dan miegħek"
 
@@ -591,7 +591,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informazzjoni"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Format tal-istampa invalidu. Jekk jogħġbok uża PNG, JPEG jew GIF."
 
@@ -620,16 +620,15 @@ msgid "Kosovo"
 msgstr "Il-Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "issejvjata"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Tgħallem aktar dwar din l-għodda…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -852,7 +851,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Irreferi għall-eżempji taħt il-formola."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Posponiment"
@@ -1008,11 +1006,11 @@ msgstr "Informazzjoni u ggruppar tas-setturi għall-klijent."
 msgid "Sector workflow"
 msgstr "Fluss tax-xogħol ta' settur"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sessjoni \"${name}\" tħassret."
 
@@ -1024,7 +1022,7 @@ msgstr "It-titlu tas-sessjoni nbidel għal ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Aqsam din l-Għodda ta' OiRA ma' ħaddieħor"
 
@@ -1058,7 +1056,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1122,7 +1120,7 @@ msgstr ""
 "L-istruttura bażika ta’ Valutazzjoni tar-Riskji interattiva Onlajn "
 "tikkonsisti f’dan li ġej:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1161,7 +1159,7 @@ msgstr "Il-klijent onlajn."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1173,7 +1171,7 @@ msgstr "Il-kulur speċifikat mhuwiex validu."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Hemm erba' stadji ewlenin xi tlesti fil-proċess tal-valutazzjoni:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1181,7 +1179,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Ma kienx hemm bidliet x'jiġu ssejvjati."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Din l-Għodda tal-OiRA ġiet offruta lilek minn ${external_site}"
 
@@ -1232,7 +1230,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Din l-għodda jistħoqqilha li tkun magħrufa mid-dinja! Aqsamha ma' ħaddieħor!"
@@ -1255,7 +1253,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Ma saritx żjara"
@@ -1576,7 +1573,7 @@ msgstr "Prodotta minn ${EU-OSHA}."
 msgid "based on"
 msgstr "ibbażat fuq"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "benefiċċji"
 
@@ -1646,8 +1643,8 @@ msgid "button_cancel"
 msgstr "Ikkanċella"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Agħlaq"
 
@@ -1731,9 +1728,9 @@ msgid "button_start_new_session"
 msgstr "Ibda sessjoni ġdida b’din l-għodda"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Ibda sessjoni"
 
@@ -2200,17 +2197,17 @@ msgid "error_password_mismatch"
 msgstr "Il-passwords ma jaqblux"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Din id-data għandha tkun fid-data tal-bidu jew warajha."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Din id-data għandha tkun fid-data ta' tmiem jew qabilha."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Dan il-valur għandu jkun numru sħiħ pożittiv."
 
@@ -2324,7 +2321,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2441,12 +2438,12 @@ msgid "header_additional_content"
 msgstr "Kontenut addizzjonali"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Riżorsi addizzjonali għall-evalwazzjoni tar-riskju"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Rizörsi addizzjonali għal din it-taqsima"
 
@@ -2531,6 +2528,7 @@ msgstr "Liċenzji"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
 
@@ -2640,11 +2638,6 @@ msgstr "Il-Fażijiet tal-Proġett"
 msgid "header_publish"
 msgstr "Tippublika l-Għodda tal-OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Mistoqsijiet imwieġba għal kull modulu"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2658,7 +2651,7 @@ msgid "header_reporting"
 msgstr "Rappurtar"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Riżorsi"
 
@@ -2789,13 +2782,12 @@ msgid "header_why_oira"
 msgstr "Għaliex il-proġett tal-OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Kummenti"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Riskji ta' prijorità għolja"
 
@@ -2993,7 +2985,7 @@ msgstr ""
 "ta' Għodda tal-OiRA eżistenti.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indika l-frekwenza li biha dan ir-riskju jimmaterjalizza ruħu f'sitwazzjoni "
@@ -3007,12 +2999,12 @@ msgstr ""
 "jkunu jistgħu jibdlu l-prijorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Indika l-probabbiltà ta' dan ir-riskju f'sitwazzjoni normali."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indika s-severità jekk dan ir-riskju jimmaterjalizza ruħu."
 
@@ -3364,7 +3356,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Din hija sessjoni ta' test"
 
@@ -3610,7 +3601,7 @@ msgid "label_body"
 msgstr "Kontenut tal-paġna"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Aqbeż"
 
@@ -3646,7 +3637,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Tista' tħalli xi kummenti dwar il-mistoqsija t'hawn fuq f'dan il-qasam. Dawn "
@@ -3808,11 +3799,6 @@ msgstr "Insejt il-password tiegħi"
 msgid "label_format"
 msgstr "Format"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Informazzjoni ġenerali"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3891,7 +3877,7 @@ msgid "label_language"
 msgstr "Lingwa"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referenzi legali u tal-politika"
@@ -3946,11 +3932,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr "Livell ta' kompetenza u/jew rekwiżiti meħtieġa"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3986,38 +3967,34 @@ msgstr "Sessjoni ta' test ġdida"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Li jmiss"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Le"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "L-ebda riskju"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "L-ebda riskju"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "L-ebda riskju"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "L-ebda riskju"
 
@@ -4037,12 +4014,12 @@ msgid "label_old_password"
 msgstr "Password Attwali"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Paġna"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "minn"
 
@@ -4074,9 +4051,9 @@ msgid "label_preview"
 msgstr "Preview"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Preċedenti"
 
@@ -4094,7 +4071,7 @@ msgstr "Mistoqsija"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Ippubblikata"
 
@@ -4111,7 +4088,7 @@ msgstr "B'liema mod sirt taf dwar din l-għodda?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "irreġistra"
 
@@ -4184,49 +4161,41 @@ msgstr "Tip ta' riskju"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Riskju mingħajr miżura"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Riskju mingħajr miżura"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Riskju mingħajr miżura"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riskju mingħajr miżura"
 
@@ -4267,13 +4236,20 @@ msgstr "Titlu tas-settur."
 msgid "label_select_measure"
 msgstr "Agħżel waħda jew iktar mill-miżuri komuni pprovduti."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Ibda sessjoni ġdida billi tagħżel waħda mill-għodda settorjali li ġejjin"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4316,14 +4292,9 @@ msgid "label_start_identification"
 msgstr "Ibda l-Identifikazzjoni tar-Riskji"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Ibda"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "Mibdi"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4359,6 +4330,11 @@ msgstr "Isem il-verżjoni"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Titlu tal-Għodda tal-OiRA impurtata"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4402,11 +4378,6 @@ msgstr "Tip ta’ Għodda OiRA"
 msgid "label_tryout"
 msgstr "ħaddem sessjoni ta' test"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4426,11 +4397,6 @@ msgstr "Isem għall-verżjoni tal-Għodda tal-OiRA"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "L-għodda użata"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4453,7 +4419,7 @@ msgid "label_workers_participated"
 msgstr "Il-ħaddiema ġew mistiedna jieħdu sehem fil-valutazzjoni tar-riskji"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Iva"
@@ -4485,18 +4451,17 @@ msgstr ""
 "${label} = Din il-verżjoni fiha bidliet li attwalment mhumiex ippubblikati. "
 "Ikklikkja l-ikona tal-aġġornament biex tagħmel il-bidliet kollha"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "limitazzjonijiet"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Login"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4704,7 +4669,7 @@ msgstr "Settings"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Stat"
 
@@ -4806,7 +4771,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4837,7 +4802,7 @@ msgid "portlet_header_versions"
 msgstr "Verżjonijiet"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4879,6 +4844,11 @@ msgstr "Medju"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Żgħir"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5191,14 +5161,14 @@ msgstr ""
 "tipproċedi aqra sew it-termini u l-kundizzjonijiet il-ġodda."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Aqra hawnhekk dwar l-${benefits}${tooltip_benefits} u "
 "${limitations}${tooltip_limitations} ta' sessjoni ta' test."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Jew ${register_link} minflok. Sir af għaliex għandek tirreġistra"
@@ -5296,14 +5266,9 @@ msgstr "Irkupru tal-password"
 msgid "title_sectors"
 msgstr "Setturi"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Status ta' ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -5324,11 +5289,6 @@ msgstr "Neħħi mill-pubblikazzjoni \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "L-Għodda tal-OiRA ġiet aġġornata"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Status ta' ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5442,6 +5402,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Iva"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Mistoqsijiet imwieġba għal kull modulu"
+
+#~ msgid "label_general_information"
+#~ msgstr "Informazzjoni ġenerali"
+
+#~ msgid "label_started"
+#~ msgstr "Mibdi"
+
+#~ msgid "label_used_tool"
+#~ msgstr "L-għodda użata"
+
+#~ msgid "title_status_of"
+#~ msgstr "Status ta' ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Status ta' ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Ma saru l-ebda bidliet fil-miżuri tal-pjan t’azzjoni tiegħek."

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -230,7 +230,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Beschikbare OiRA RI&E instrumenten"
 
@@ -417,7 +417,7 @@ msgstr "Moet ik me voorbereiden?"
 msgid "Documentation"
 msgstr "Documentatie"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr "Download het overzicht van maatregelen"
 msgid "Download the risks overview"
 msgstr "Download het overzicht van risico's"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -474,11 +474,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr "E-mail adres/login naam"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 "te maken. U kunt op elk moment stoppen en later weer verder gaan waar u "
 "gebleven was of wijzigen aanbrengen."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -582,7 +582,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informatie"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
@@ -612,16 +612,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "Laatst opgeslagen"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Meer informatie over deze tool…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -847,7 +846,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Overgeslagen"
@@ -999,11 +997,11 @@ msgstr "Branche-informatie en groepen voor de gebruiker"
 msgid "Sector workflow"
 msgstr "Branche workflow"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sessie `${name}` is verwijderd."
 
@@ -1015,7 +1013,7 @@ msgstr "De titel van de sessie is veranderd in ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Deze OiRA-tool delen"
 
@@ -1049,7 +1047,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1104,7 +1102,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1143,7 +1141,7 @@ msgstr "De online gebruikerssite"
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1155,7 +1153,7 @@ msgstr "De opgegven kleur is niet geldig."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Er zijn vier stappen die u moet doorlopen voor een RI&E:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1163,7 +1161,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Er waren geen wijzigingen om op te slaan."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Dit OiRA-tool werd u aangeboden door ${external_site}"
 
@@ -1212,7 +1210,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Deze tool verdient wereldwijde bekendheid! Deel de tool!"
 
@@ -1234,7 +1232,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Niet bekekeken"
@@ -1540,7 +1537,7 @@ msgstr "Geproduceerd door ${EU-OSHA}"
 msgid "based on"
 msgstr "gebaseerd op"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "voordelen"
 
@@ -1607,8 +1604,8 @@ msgid "button_cancel"
 msgstr "Annuleren"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Sluit"
 
@@ -1692,9 +1689,9 @@ msgid "button_start_new_session"
 msgstr "Start een nieuwe sessie met deze tool"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Sessie starten"
 
@@ -2158,17 +2155,17 @@ msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2304,7 +2301,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 "In eerste instantie staat er bij elke vraag ‘dit risico is nog niet "
@@ -2424,12 +2421,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Aanvullende bronnen om het risico te beoordelen"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Aanvullende bronnen voor deze module"
 
@@ -2514,6 +2511,7 @@ msgstr "Licentie"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
 
@@ -2623,11 +2621,6 @@ msgstr "Projectfasen"
 msgid "header_publish"
 msgstr "Publiceer de RI&E"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Beantwoorde vragen per module"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2641,7 +2634,7 @@ msgid "header_reporting"
 msgstr "Rapportage"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Bronnen"
 
@@ -2770,13 +2763,12 @@ msgid "header_why_oira"
 msgstr "Waarom het OiRA project"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Opmerkingen"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Risico's met een hoge prioriteit"
 
@@ -2977,7 +2969,7 @@ msgstr ""
 "kopie van een bestaande RI&E."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -2989,14 +2981,14 @@ msgstr ""
 "kan dit zelf alsnog wijzigen bij het invullen van de RI&E."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 "Geef een indicatie van de zwaarte van het effect (hoe schadelijk is het voor "
@@ -3364,7 +3356,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Dit is een proefsessie"
 
@@ -3603,7 +3594,7 @@ msgid "label_body"
 msgstr "Pagina inhoud"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Overslaan"
 
@@ -3639,7 +3630,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Vul hier eventuele opmerkingen in die moeten worden meegenomen in het "
@@ -3802,11 +3793,6 @@ msgstr "Ik ben mijn wachtwoord vergeten."
 msgid "label_format"
 msgstr "Bestandsformaat"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Algemene informatie"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3885,7 +3871,7 @@ msgid "label_language"
 msgstr "Taal"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Wet- en regelgeving"
@@ -3938,11 +3924,6 @@ msgstr "Preventie plan"
 msgid "label_measure_requirements"
 msgstr "Vereisten"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr "door"
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3978,38 +3959,34 @@ msgstr "Nieuwe proefsessie"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Volgende"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Nee"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Geen risico"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Geen risico"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Geen risico"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Geen risico"
 
@@ -4029,12 +4006,12 @@ msgid "label_old_password"
 msgstr "Huidige wachtwoord"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Pagina"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "van"
 
@@ -4066,9 +4043,9 @@ msgid "label_preview"
 msgstr "Preview"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorige"
 
@@ -4086,7 +4063,7 @@ msgstr "Vraagstelling"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Gepubliceerd"
 
@@ -4103,7 +4080,7 @@ msgstr "Hoe bent u bij deze site gevonden?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "Registreer"
 
@@ -4176,49 +4153,41 @@ msgstr "Type risico"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Risico met maatregel(en)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Risico zonder maatregel"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risico‘s zonder maatregel"
 
@@ -4259,12 +4228,19 @@ msgstr "Titel van de branche"
 msgid "label_select_measure"
 msgstr "Selecteer één of meer van de bekende vaak voorkomende maatregelen."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Start een nieuwe RI&E in de volgende branche"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr "Kies uit een van onderstaande instrumenten"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4309,14 +4285,9 @@ msgid "label_start_identification"
 msgstr "Start risico inventarisatie"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Start"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "Gestart"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4352,6 +4323,11 @@ msgstr "Versie"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Titel van geïmporteerde RI&E"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4395,11 +4371,6 @@ msgstr "Soort OiRA-tool"
 msgid "label_tryout"
 msgstr "Start een proefsessie"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4419,11 +4390,6 @@ msgstr "Naam voor RI&E versie"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Gebruikte tool"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4446,7 +4412,7 @@ msgid "label_workers_participated"
 msgstr "Er zijn werknemers gevraagd deel te nemen in deze RI&E"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Ja"
@@ -4478,18 +4444,17 @@ msgstr ""
 "${label} = Deze versie bevat wijzigingen die nog niet gepubliceerd zijn. "
 "Klik op Publiceer om deze zichtbaar te maken voor de invuller (client)."
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "beperkingen"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Login"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4700,7 +4665,7 @@ msgstr "Instellingen"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Status"
 
@@ -4802,7 +4767,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4834,7 +4799,7 @@ msgid "portlet_header_versions"
 msgstr "Versies"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4876,6 +4841,11 @@ msgstr "Gemiddeld"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Klein"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5185,14 +5155,14 @@ msgstr ""
 "met de nieuwe voorwaarden voordat u verder kan gaan."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Lees hier meer over de ${benefits}${tooltip_benefits} en "
 "${limitations}${tooltip_limitations} van een proefsessie."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Of kies in plaats daarvan voor ${register_link}. Ontdek waarom het goed is "
@@ -5290,14 +5260,9 @@ msgstr "Wachtwoord vergeten"
 msgid "title_sectors"
 msgstr "Branches"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Status van ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "Risico Inventarisatie en Evaluatie (RI&E)"
@@ -5316,11 +5281,6 @@ msgstr "De-publiceer \"${title}\""
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "De RI&E is bijgewerkt."
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Status van ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5435,6 +5395,27 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Beantwoorde vragen per module"
+
+#~ msgid "label_general_information"
+#~ msgstr "Algemene informatie"
+
+#~ msgid "label_modified_by"
+#~ msgstr "door"
+
+#~ msgid "label_started"
+#~ msgstr "Gestart"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Gebruikte tool"
+
+#~ msgid "title_status_of"
+#~ msgstr "Status van ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Status van ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Er zijn geen wijzigingen gedaan in de maatregelen van uw actieplan."

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -236,7 +236,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Beschikbare OiRA-tools"
 
@@ -421,7 +421,7 @@ msgstr "Moet ik me voorbereiden?"
 msgid "Documentation"
 msgstr "Documentatie"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Gebeurt dit op meerdere plaatsen?"
 
@@ -449,7 +449,7 @@ msgstr "Download het overzicht van maatregelen"
 msgid "Download the risks overview"
 msgstr "Download het overzicht van risico's"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -478,11 +478,11 @@ msgstr "Bewerk Profielvraag"
 msgid "Email address/account name"
 msgstr "E-mailadres/accountnaam"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Vul de naam van de locatie in"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Vul de naam van elke locatie in"
 
@@ -560,7 +560,7 @@ msgstr ""
 "Het is echter mogelijk om een risicoanalyse aan te vangen en op een later "
 "tijdstip, wanneer het beter uitkomt, vanaf dat punt weer verder te gaan."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Ik wil het volgende met u delen"
 
@@ -586,7 +586,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informatie"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
@@ -615,16 +615,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "Laatst opgeslagen"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Meer informatie over deze tool…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -846,7 +845,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Verwijs naar de voorbeelden onder het formulier."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Uitgesteld"
@@ -1002,11 +1000,11 @@ msgstr "Sectorinformatie en groepen voor de gebruiker."
 msgid "Sector workflow"
 msgstr "Sectorworkflow"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Sessie `${name}` is verwijderd."
 
@@ -1018,7 +1016,7 @@ msgstr "De titel van de sessie is veranderd in ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Deze OiRA-tool delen"
 
@@ -1052,7 +1050,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1114,7 +1112,7 @@ msgid ""
 msgstr ""
 "De basisarchitectuur van een Online interactive Risk Assessment bestaat uit:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1152,7 +1150,7 @@ msgstr "De online gebruikerssite."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1164,7 +1162,7 @@ msgstr "De opgegeven kleur is niet geldig."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "De risicoanalyse bestaat uit vier hoofdfasen."
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1172,7 +1170,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Er waren geen wijzigingen om op te slaan."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Dit OiRA-tool werd u aangeboden door ${external_site}"
 
@@ -1222,7 +1220,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Deze tool verdient wereldwijde bekendheid! Deel de tool!"
 
@@ -1244,7 +1242,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Onbeantwoord"
@@ -1563,7 +1560,7 @@ msgstr "Geproduceerd door ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "voordelen"
 
@@ -1632,8 +1629,8 @@ msgid "button_cancel"
 msgstr "Annuleren"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Sluit"
 
@@ -1717,9 +1714,9 @@ msgid "button_start_new_session"
 msgstr "Start een nieuwe sessie met deze tool"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Sessie starten"
 
@@ -2186,17 +2183,17 @@ msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2314,7 +2311,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2431,12 +2428,12 @@ msgid "header_additional_content"
 msgstr "Aanvullende inhoud"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Aanvullende bronnen om het risico te beoordelen"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Aanvullende bronnen voor deze module"
 
@@ -2521,6 +2518,7 @@ msgstr "Licenties"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Inloggen"
 
@@ -2630,11 +2628,6 @@ msgstr "Projectfase"
 msgid "header_publish"
 msgstr "OiRA-instrument publiceren"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Vragen beantwoord per module"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2648,7 +2641,7 @@ msgid "header_reporting"
 msgstr "Rapportering"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Middelen"
 
@@ -2777,13 +2770,12 @@ msgid "header_why_oira"
 msgstr "Waarom het OiRA-project"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Commentaar"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Risico's met een hoge prioriteit"
 
@@ -2981,7 +2973,7 @@ msgstr ""
 "wilt aanvangen met een exemplaar van een bestaand OiRA-instrument.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -2993,14 +2985,14 @@ msgstr ""
 "Hij/zij kan de prioriteit later nog wel wijzigen."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Geef de ernst aan wanneer dit risico zich voordoet."
 
@@ -3361,7 +3353,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Dit is een proefsessie"
 
@@ -3605,7 +3596,7 @@ msgid "label_body"
 msgstr "Pagina-inhoud"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Overslaan"
 
@@ -3641,7 +3632,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Gelieve hier al uw opmerkingen met betrekking tot de bovenstaande vraag te "
@@ -3804,11 +3795,6 @@ msgstr "Ik ben mijn wachtwoord vergeten"
 msgid "label_format"
 msgstr "Bestandsformaat"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Algemene informatie"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3887,7 +3873,7 @@ msgid "label_language"
 msgstr "Taal"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Wet- en beleidsreferenties"
@@ -3941,11 +3927,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr "Niveau van expertise en/of vereisten nodig"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr "door"
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3982,38 +3963,34 @@ msgstr "Nieuwe proefsessie"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Volgende"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Nee"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Geen risico"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Geen risico"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Geen risico"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Geen risico"
 
@@ -4033,12 +4010,12 @@ msgid "label_old_password"
 msgstr "Huidig wachtwoord"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Pagina"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "van"
 
@@ -4070,9 +4047,9 @@ msgid "label_preview"
 msgstr "Voorbeeld"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorige"
 
@@ -4090,7 +4067,7 @@ msgstr "Vraag"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Gepubliceerd"
 
@@ -4107,7 +4084,7 @@ msgstr "Waar hebt u over dit instrument gehoord?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registreer"
 
@@ -4180,49 +4157,41 @@ msgstr "Risicotype"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Risico met maatregel(en)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Risico zonder maatregel"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risico‘s zonder maatregel"
 
@@ -4263,12 +4232,19 @@ msgstr "Titel van de sector."
 msgid "label_select_measure"
 msgstr "Selecteer één of meer van de bekende vaak voorkomende maatregelen."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Kies uw sector in het uitrolmenu hieronder"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4311,14 +4287,9 @@ msgid "label_start_identification"
 msgstr "Start risico-identificatie"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Start"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "Gestart"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4354,6 +4325,11 @@ msgstr "Versienaam"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Titel van geïmporteerd OiRA-instrument"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4397,11 +4373,6 @@ msgstr "Soort OiRA-tool"
 msgid "label_tryout"
 msgstr "Start een proefsessie"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4421,11 +4392,6 @@ msgstr "Naam voor de versie van het OiRA-instrument"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Gebruikte tool"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4448,7 +4414,7 @@ msgid "label_workers_participated"
 msgstr "Arbeiders werden uitgenodigd om deel te nemen aan de risicobeoordeling"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Ja"
@@ -4480,18 +4446,17 @@ msgstr ""
 "${label} = Deze versie bevat wijzigingen die nog niet gepubliceerd zijn. "
 "Klik op het pictogram bijwerken om alle wijzigingen zichtbaar te maken"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "beperkingen"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Inloggen"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4705,7 +4670,7 @@ msgstr "Instellingen"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Bekijk uw voortgang"
 
@@ -4807,7 +4772,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4839,7 +4804,7 @@ msgid "portlet_header_versions"
 msgstr "Versies"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4881,6 +4846,11 @@ msgstr "Gemiddeld"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Klein"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5195,14 +5165,14 @@ msgstr ""
 "nieuwe algemene voorwaarden aandachtig door voordat u verdergaat."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Lees hier meer over de ${benefits}${tooltip_benefits} en "
 "${limitations}${tooltip_limitations} van een proefsessie."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Of kies in plaats daarvan voor ${register_link}. Ontdek waarom het goed is "
@@ -5300,14 +5270,9 @@ msgstr "Wachtwoord herstel"
 msgid "title_sectors"
 msgstr "Sectoren"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Status van ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Online interactive Risk Assessment"
@@ -5326,11 +5291,6 @@ msgstr "Publicatie \"${title}\" ongedaan maken"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "OiRA-instrument werd bijgewerkt"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Status van ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5445,6 +5405,27 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Vragen beantwoord per module"
+
+#~ msgid "label_general_information"
+#~ msgstr "Algemene informatie"
+
+#~ msgid "label_modified_by"
+#~ msgstr "door"
+
+#~ msgid "label_started"
+#~ msgstr "Gestart"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Gebruikte tool"
+
+#~ msgid "title_status_of"
+#~ msgstr "Status van ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Status van ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-post"
@@ -450,11 +450,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -579,16 +579,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -789,7 +788,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -933,11 +931,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -949,7 +947,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Del dette OiRA-verktøyet"
 
@@ -983,7 +981,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1038,7 +1036,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1071,7 +1069,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1083,7 +1081,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1091,7 +1089,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1138,7 +1136,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Hele verden bør bli kjent med dette verktøyet! Del det med andre!"
 
@@ -1160,7 +1158,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1414,7 +1411,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1481,8 +1478,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1566,9 +1563,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1944,17 +1941,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2048,7 +2045,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2159,12 +2156,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2248,6 +2245,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2357,11 +2355,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2375,7 +2368,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2503,13 +2496,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2699,7 +2691,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2709,12 +2701,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3002,7 +2994,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3198,7 +3189,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3234,7 +3225,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3394,11 +3385,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3477,7 +3463,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3530,11 +3516,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3570,38 +3551,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3621,12 +3598,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3658,9 +3635,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3678,7 +3655,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3695,7 +3672,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3766,49 +3743,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3849,11 +3818,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3897,13 +3873,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3939,6 +3910,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3983,11 +3959,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4006,11 +3977,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4034,7 +4000,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4064,18 +4030,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4271,7 +4236,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4373,7 +4338,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4398,7 +4363,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4439,6 +4404,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4732,12 +4702,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4833,14 +4803,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4858,11 +4823,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -236,7 +236,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -453,11 +453,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -582,16 +582,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -792,7 +791,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -936,11 +934,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -952,7 +950,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Podziel się narzędziem OiRA"
 
@@ -986,7 +984,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1041,7 +1039,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1074,7 +1072,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1086,7 +1084,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1094,7 +1092,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1141,7 +1139,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Narzędzie to powinno zostać rozpowszechnione na cały świat! Udostępnij!"
@@ -1164,7 +1162,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1418,7 +1415,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1485,8 +1482,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1570,9 +1567,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1951,17 +1948,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2055,7 +2052,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2166,12 +2163,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2255,6 +2252,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2364,11 +2362,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2382,7 +2375,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2510,13 +2503,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2706,7 +2698,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2716,12 +2708,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3009,7 +3001,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3205,7 +3196,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3241,7 +3232,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3401,11 +3392,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3484,7 +3470,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3537,11 +3523,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3577,38 +3558,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3628,12 +3605,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3665,9 +3642,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3685,7 +3662,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3702,7 +3679,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3773,49 +3750,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3856,11 +3825,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3904,13 +3880,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3946,6 +3917,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3990,11 +3966,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4013,11 +3984,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4041,7 +4007,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4071,18 +4037,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4278,7 +4243,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4380,7 +4345,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4405,7 +4370,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4446,6 +4411,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4739,12 +4709,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4840,14 +4810,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4865,11 +4830,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Ferramentas OiRA disponíveis"
 
@@ -421,7 +421,7 @@ msgstr "Preciso de me preparar?"
 msgid "Documentation"
 msgstr "Documentação"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Isto ocorre em locais diversos?"
 
@@ -449,7 +449,7 @@ msgstr "Descarregue o quadro geral das medidas"
 msgid "Download the risks overview"
 msgstr "Descarregue o quadro geral dos riscos"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Correio eletrónico"
@@ -478,11 +478,11 @@ msgstr "Editar Perguntas do perfil"
 msgid "Email address/account name"
 msgstr "Endereço de e-mail/nome da conta"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Introduza o nome do local"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Introduza o nome de cada local"
 
@@ -559,7 +559,7 @@ msgstr ""
 "Contudo, pode dedicar o seu tempo conforme as suas disponibilidades, podendo "
 "fazer interrupções e continuar a avaliação quando for mais conveniente."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Clique para seguir ligação"
 
@@ -585,7 +585,7 @@ msgstr "Informação"
 msgid "Information"
 msgstr "Informação"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -615,16 +615,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "guardada"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Saiba mais sobre esta ferramenta…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -844,7 +843,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Consulte os exemplos abaixo do formulário."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Adiado"
@@ -1001,11 +999,11 @@ msgstr "Informação do setor e agrupamento para o cliente."
 msgid "Sector workflow"
 msgstr "Fluxo de trabalho do setor"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "A sessão `${name}` foi eliminada."
 
@@ -1017,7 +1015,7 @@ msgstr "O título da sessão foi mudado para ${nome}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Partilhar este OiRA"
 
@@ -1051,7 +1049,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1114,7 +1112,7 @@ msgstr ""
 "A arquitetura de base de um instrumento interativo em linha de avaliação de "
 "risco consiste em:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1152,7 +1150,7 @@ msgstr "O cliente online."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1164,7 +1162,7 @@ msgstr "A cor especificada não é válida."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "O processo de avaliação compreende quatro etapas principais:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1172,7 +1170,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Não existiam alterações para guardar."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Esta ferramenta OiRA foi-lhe oferecida por ${external_site}"
 
@@ -1222,7 +1220,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Este instrumento merece ser conhecido em todo o mundo! Partilhe-o!"
 
@@ -1244,7 +1242,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Sem resposta"
@@ -1555,7 +1552,7 @@ msgstr "Elaborada por ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "vantagens"
 
@@ -1624,8 +1621,8 @@ msgid "button_cancel"
 msgstr "Cancelar"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Fechar"
 
@@ -1709,9 +1706,9 @@ msgid "button_start_new_session"
 msgstr "Inicie uma nova sessão com esta ferramenta"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Iniciar sessão"
 
@@ -2175,17 +2172,17 @@ msgid "error_password_mismatch"
 msgstr "As palavras-passe não correspondem"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr "Esta data deve ser igual ou posterior à data inicial."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr "Esta data deve ser igual ou anterior à data final."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Este valor deve ser um número inteiro positivo."
 
@@ -2300,7 +2297,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2417,12 +2414,12 @@ msgid "header_additional_content"
 msgstr "Conteúdo adicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Recursos adicionais para a avaliação do risco"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Recursos adicionais para este mòdulo"
 
@@ -2507,6 +2504,7 @@ msgstr "Licenças"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
 
@@ -2616,11 +2614,6 @@ msgstr "Fases do projeto"
 msgid "header_publish"
 msgstr "Publicar Ferramenta OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Perguntas respondidas por módulo"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2634,7 +2627,7 @@ msgid "header_reporting"
 msgstr "Relatório"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Recursos"
 
@@ -2763,13 +2756,12 @@ msgid "header_why_oira"
 msgstr "Porquê o projeto OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Comentários"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Riscos de prioridade alta"
 
@@ -2967,7 +2959,7 @@ msgstr ""
 "começar com uma cópia de uma Ferramenta OiRA existente.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Indica a frequência de ocorrência do risco numa situação normal."
 
@@ -2979,12 +2971,12 @@ msgstr ""
 "ainda pode alterar a prioridade."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Indica a probabilidade de ocorrência deste risco numa siutação normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indica a gravidade em caso de ocorrência do risco."
 
@@ -3335,7 +3327,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "Sessão de teste"
 
@@ -3578,7 +3569,7 @@ msgid "label_body"
 msgstr "Conteúdo da página"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Avançar"
 
@@ -3614,7 +3605,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Queira por favor comentar a questão acima indicada. Estes comentários serão "
@@ -3776,11 +3767,6 @@ msgstr "Esqueci-me da palavra-passe"
 msgid "label_format"
 msgstr "Formato"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3859,7 +3845,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referências legais e políticas"
@@ -3912,11 +3898,6 @@ msgstr "Ação(ões) específica(s) necessária(s) para implementar esta abordag
 msgid "label_measure_requirements"
 msgstr "Nível de competência e/ou requisitos necessários"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3952,38 +3933,34 @@ msgstr "Nova sessão de teste"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Seguinte"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Não"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Nenhum risco"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Nenhum risco"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Nenhum risco"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Nenhum risco"
 
@@ -4003,12 +3980,12 @@ msgid "label_old_password"
 msgstr "Palavra-passe atual"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Página"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "de"
 
@@ -4040,9 +4017,9 @@ msgid "label_preview"
 msgstr "Pré-visualização"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
 
@@ -4060,7 +4037,7 @@ msgstr "Pergunta"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Publicado"
 
@@ -4077,7 +4054,7 @@ msgstr "Através de que meio entrou em contacto com esta ferramenta?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registe-se"
 
@@ -4148,49 +4125,41 @@ msgstr "Tipo de risco"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Risco com medida(s)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Risco sem medida"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Riscos com medida(s"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Riscos com medida(s"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riscos com medida(s"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Riscos sem medida"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Riscos sem medida"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riscos sem medida"
 
@@ -4232,13 +4201,20 @@ msgid "label_select_measure"
 msgstr ""
 "Selecione uma ou mais das medidas comuns conhecidas que foram fornecidas."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Inicie uma nova sessão, selecionando uma das seguintes ferramentas setoriais"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4281,14 +4257,9 @@ msgid "label_start_identification"
 msgstr "Iniciar a identificação de perigos"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Iniciar"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4324,6 +4295,11 @@ msgstr "Nome da versão"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Título da Ferramenta OiRA importada"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4367,11 +4343,6 @@ msgstr "Tipo de Ferramenta OiRA"
 msgid "label_tryout"
 msgstr "realizar uma sessão de teste"
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4390,11 +4361,6 @@ msgstr "Nome para a versão da Ferramenta OiRA "
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4418,7 +4384,7 @@ msgid "label_workers_participated"
 msgstr "Os trabalhadores foram convidados a participar na avaliação de riscos"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Sim"
@@ -4450,18 +4416,17 @@ msgstr ""
 "${label} = Esta versão contém alterações que não estão publicadas "
 "atualmente. Clique no ícone de atualização para ativar todas as alterações"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "limitações"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Login"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4674,7 +4639,7 @@ msgstr "Definições"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Estado"
 
@@ -4776,7 +4741,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr "A sua palavra-passe para confirmação"
 
@@ -4806,7 +4771,7 @@ msgid "portlet_header_versions"
 msgstr "Versões"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4848,6 +4813,11 @@ msgstr "Média"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Pequena"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5159,14 +5129,14 @@ msgstr ""
 "atentamente os novos termos e condições antes de avançar."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Leia aqui sobre as ${benefits}${tooltip_benefits} e "
 "${limitations}${tooltip_limitations} de uma sessão de teste."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Ou ${register_link} em alternativa. Conheça os motivos por que deve registar-"
@@ -5264,14 +5234,9 @@ msgstr "Recuperação de senha"
 msgid "title_sectors"
 msgstr "Setores"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Estado do ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Online interactive Risk Assessment"
@@ -5290,11 +5255,6 @@ msgstr "Não publicar \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "A Ferramenta OiRA foi atualizada"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Estado do ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5408,6 +5368,15 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sim"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Perguntas respondidas por módulo"
+
+#~ msgid "title_status_of"
+#~ msgstr "Estado do ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Estado do ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Nenhuma alteração foi feita ao seu plano de ação"

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -236,7 +236,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -453,11 +453,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -582,16 +582,15 @@ msgid "Kosovo"
 msgstr ""
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Aflați mai multe despre acest instrument…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -792,7 +791,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr ""
@@ -936,11 +934,11 @@ msgstr ""
 msgid "Sector workflow"
 msgstr ""
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -952,7 +950,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Distribuiți acest instrument OiRA"
 
@@ -986,7 +984,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1041,7 +1039,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1074,7 +1072,7 @@ msgstr ""
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1086,7 +1084,7 @@ msgstr ""
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1094,7 +1092,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1141,7 +1139,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Acest instrument merită să fie cunoscut în lume! Distribuiți-l!"
 
@@ -1163,7 +1161,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1417,7 +1414,7 @@ msgstr ""
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1484,8 +1481,8 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1569,9 +1566,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -1950,17 +1947,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2054,7 +2051,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2165,12 +2162,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2254,6 +2251,7 @@ msgstr ""
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
 
@@ -2363,11 +2361,6 @@ msgstr ""
 msgid "header_publish"
 msgstr ""
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr ""
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2381,7 +2374,7 @@ msgid "header_reporting"
 msgstr ""
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2509,13 +2502,12 @@ msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2705,7 +2697,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2715,12 +2707,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3009,7 +3001,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3205,7 +3196,7 @@ msgid "label_body"
 msgstr ""
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3241,7 +3232,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 
@@ -3401,11 +3392,6 @@ msgstr ""
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3484,7 +3470,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3537,11 +3523,6 @@ msgstr ""
 msgid "label_measure_requirements"
 msgstr ""
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3577,38 +3558,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr ""
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3628,12 +3605,12 @@ msgid "label_old_password"
 msgstr ""
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3665,9 +3642,9 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
 
@@ -3685,7 +3662,7 @@ msgstr ""
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr ""
 
@@ -3702,7 +3679,7 @@ msgstr ""
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr ""
 
@@ -3773,49 +3750,41 @@ msgstr ""
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -3856,11 +3825,18 @@ msgstr ""
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
+msgstr ""
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
@@ -3904,13 +3880,8 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
-msgstr ""
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
 msgstr ""
 
 #. Default: "Affirmative statement"
@@ -3946,6 +3917,11 @@ msgstr ""
 #. Default: "Title of imported OiRA Tool"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
+msgstr ""
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
@@ -3990,11 +3966,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4013,11 +3984,6 @@ msgstr ""
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4041,7 +4007,7 @@ msgid "label_workers_participated"
 msgstr ""
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr ""
@@ -4071,18 +4037,17 @@ msgstr ""
 msgid "legend_updated"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4278,7 +4243,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr ""
 
@@ -4380,7 +4345,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4405,7 +4370,7 @@ msgid "portlet_header_versions"
 msgstr ""
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4446,6 +4411,11 @@ msgstr ""
 #: euphorie/client/browser/templates/webhelpers.pt:486
 #: euphorie/content/risk.py:395
 msgid "probability_small"
+msgstr ""
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
 msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
@@ -4739,12 +4709,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -4840,14 +4810,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr ""
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -4865,11 +4830,6 @@ msgstr ""
 #. Default: "OiRA Tool was updated"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
-msgstr ""
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -255,7 +255,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -415,7 +415,7 @@ msgstr "Potrebujem sa pripraviť?"
 msgid "Documentation"
 msgstr "Dokumentácia"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Deje sa to na viacerých miestach?"
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -472,11 +472,11 @@ msgstr "Upraviť Profilová otázka"
 msgid "Email address/account name"
 msgstr "E-mailová adresa/názov konta"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Zadajte názov miesta"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Zadajte názov každého miesta"
 
@@ -551,7 +551,7 @@ msgstr ""
 "sa môžete k hodnoteniu vrátiť, keď bude vhodné použiť rovnaké miesto, z "
 "ktorého ste odišli."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -577,7 +577,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informácie"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -606,16 +606,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "uložené"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Prečítajte si viac informácií o tomto nástroji…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -831,7 +830,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Pozrite si príklady pod formulárom."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Odložené"
@@ -986,11 +984,11 @@ msgstr "Informácie o sektore a zoskupenie pre klienta."
 msgid "Sector workflow"
 msgstr "Tok práce v sektore"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -1002,7 +1000,7 @@ msgstr "Názov relácie bol zmenený na ${name}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Zdieľajte tento OiRA-Tool"
 
@@ -1036,7 +1034,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1098,7 +1096,7 @@ msgid ""
 msgstr ""
 "Základná architektúra Online interaktívneho hodnotenia rizika pozostáva z:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1136,7 +1134,7 @@ msgstr "Online klient."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1148,7 +1146,7 @@ msgstr "Určená farba nie je platná."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "V procese hodnotenia je potrebné vyplniť štyri hlavné fázy:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1156,7 +1154,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Nevykonali ste žiadne zmeny, ktoré by bolo možné uložiť."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Tento nástroj OiRA vám ponúkol ${external_site}"
 
@@ -1205,7 +1203,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "O tomto nástroji by sa mal dozvedieť celý svet! Zdieľaj ho!"
 
@@ -1227,7 +1225,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Nenavštívené"
@@ -1508,7 +1505,7 @@ msgstr "Vytvorila agentúra ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1577,8 +1574,8 @@ msgid "button_cancel"
 msgstr "Zrušiť"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1662,9 +1659,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -2076,17 +2073,17 @@ msgid "error_password_mismatch"
 msgstr "Heslá sa nezhodujú"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2198,7 +2195,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2311,12 +2308,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2400,6 +2397,7 @@ msgstr "Licencie"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prihlásenie"
 
@@ -2509,11 +2507,6 @@ msgstr "Fázy projektu"
 msgid "header_publish"
 msgstr "Uverejniť nástroj OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Zodpovedané otázky na jeden modul"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2527,7 +2520,7 @@ msgid "header_reporting"
 msgstr "Spravodajstvo"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2658,13 +2651,12 @@ msgid "header_why_oira"
 msgstr "Prečo projekt OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2858,7 +2850,7 @@ msgstr ""
 "existujúceho nástroja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Uveďte, ako často k tomuto riziku dochádza v normálnej situácii."
 
@@ -2870,14 +2862,14 @@ msgstr ""
 "môže zmeniť prioritu."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, aká je pravdepodobnosť vyskytnutia sa tohto rizika v normálnej "
 "situácii."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Uveďte závažnosť vyskytnutia sa tohto rizika."
 
@@ -3204,7 +3196,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3425,7 +3416,7 @@ msgid "label_body"
 msgstr "Obsah strany"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3461,7 +3452,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Uveďte prosím prípadné komentáre k predchádzajúcej otázke v tomto poli. "
@@ -3623,11 +3614,6 @@ msgstr "Zabudol som svoje heslo"
 msgid "label_format"
 msgstr "Formát"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3706,7 +3692,7 @@ msgid "label_language"
 msgstr "Jazyk"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Právne a politické odkazy"
@@ -3759,11 +3745,6 @@ msgstr "Konkrétna akcia (akcie) potrebná na realizáciu tohto prístupu"
 msgid "label_measure_requirements"
 msgstr "Úroveň potrebnej odbornosti a/alebo požiadavky"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3801,38 +3782,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Nasledujúci"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Nie"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3852,12 +3829,12 @@ msgid "label_old_password"
 msgstr "Aktuálne heslo"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3889,9 +3866,9 @@ msgid "label_preview"
 msgstr "Náhľad"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Predchádzajúci"
 
@@ -3909,7 +3886,7 @@ msgstr "Otázka"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Zverejnené"
 
@@ -3926,7 +3903,7 @@ msgstr "Cez aký kanál ste sa dozvedeli o tomto nástroji?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registrácia"
 
@@ -3999,49 +3976,41 @@ msgstr "Typ rizika"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -4082,13 +4051,20 @@ msgstr "Názov sektora."
 msgid "label_select_measure"
 msgstr "Vyberte jedno alebo viac z uvedených známych spoločných opatrení."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Začať nové stretnutie výberom jedného z nasledujúcich sektorových nástrojov"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4131,14 +4107,9 @@ msgid "label_start_identification"
 msgstr "Identifikácia počiatočného rizika"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Začať"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4174,6 +4145,11 @@ msgstr "Názov verzie"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Názov importovaného nástroja OiRA"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4217,11 +4193,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4240,11 +4211,6 @@ msgstr "Názov pre verziu nástroja OiRA"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4268,7 +4234,7 @@ msgid "label_workers_participated"
 msgstr "Pracovníci boli pozvaní, aby sa zúčastnili hodnotenia rizík"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Áno"
@@ -4300,18 +4266,17 @@ msgstr ""
 "${label} = Táto verzia má zmeny, ktoré momentálne nie sú zverejnené. "
 "Kliknutím na ikonu aktualizácie vyvolajte všetky aktívne zmeny"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4516,7 +4481,7 @@ msgstr "Nastavenia"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Stav"
 
@@ -4618,7 +4583,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr "Vaše heslo na potvrdenie"
 
@@ -4645,7 +4610,7 @@ msgid "portlet_header_versions"
 msgstr "Verzie"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4687,6 +4652,11 @@ msgstr "Stredná"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Malá"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -4987,12 +4957,12 @@ msgstr ""
 "pokračovať, si pozorne prečítajte nové podmienky."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -5088,14 +5058,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr "Sektory"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr ""
@@ -5116,11 +5081,6 @@ msgstr "Nezverejniť \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Nástroj OiRA bol aktualizovaný"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr ""
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5229,6 +5189,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Áno"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Zodpovedané otázky na jeden modul"
 
 #~ msgid "Page ${number} of ${total}"
 #~ msgstr "Strana ${number} z ${total}"

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -258,7 +258,7 @@ msgstr "Ali res želiš nadaljevati?"
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr "Razpoložljiva OiRA orodja"
 
@@ -424,7 +424,7 @@ msgstr "Ali se moram pripraviti?"
 msgid "Documentation"
 msgstr "Dokumentacija"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr "Se je to zgodilo na več mestih?"
 
@@ -452,7 +452,7 @@ msgstr "Prenesite pregled ukrepov"
 msgid "Download the risks overview"
 msgstr "Prenesite pregled tveganj"
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-pošta"
@@ -481,11 +481,11 @@ msgstr "Uredi Profilno vprašanje"
 msgid "Email address/account name"
 msgstr "E-poštni naslov/ime računa"
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr "Vpišite ime lokacije"
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr "Vpišite ime vsake od lokacij"
 
@@ -561,7 +561,7 @@ msgstr ""
 "Vendar pa si lahko za oceno vzamete toliko časa kot ga imate na voljo in se "
 "kasneje vrnete in nadaljujete, kjer ste prekinili."
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr "Z vami želim deliti naslednje"
 
@@ -587,7 +587,7 @@ msgstr "Informacije"
 msgid "Information"
 msgstr "Informacije"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Napačen format slike. Prosim, uporabi PNG, JPEG ali GIF."
 
@@ -616,16 +616,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr "shranjeno"
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr "Preberite več o tem orodju…"
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -847,7 +846,6 @@ msgid "Please refer to the examples below the form."
 msgstr "Oglejte si primere pod obrazcem."
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "Preloženo"
@@ -1002,11 +1000,11 @@ msgstr "Informacije o sektorju in združevanje za odjemalca."
 msgid "Sector workflow"
 msgstr "Delovni tok sektorja"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr "Seja `${name}` je bila izbrisana."
 
@@ -1018,7 +1016,7 @@ msgstr "Naslov seje je bil spremenjen v ${ime}"
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Seznanite druge s tem orodjem OiRA"
 
@@ -1052,7 +1050,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1113,7 +1111,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "V osnovi spletno interaktivno oceno tveganja sestavljajo:"
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1151,7 +1149,7 @@ msgstr "Spletni odjemalec."
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1163,7 +1161,7 @@ msgstr "Specificirana barva ni veljavna."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr "Ocenjevalni postopek ima štiri glavne faze:"
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1171,7 +1169,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr "Nobene spremembe se niso shranile."
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr "Orodje OiRA je za vas omogočeno s pomočjo ${external_site}"
 
@@ -1220,7 +1218,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "To orodje si zasluži vsesplošno prepoznavnost! Delite ga!"
 
@@ -1242,7 +1240,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr "Neodgovorjeno"
@@ -1544,7 +1541,7 @@ msgstr "Izdelal ${EU-OSHA}."
 msgid "based on"
 msgstr "na podlagi"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr "koristi"
 
@@ -1611,8 +1608,8 @@ msgid "button_cancel"
 msgstr "Prekliči"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr "Zapri"
 
@@ -1696,9 +1693,9 @@ msgid "button_start_new_session"
 msgstr "Začni z novo oceno tveganja s tem orodjem"
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr "Začni sejo"
 
@@ -2148,20 +2145,20 @@ msgid "error_password_mismatch"
 msgstr "Gesli se ne ujemata"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 "Ta datum mora biti enak začetnemu datumu oziroma mora biti poznejši od njega."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 "Ta datum mora biti enak končnemu datumu oziroma ne sme biti poznejši od "
 "njega."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr "Ta vrednost mora biti pozitivno celo število."
 
@@ -2274,7 +2271,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2391,12 +2388,12 @@ msgid "header_additional_content"
 msgstr "Dodatna vsebina"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr "Dodatni viri za ocenjevanje tveganja"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr "Dodatni viri za ta modul"
 
@@ -2481,6 +2478,7 @@ msgstr "Licence"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prijava"
 
@@ -2590,11 +2588,6 @@ msgstr "Faze projekta"
 msgid "header_publish"
 msgstr "Objavi orodje OiRA"
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Odgovorjena vprašanja na modul"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2608,7 +2601,7 @@ msgid "header_reporting"
 msgstr "Poročanje"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr "Viri"
 
@@ -2737,13 +2730,12 @@ msgid "header_why_oira"
 msgstr "Zakaj projekt OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr "Opombe"
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr "Prednostna tveganja"
 
@@ -2940,7 +2932,7 @@ msgstr ""
 "obstoječega orodja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Označite, kako pogosto se to tveganje pojavi v običajni situaciji."
 
@@ -2952,13 +2944,13 @@ msgstr ""
 "Svojo prioriteto bo še vedno lahko spremenil/a."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Označite verjetnost, da bi se to tveganje pojavilo v običajni situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Označite stopnjo resnosti, če se to tveganje pojavi."
 
@@ -3297,7 +3289,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr "To je poskusna seja"
 
@@ -3532,7 +3523,7 @@ msgid "label_body"
 msgstr "Vsebina strani"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr "Preskoči"
 
@@ -3568,7 +3559,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "V to polje vnesite vse morebitne opombe glede zgoraj navedenega, "
@@ -3730,11 +3721,6 @@ msgstr "Pozabil/a sem svoje geslo"
 msgid "label_format"
 msgstr "Format"
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr "Splošne informacije"
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3813,7 +3799,7 @@ msgid "label_language"
 msgstr "Jezik"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Zakonodaja in drugi viri"
@@ -3866,11 +3852,6 @@ msgstr "Specifični ukrepi, potrebni za izvajanje tega pristopa"
 msgid "label_measure_requirements"
 msgstr "Raven potrebne strokovnosti in/ali zahteve"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3908,38 +3889,34 @@ msgstr "Nova poskusna seja"
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Naprej"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr "Tveganje ni"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr "Tveganji ni"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr "Tveganja ni"
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr "Tveganj ni"
 
@@ -3959,12 +3936,12 @@ msgid "label_old_password"
 msgstr "Trenutno geslo"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr "Stran"
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr "od"
 
@@ -3996,9 +3973,9 @@ msgid "label_preview"
 msgstr "Predogled"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Nazaj"
 
@@ -4016,7 +3993,7 @@ msgstr "Vprašanje"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Objavljena"
 
@@ -4033,7 +4010,7 @@ msgstr "Kako ste izvedeli za to orodje?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "registriraj se"
 
@@ -4106,49 +4083,41 @@ msgstr "Vrsta tveganja"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr "Tveganje z ukrepom(-i)"
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr "Tveganje brez ukrepa"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr "Tveganji z ukrepom(-i)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr "Tveganja z ukrepom(-i)"
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Tveganj z ukrepom(-i)"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr "Tveganji brez ukrepa"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr "Tveganja brez ukrepa"
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Tveganj brez ukrepa"
 
@@ -4189,13 +4158,20 @@ msgstr "Naslov sektorja."
 msgid "label_select_measure"
 msgstr "Izberite enega ali več znanih splošnih ukrepov."
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr ""
 "Začnite novo sejo, tako da izberete eno od naslednjih sektorskih orodij"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4238,14 +4214,9 @@ msgid "label_start_identification"
 msgstr "Začni z identifikacijo tveganj"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Začni"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr "Začeto"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4281,6 +4252,11 @@ msgstr "Ime različice"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Naslov uvoženega orodja OiRA"
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4324,11 +4300,6 @@ msgstr "Vrsta orodja OiRA"
 msgid "label_tryout"
 msgstr "prijavite se kot \"gost\""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4348,11 +4319,6 @@ msgstr "Ime za različico orodja OiRA"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
 msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
-msgstr "Uporabljeno orodje"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4375,7 +4341,7 @@ msgid "label_workers_participated"
 msgstr "Delavci so bili povabljeni, da sodelujejo pri oceni tveganja"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Da"
@@ -4407,18 +4373,17 @@ msgstr ""
 "${label} = Ta različlica ima spremembe, ki trenutno niso objavljene. "
 "Kliknite ikono za posodobitev, da posodobite vse spremembe"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr "omejitve"
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr "Prijava"
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4627,7 +4592,7 @@ msgstr "Nastavitve"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Status"
 
@@ -4729,7 +4694,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 "Your password must contain at least 5 characters, including at least one "
@@ -4759,7 +4724,7 @@ msgid "portlet_header_versions"
 msgstr "Različice"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4801,6 +4766,11 @@ msgstr "Srednja"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Majhna"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -5111,14 +5081,14 @@ msgstr ""
 "skrbno preberite nove pogoje in določila."
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 "Tukaj si preberite o ${benefits}${tooltip_benefits} in "
 "${limitations}${tooltip_limitations} poskusne seje."
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 "Ali namesto tega ${register_link}. Preberite, zakaj se je koristno "
@@ -5216,14 +5186,9 @@ msgstr "Obnovitev gesla"
 msgid "title_sectors"
 msgstr "Sektorji"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr "Stanje ${survey_title}"
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA - Spletno interaktivno orodje za oceno tveganja"
@@ -5242,11 +5207,6 @@ msgstr "Prekliči objavo \"${title}"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Orodje OiRA je bilo posodobljeno"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr "Stanje ${survey_title}"
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5359,6 +5319,24 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Da"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Odgovorjena vprašanja na modul"
+
+#~ msgid "label_general_information"
+#~ msgstr "Splošne informacije"
+
+#~ msgid "label_started"
+#~ msgstr "Začeto"
+
+#~ msgid "label_used_tool"
+#~ msgstr "Uporabljeno orodje"
+
+#~ msgid "title_status_of"
+#~ msgstr "Stanje ${survey_title}"
+
+#~ msgid "title_with_vowel_status_of"
+#~ msgstr "Stanje ${survey_title}"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "V vaš načrt ukrepov ni bila vnešena nobena sprememba."

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-09 15:20+0000\n"
+"POT-Creation-Date: 2020-02-27 16:07+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:856
+#: euphorie/client/browser/risk.py:863
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Automatically generate unique ids for content"
 msgstr ""
 
-#: euphorie/client/browser/templates/portlet-available-tools.pt:10
+#: euphorie/client/browser/templates/portlet-available-tools.pt:12
 msgid "Available OiRA tools"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: euphorie/client/browser/session.py:371
+#: euphorie/client/browser/session.py:366
 msgid "Does this happen in multiple places?"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:147
+#: euphorie/client/browser/templates/start.pt:153
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-post"
@@ -454,11 +454,11 @@ msgstr ""
 msgid "Email address/account name"
 msgstr ""
 
-#: euphorie/client/browser/session.py:376
+#: euphorie/client/browser/session.py:371
 msgid "Enter the name of the location"
 msgstr ""
 
-#: euphorie/client/browser/session.py:381
+#: euphorie/client/browser/session.py:376
 msgid "Enter the names of each location"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:634
+#: euphorie/client/browser/webhelpers.py:706
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Information"
 msgstr "Information"
 
-#: euphorie/client/browser/risk.py:523
+#: euphorie/client/browser/risk.py:530
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -583,16 +583,15 @@ msgid "Kosovo"
 msgstr "Kosovo"
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:120
-#: euphorie/client/browser/templates/status.pt:73
 #: euphorie/client/browser/templates/tool_sessions.pt:49
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:55
+#: euphorie/client/browser/templates/start.pt:61
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:301
+#: euphorie/client/templates/shell.pt:314
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -795,7 +794,6 @@ msgid "Please refer to the examples below the form."
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:322
-#: euphorie/client/browser/templates/status.pt:243
 #: euphorie/client/browser/templates/webhelpers.pt:180
 msgid "Postponed"
 msgstr "${count} frågorna har skjutits upp"
@@ -942,11 +940,11 @@ msgstr "Branschinformation och gruppering för klienten."
 msgid "Sector workflow"
 msgstr "Branch arbetsflöde"
 
-#: euphorie/client/browser/session.py:576
+#: euphorie/client/browser/session.py:571
 msgid "Session `${name}` has been archived."
 msgstr ""
 
-#: euphorie/client/browser/session.py:519
+#: euphorie/client/browser/session.py:514
 msgid "Session `${name}` has been deleted."
 msgstr ""
 
@@ -958,7 +956,7 @@ msgstr ""
 msgid "Setup a standard Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:33
+#: euphorie/client/browser/templates/start.pt:39
 msgid "Share this OiRA-Tool"
 msgstr "Dela detta OiRA-verktyg"
 
@@ -992,7 +990,7 @@ msgid "Started"
 msgstr ""
 
 #: euphorie/client/browser/login.py:232
-#: euphorie/client/browser/templates/new-session-test.pt:88
+#: euphorie/client/browser/templates/new-session-test.pt:89
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
@@ -1047,7 +1045,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:860
+#: euphorie/client/browser/risk.py:867
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1080,7 +1078,7 @@ msgstr "Online-klient"
 msgid "The online risk assessment client interface for an Euphorie website"
 msgstr ""
 
-#: euphorie/client/browser/session.py:661
+#: euphorie/client/browser/session.py:657
 msgid "The risk assessment has been cloned"
 msgstr ""
 
@@ -1092,7 +1090,7 @@ msgstr "Den angivna färgen är ogiltig."
 msgid "There are four main stages to complete in the assessment process:"
 msgstr ""
 
-#: euphorie/client/browser/session.py:498
+#: euphorie/client/browser/session.py:493
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
@@ -1100,7 +1098,7 @@ msgstr ""
 msgid "There were no changes to be saved."
 msgstr ""
 
-#: euphorie/client/browser/templates/tool-more-info.pt:64
+#: euphorie/client/browser/templates/tool-more-info.pt:63
 msgid "This OiRA tool was offered to you by ${external_site}"
 msgstr ""
 
@@ -1147,7 +1145,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:125
+#: euphorie/client/browser/templates/start.pt:131
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Detta verktyg förtjänar att bli känt i världen! Dela det!"
 
@@ -1169,7 +1167,6 @@ msgid "Unpublish Risk Assessment"
 msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:330
-#: euphorie/client/browser/templates/status.pt:251
 #: euphorie/client/browser/templates/webhelpers.pt:177
 msgid "Unvisited"
 msgstr ""
@@ -1465,7 +1462,7 @@ msgstr "Producerad av ${EU-OSHA}."
 msgid "based on"
 msgstr ""
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
 msgstr ""
 
@@ -1532,8 +1529,8 @@ msgid "button_cancel"
 msgstr "Avbryt"
 
 #. Default: "Close"
-#: euphorie/client/browser/templates/new-session-test.pt:92
-#: euphorie/client/browser/webhelpers.py:631
+#: euphorie/client/browser/templates/new-session-test.pt:93
+#: euphorie/client/browser/webhelpers.py:703
 msgid "button_close"
 msgstr ""
 
@@ -1617,9 +1614,9 @@ msgid "button_start_new_session"
 msgstr ""
 
 #. Default: "Start session"
-#: euphorie/client/browser/templates/new-session-test.pt:80
-#: euphorie/client/browser/templates/new-session.pt:75
-#: euphorie/client/browser/templates/portlet-available-tools.pt:46
+#: euphorie/client/browser/templates/new-session-test.pt:81
+#: euphorie/client/browser/templates/new-session.pt:76
+#: euphorie/client/browser/templates/portlet-available-tools.pt:73
 msgid "button_start_session"
 msgstr ""
 
@@ -2026,17 +2023,17 @@ msgid "error_password_mismatch"
 msgstr "Lösenorden stämmer inte överens"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:869
+#: euphorie/client/browser/risk.py:876
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:865
+#: euphorie/client/browser/risk.py:872
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:873
+#: euphorie/client/browser/risk.py:880
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2147,7 +2144,7 @@ msgstr ""
 msgid "explanation_risk_always_present"
 msgstr ""
 
-#: euphorie/client/browser/session.py:489
+#: euphorie/client/browser/session.py:484
 msgid "extra_text_identification"
 msgstr ""
 
@@ -2258,12 +2255,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:809
+#: euphorie/client/browser/templates/webhelpers.pt:813
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:812
+#: euphorie/client/browser/templates/webhelpers.pt:816
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2347,6 +2344,7 @@ msgstr "Licenser"
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
 #: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Logga in"
 
@@ -2456,11 +2454,6 @@ msgstr "Projektfas"
 msgid "header_publish"
 msgstr "Publicera undersökning "
 
-#. Default: "Questions answered per module"
-#: euphorie/client/browser/templates/status.pt:117
-msgid "header_questions_answered"
-msgstr "Besvarade frågor per modul"
-
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
 #: euphorie/client/templates/shell.pt:116
@@ -2474,7 +2467,7 @@ msgid "header_reporting"
 msgstr "Rapportering"
 
 #. Default: "Resources"
-#: euphorie/client/browser/templates/risk_identification.pt:39
+#: euphorie/client/browser/templates/risk_identification.pt:46
 msgid "header_resources"
 msgstr ""
 
@@ -2603,13 +2596,12 @@ msgid "header_why_oira"
 msgstr "Varför OiRA-projektet?"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:842
+#: euphorie/client/browser/templates/webhelpers.pt:846
 msgid "heading_comments"
 msgstr ""
 
 #. Default: "High priority risks"
 #: euphorie/client/browser/templates/measures_overview.pt:85
-#: euphorie/client/browser/templates/status.pt:259
 msgid "heading_high_prio_risks"
 msgstr ""
 
@@ -2807,7 +2799,7 @@ msgstr ""
 "starta med en kopia av en befintlig undersökning."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:318 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Ange hur ofta denna risk inträffar i en normal situation."
 
@@ -2819,12 +2811,12 @@ msgstr ""
 "fortfarande ändra prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:313 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Ange hur trolig förekomsten av denna risk är i en normal situation."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:322 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Ange allvarighetsgraden av att hantera denna risk om den inträffar."
 
@@ -3165,7 +3157,6 @@ msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
 msgid "info_testsession"
 msgstr ""
 
@@ -3394,7 +3385,7 @@ msgid "label_body"
 msgstr "Sidinnehåll"
 
 #. Default: "Skip"
-#: euphorie/client/browser/templates/risk_identification.pt:61
+#: euphorie/client/browser/templates/risk_identification.pt:68
 msgid "label_button_skip"
 msgstr ""
 
@@ -3430,7 +3421,7 @@ msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
 #: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:849
+#: euphorie/client/browser/templates/webhelpers.pt:853
 msgid "label_comment"
 msgstr ""
 "Lämna gärna synpunkter du kan ha om ovanstående fråga inom detta område. "
@@ -3592,11 +3583,6 @@ msgstr "Jag har glömt bort mitt lösenord"
 msgid "label_format"
 msgstr ""
 
-#. Default: "General information"
-#: euphorie/client/browser/templates/status.pt:44
-msgid "label_general_information"
-msgstr ""
-
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
 msgid "label_help_actionplan"
@@ -3675,7 +3661,7 @@ msgid "label_language"
 msgstr "Språk"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:797
+#: euphorie/client/browser/templates/webhelpers.pt:801
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Rättsliga och politiska referenser"
@@ -3728,11 +3714,6 @@ msgstr "Förebyggande plan"
 msgid "label_measure_requirements"
 msgstr "Krav"
 
-#. Default: "by"
-#: euphorie/client/browser/templates/status.pt:70
-msgid "label_modified_by"
-msgstr ""
-
 #. Default: "Description"
 #: euphorie/content/module.py:51 euphorie/content/page.py:19
 #: euphorie/content/solution.py:35
@@ -3768,38 +3749,34 @@ msgstr ""
 
 #. Default: "Next"
 #: euphorie/client/browser/templates/module_actionplan.pt:58
-#: euphorie/client/browser/templates/module_identification.pt:69
+#: euphorie/client/browser/templates/module_identification.pt:75
 #: euphorie/client/browser/templates/register.pt:99
 msgid "label_next"
 msgstr "Nästa"
 
 #. Default: "No"
-#: euphorie/client/browser/templates/module_identification.pt:62
+#: euphorie/client/browser/templates/module_identification.pt:68
 #: euphorie/client/company.py:94 euphorie/client/templates/report_company.pt:70
 msgid "label_no"
 msgstr "Nej"
 
 #. Default: "No risk"
 #: euphorie/client/browser/templates/risks_overview.pt:259
-#: euphorie/client/browser/templates/status.pt:180
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:263
-#: euphorie/client/browser/templates/status.pt:184
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:267
-#: euphorie/client/browser/templates/status.pt:188
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
 #: euphorie/client/browser/templates/risks_overview.pt:271
-#: euphorie/client/browser/templates/status.pt:192
 msgid "label_no_risks_5_or_more"
 msgstr ""
 
@@ -3819,12 +3796,12 @@ msgid "label_old_password"
 msgstr "Lösenord"
 
 #. Default: "Page"
-#: euphorie/client/browser/session.py:832
+#: euphorie/client/browser/session.py:828
 msgid "label_page"
 msgstr ""
 
 #. Default: "of"
-#: euphorie/client/browser/session.py:835
+#: euphorie/client/browser/session.py:831
 msgid "label_page_of"
 msgstr ""
 
@@ -3856,9 +3833,9 @@ msgid "label_preview"
 msgstr "Förhandsgranskning"
 
 #. Default: "Previous"
-#: euphorie/client/browser/templates/module_identification.pt:68
+#: euphorie/client/browser/templates/module_identification.pt:74
 #: euphorie/client/browser/templates/risk_actionplan.pt:448
-#: euphorie/client/browser/templates/risk_identification.pt:59
+#: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Föregående"
 
@@ -3876,7 +3853,7 @@ msgstr "Fråga"
 #. Default: "Published"
 #: euphorie/client/browser/templates/publication_menu.pt:24
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:131
-#: euphorie/client/browser/templates/status.pt:89
+#: euphorie/deployment/tiles/templates/versions.pt:48
 msgid "label_published"
 msgstr "Publicerad"
 
@@ -3893,7 +3870,7 @@ msgstr "Hur fick du kännedom om detta verktyg?"
 
 #. Default: "register"
 #: euphorie/client/browser/templates/login.pt:51
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "label_register"
 msgstr "Registrera"
 
@@ -3964,49 +3941,41 @@ msgstr "Risktyp"
 
 #. Default: "Risk with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:280
-#: euphorie/client/browser/templates/status.pt:201
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:301
-#: euphorie/client/browser/templates/status.pt:222
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:284
-#: euphorie/client/browser/templates/status.pt:205
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:288
-#: euphorie/client/browser/templates/status.pt:209
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
 #: euphorie/client/browser/templates/risks_overview.pt:292
-#: euphorie/client/browser/templates/status.pt:213
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:305
-#: euphorie/client/browser/templates/status.pt:226
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:309
-#: euphorie/client/browser/templates/status.pt:230
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
 #: euphorie/client/browser/templates/risks_overview.pt:313
-#: euphorie/client/browser/templates/status.pt:234
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
 
@@ -4047,12 +4016,19 @@ msgstr "Bransch titel."
 msgid "label_select_measure"
 msgstr ""
 
-#. Default: "Start a new session by choosing one of the following sectoral tools:"
+#. Default: "Start a new session by choosing one of the following sectoral tools."
 #: euphorie/client/browser/templates/new-session-test.pt:27
 #: euphorie/client/browser/templates/new-session.pt:28
-#: euphorie/client/browser/templates/portlet-available-tools.pt:24
+#: euphorie/client/browser/templates/portlet-available-tools.pt:26
 msgid "label_select_new_session"
 msgstr "Starta en ny session genom att välja en av följande branschverktyg"
+
+#. Default: "Select an OiRA tool"
+#: euphorie/client/browser/templates/new-session-test.pt:53
+#: euphorie/client/browser/templates/new-session.pt:54
+#: euphorie/client/browser/templates/portlet-available-tools.pt:54
+msgid "label_select_oira_tool"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4095,14 +4071,9 @@ msgid "label_start_identification"
 msgstr "Starta riskidentifiering"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:111
+#: euphorie/client/browser/templates/start.pt:117
 msgid "label_start_survey"
 msgstr "Starta"
-
-#. Default: "Started"
-#: euphorie/client/browser/templates/status.pt:61
-msgid "label_started"
-msgstr ""
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4138,6 +4109,11 @@ msgstr "Version namn"
 #: euphorie/content/upload.py:106
 msgid "label_surveygroup_title"
 msgstr "Titel på importerad undersökning."
+
+#. Default: "Test session"
+#: euphorie/client/templates/shell.pt:107
+msgid "label_testsession"
+msgstr ""
 
 #. Default: "High"
 #: euphorie/client/report.py:107
@@ -4181,11 +4157,6 @@ msgstr ""
 msgid "label_tryout"
 msgstr ""
 
-#. Default: "Unpublished"
-#: euphorie/client/browser/templates/status.pt:104
-msgid "label_unpublished"
-msgstr ""
-
 #. Default: "Update"
 #: euphorie/deployment/tiles/templates/versions.pt:85
 msgid "label_update"
@@ -4204,11 +4175,6 @@ msgstr "Namn på undersökningens version"
 #. Default: "Ask the user about (multiple) locations?"
 #: euphorie/content/profilequestion.py:56
 msgid "label_use_location_question"
-msgstr ""
-
-#. Default: "Used tool"
-#: euphorie/client/browser/templates/status.pt:48
-msgid "label_used_tool"
 msgstr ""
 
 #. Default: "Name"
@@ -4232,7 +4198,7 @@ msgid "label_workers_participated"
 msgstr "Namn"
 
 #. Default: "Yes"
-#: euphorie/client/browser/templates/module_identification.pt:58
+#: euphorie/client/browser/templates/module_identification.pt:64
 #: euphorie/client/company.py:93 euphorie/client/templates/report_company.pt:69
 msgid "label_yes"
 msgstr "Ja"
@@ -4264,18 +4230,17 @@ msgstr ""
 "${label} = Denna version har förändringar som för närvarande inte är "
 "publicerade. Klicka på ikonen Uppdatera för att aktivera ändringarna"
 
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
 #: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/tooltips.pt:8
 msgid "link_sign_in"
 msgstr ""
 
 #. Default: "start a new session"
-#: euphorie/client/browser/country.py:433
+#: euphorie/client/browser/country.py:436
 #: euphorie/client/browser/templates/portlet-my-ras.pt:64
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:47
 msgid "link_start_session"
@@ -4475,7 +4440,7 @@ msgstr "Status"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:268
+#: euphorie/client/templates/shell.pt:273
 msgid "navigation_status"
 msgstr "Status"
 
@@ -4577,7 +4542,7 @@ msgstr ""
 #. Default: "Your password must contain at least 5 characters, including at least one capital letter, one number and one special character (e.g. $, # or @)."
 #: euphorie/content/passwordpolicy.py:49
 #: euphorie/content/templates/settings.pt:73
-#: euphorie/content/tests/test_passwordpolicy.py:14
+#: euphorie/content/tests/test_passwordpolicy.py:13
 msgid "password_policy_conditions"
 msgstr ""
 
@@ -4605,7 +4570,7 @@ msgid "portlet_header_versions"
 msgstr "Versioner"
 
 #. Default: "COPY"
-#: euphorie/client/browser/session.py:605
+#: euphorie/client/browser/session.py:601
 msgid "prefix_cloned_title"
 msgstr ""
 
@@ -4647,6 +4612,11 @@ msgstr "Medium"
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Liten"
+
+#. Default: "${completion_percentage}% Complete"
+#: euphorie/client/browser/webhelpers.py:251
+msgid "progress_indicator_title"
+msgstr ""
 
 #. Default: "<p><strong>Important:</strong> In order to avoid duplicating risks, we strongly recommend you to go first through all the previous modules, if you have not done it yet.</p><p>If you don't need to add risks, please continue.</p>"
 #: euphorie/client/publish.py:147 euphorie/deployment/upgrade/v23.py:42
@@ -4948,12 +4918,12 @@ msgid "terms_changed"
 msgstr ""
 
 #. Default: "Read here about the ${benefits}${tooltip_benefits} and ${limitations}${tooltip_limitations} of a test session."
-#: euphorie/client/browser/templates/new-session-test.pt:71
+#: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "testsession_benefits_limitations"
 msgstr ""
 
 #. Default: "Or ${register_link} instead. Find out why you should register${tooltip_register}."
-#: euphorie/client/browser/templates/new-session-test.pt:74
+#: euphorie/client/browser/templates/new-session-test.pt:75
 msgid "testsession_register"
 msgstr ""
 
@@ -5049,14 +5019,9 @@ msgstr ""
 msgid "title_sectors"
 msgstr "Branscher"
 
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:37
-msgid "title_status_of"
-msgstr ""
-
 #. Default: "OiRA - Online interactive Risk Assessment"
-#: euphorie/client/browser/country.py:260
-#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/country.py:263
+#: euphorie/client/browser/templates/modal-template.pt:23
 #: euphorie/client/browser/templates/webhelpers.pt:40
 msgid "title_tool"
 msgstr "OiRA"
@@ -5075,11 +5040,6 @@ msgstr "Publicerad"
 #: euphorie/client/browser/templates/updated.pt:15
 msgid "title_updated"
 msgstr "Undersökningen har uppdaterats"
-
-#. Default: "Status of &ldquo;${survey_title}&rdquo;"
-#: euphorie/client/browser/templates/status.pt:40
-msgid "title_with_vowel_status_of"
-msgstr ""
 
 #. Default: "Contents"
 #: euphorie/client/browser/templates/risks_overview.pt:167
@@ -5190,6 +5150,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "header_questions_answered"
+#~ msgstr "Besvarade frågor per modul"
 
 #~ msgid "header_or"
 #~ msgstr "eller…"


### PR DESCRIPTION
Better portlet for available tools (for starting a new session): above threshold, use auto-complete dropdown, like we do in the new-session popup.
In all those cases that use the dropdown: don't automatically select the first tool, but force the user to actively pick a tool. Only enable the submit-button when a selection has been made.