### PR TITLE
WIP Action plan redesign

### DIFF
--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -472,9 +472,13 @@ class IdentificationView(BrowserView):
         }
         existing_measures = []
         for solution in self.solutions:
+            if self.italy_special:
+                text = solution.action
+            else:
+                text = solution.description
             existing_measures.append(
                 {
-                    "text": solution.action,
+                    "text": text,
                     "active": solution.id in saved_standard_measures,
                     "solution_id": solution.id,
                     "plan_type": "in_place_standard",

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -855,11 +855,12 @@ class ActionPlanView(BrowserView):
                             "action_plan": solution.action_plan,
                             "prevention_plan": solution.prevention_plan,
                             "requirements": solution.requirements,
+                            "id": solution.id,
                         }
                     )
             self.solutions = solutions
             self.solutions_condition = "condition: not ({})".format(
-                " and ".join(["sm-%d" % (i + 1) for i in range(len(self.solutions))])
+                " and ".join(["sm-%s" % solution["id"] for solution in self.solutions])
             )
 
         self.image_class = IMAGE_CLASS[self.number_images]

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -858,6 +858,9 @@ class ActionPlanView(BrowserView):
                         }
                     )
             self.solutions = solutions
+            self.solutions_condition = "condition: not ({})".format(
+                " and ".join(["sm-%d" % (i + 1) for i in range(len(self.solutions))])
+            )
 
         self.image_class = IMAGE_CLASS[self.number_images]
         self.risk_number = self.context.number

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -856,8 +856,6 @@ class ActionPlanView(BrowserView):
                     solutions.append(
                         {
                             "description": StripMarkup(solution.description),
-                            "action_plan": solution.action_plan,
-                            "prevention_plan": solution.prevention_plan,
                             "action": solution.action,
                             "requirements": solution.requirements,
                             "id": solution_id,
@@ -941,8 +939,7 @@ class ActionPlanView(BrowserView):
                 if measure.get("id", "-1") in existing_plans:
                     plan = existing_plans[measure.get("id")]
                     if (
-                        measure.get("action_plan") != plan.action_plan
-                        or measure.get("prevention_plan") != plan.prevention_plan
+                        measure.get("action") != plan.action
                         or measure.get("requirements") != plan.requirements  # noqa
                         or measure.get("responsible") != plan.responsible
                         or (
@@ -972,8 +969,7 @@ class ActionPlanView(BrowserView):
                     added += 1
                 new_plans.append(
                     model.ActionPlan(
-                        action_plan=measure.get("action_plan"),
-                        prevention_plan=measure.get("prevention_plan"),
+                        action=measure.get("action"),
                         requirements=measure.get("requirements"),
                         responsible=measure.get("responsible"),
                         budget=budget,

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -808,7 +808,7 @@ class ActionPlanView(BrowserView):
             context.priority = reply.get("priority")
 
             new_plans, changes = self.extract_plans_from_request()
-            for plan in context.action_plans:
+            for plan in context.standard_measures + context.custom_measures:
                 session.delete(plan)
             context.action_plans.extend(new_plans)
             if changes:
@@ -908,7 +908,8 @@ class ActionPlanView(BrowserView):
         added = 0
         updated = 0
         existing_plans = {}
-        for plan in self.context.action_plans:
+        context = aq_inner(self.context)
+        for plan in context.standard_measures + context.custom_measures:
             existing_plans[str(plan.id)] = plan
         form = self.request.form
         form["action_plans"] = []

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -43,8 +43,10 @@ from zope.publisher.interfaces import NotFound
 
 import datetime
 import PIL
+import re
 
 IMAGE_CLASS = {0: "", 1: "twelve", 2: "six", 3: "four", 4: "three"}
+all_breaks = re.compile("(\n|\r)+")
 
 
 class IdentificationView(BrowserView):
@@ -225,13 +227,13 @@ class IdentificationView(BrowserView):
                         and isinstance(val, str)
                         and val.strip() != ""
                     ):
-                        new_custom_measures[k] = (
-                            model.ActionPlan(action=val, plan_type="in_place_custom")
+                        new_custom_measures[k] = model.ActionPlan(
+                            action=val, plan_type="in_place_custom"
                         )
                     elif k.startswith("measure-custom"):
                         _id = k.rsplit("-", 1)[-1]
-                        new_custom_measures[_id] = (
-                            model.ActionPlan(action=val, plan_type="in_place_custom")
+                        new_custom_measures[_id] = model.ActionPlan(
+                            action=val, plan_type="in_place_custom"
                         )
                     # This only happens on custom risks
                     elif k.startswith("present-measure") and val.strip() != "":
@@ -887,10 +889,13 @@ class ActionPlanView(BrowserView):
                     continue
                 solution_id = solution.id
                 if solution_id not in existing_measure_ids:
+                    action = getattr(solution, "action", "") or ""
+                    action_markup = all_breaks.sub("<br/>", action)
                     solutions.append(
                         {
                             "description": StripMarkup(solution.description),
-                            "action": solution.action,
+                            "action": action,
+                            "action_markup": action_markup,
                             "requirements": solution.requirements,
                             "id": solution_id,
                         }

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -820,8 +820,6 @@ class ActionPlanView(BrowserView):
 
         else:
             self.data = context
-            if len(context.action_plans) == 0:
-                self.data.empty_action_plan = [model.ActionPlan()]
 
         self.title = context.parent.title
 
@@ -915,6 +913,8 @@ class ActionPlanView(BrowserView):
             if len(measure):
                 budget = measure.get("budget")
                 budget = budget and budget.split(",")[0].split(".")[0]
+                plan_type = measure.get("plan_type", "measure_custom")
+                solution_id = measure.get("solution_id", None)
                 p_start = measure.get("planning_start")
                 if p_start:
                     try:
@@ -968,6 +968,8 @@ class ActionPlanView(BrowserView):
                         budget=budget,
                         planning_start=p_start,
                         planning_end=p_end,
+                        plan_type=plan_type,
+                        solution_id=solution_id,
                     )
                 )
         removed = len(existing_plans)

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -462,7 +462,7 @@ class IdentificationView(BrowserView):
     @memoize
     def get_existing_measures(self):
         saved_standard_measures = {
-            str(getattr(measure, "solution_id", "")): measure
+            getattr(measure, "solution_id", ""): measure
             for measure in self.context.in_place_standard_measures
         }
         existing_measures = []
@@ -876,10 +876,10 @@ class ActionPlanView(BrowserView):
             self.risk.evaluation_method = u""
         if not self.is_custom_risk:
             existing_measure_ids = [
-                str(measure.solution_id) for measure in self.get_existing_measures()
+                measure.solution_id for measure in self.get_existing_measures()
             ]
             self.active_standard_measures = {
-                str(getattr(measure, "solution_id", "")): measure
+                getattr(measure, "solution_id", ""): measure
                 for measure in context.standard_measures
             }
             solutions = []

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -858,6 +858,7 @@ class ActionPlanView(BrowserView):
                             "description": StripMarkup(solution.description),
                             "action_plan": solution.action_plan,
                             "prevention_plan": solution.prevention_plan,
+                            "action": solution.action,
                             "requirements": solution.requirements,
                             "id": solution_id,
                         }

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -52,7 +52,9 @@ class IdentificationView(BrowserView):
     """
 
     default_template = ViewPageTemplateFile("templates/risk_identification.pt")
-    custom_risk_template = ViewPageTemplateFile("templates/risk_identification_custom.pt")
+    custom_risk_template = ViewPageTemplateFile(
+        "templates/risk_identification_custom.pt"
+    )
     variation_class = "variation-risk-assessment"
 
     question_filter = None
@@ -512,7 +514,6 @@ class IdentificationView(BrowserView):
 
 
 class ImageUpload(BrowserView):
-
     def redirect(self):
         return self.request.response.redirect(
             "{}/@@identification".format(self.context.absolute_url())
@@ -840,10 +841,10 @@ class ActionPlanView(BrowserView):
             for solution in self.risk.values():
                 if not ISolution.providedBy(solution):
                     continue
-                description = (
-                    getattr(solution, "description", "") or "").strip()
+                description = (getattr(solution, "description", "") or "").strip()
                 prevention_plan = (
-                    getattr(solution, "prevention_plan", "") or "").strip()
+                    getattr(solution, "prevention_plan", "") or ""
+                ).strip()
                 match = description
                 if measures_full_text and prevention_plan:
                     match = u"%s: %s" % (match, prevention_plan)
@@ -860,26 +861,36 @@ class ActionPlanView(BrowserView):
 
         self.image_class = IMAGE_CLASS[self.number_images]
         self.risk_number = self.context.number
-        self.delete_confirmation = api.portal.translate(_(
-            u"Are you sure you want to delete this measure? This action can "
-            u"not be reverted."),
+        self.delete_confirmation = api.portal.translate(
+            _(
+                u"Are you sure you want to delete this measure? This action can "
+                u"not be reverted."
+            )
         )
-        self.override_confirmation = api.portal.translate(_(
-            u"The current text in the fields 'Action plan', 'Prevention plan' and "
-            u"'Requirements' of this measure will be overwritten. This action cannot be "
-            u"reverted. Are you sure you want to continue?"),
+        self.override_confirmation = api.portal.translate(
+            _(
+                u"The current text in the fields 'Action plan', 'Prevention plan' and "
+                u"'Requirements' of this measure will be overwritten. This action cannot be "
+                u"reverted. Are you sure you want to continue?"
+            )
         )
-        self.message_date_before = api.portal.translate(_(
-            u"error_validation_before_end_date",
-            default=u"This date must be on or before the end date."),
+        self.message_date_before = api.portal.translate(
+            _(
+                u"error_validation_before_end_date",
+                default=u"This date must be on or before the end date.",
+            )
         )
-        self.message_date_after = api.portal.translate(_(
-            u"error_validation_after_start_date",
-            default=u"This date must be on or after the start date."),
+        self.message_date_after = api.portal.translate(
+            _(
+                u"error_validation_after_start_date",
+                default=u"This date must be on or after the start date.",
+            )
         )
-        self.message_positive_number = api.portal.translate(_(
-            u"error_validation_positive_whole_number",
-            default=u"This value must be a positive whole number."),
+        self.message_positive_number = api.portal.translate(
+            _(
+                u"error_validation_positive_whole_number",
+                default=u"This value must be a positive whole number.",
+            )
         )
         return self.index()
 

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -366,9 +366,6 @@ class IdentificationView(BrowserView):
                 self.answer_yes = tool_type_data["answer_yes"]
                 self.answer_no = tool_type_data["answer_no"]
                 self.answer_na = tool_type_data["answer_na"]
-            if not self.context.existing_measures:
-                existing_measures = [(text, 0) for text in measures]
-                self.context.existing_measures = safe_unicode(dumps(existing_measures))
 
         survey = self.context.aq_parent.aq_parent
         if getattr(survey, "enable_custom_evaluation_descriptions", False):
@@ -961,6 +958,9 @@ class ActionPlanView(BrowserView):
                     "sm-%s" % solution_id
                 ):
                     continue
+                action = measure.get("action", "").strip()
+                if not action:
+                    continue
                 budget = measure.get("budget")
                 budget = budget and budget.split(",")[0].split(".")[0]
                 p_start = measure.get("planning_start")
@@ -978,7 +978,7 @@ class ActionPlanView(BrowserView):
                 if measure.get("id", "-1") in existing_plans:
                     plan = existing_plans[measure.get("id")]
                     if (
-                        measure.get("action") != plan.action
+                        action != plan.action
                         or measure.get("requirements") != plan.requirements  # noqa
                         or measure.get("responsible") != plan.responsible
                         or (

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -454,10 +454,7 @@ class IdentificationView(BrowserView):
     @property
     @memoize
     def solutions(self):
-        if not self.risk:
-            return []
-        else:
-            return self.risk._solutions
+        return getattr(self.risk, "_solutions", [])
 
     @memoize
     def get_existing_measures(self):
@@ -674,13 +671,9 @@ class ActionPlanView(BrowserView):
 
     @memoize
     def get_existing_measures(self):
-        return [
-            measure
-            for measure in (
-                self.context.in_place_standard_measures
-                + self.context.in_place_custom_measures
-            )
-        ]
+        return list(self.context.in_place_standard_measures) + list(
+            self.context.in_place_custom_measures
+        )
 
     def get_existing_measures_old(self):
         if not self.use_existing_measures:

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -49,7 +49,11 @@
                                    message-min: ${view/message_positive_number};
                                    message-required: This field is required;"
         >
-          <div id="content-pane">
+          <div id="content-pane"
+               tal:define="
+                 solutions view/solutions|nothing;
+               "
+          >
             <article class="rich pat-well warning"
                      id="${view/risk_number}"
             >
@@ -117,9 +121,42 @@
                 </fieldset>
                 <metal:call use-macro="here/risk_macros/macros/risk_info_actionplan" />
               </tal:priority>
-
             </article>
 
+            <tal:solutions condition="solutions">
+              <div class="pat-modal-pop-over pat-collapsible closed pat-depends"
+                   id="measures-panel"
+                   data-pat-collapsible="open-trigger: #add-standard-measures"
+                   data-pat-depends="${view/solutions_condition}"
+              >
+                <h2 class="title"
+                    i18n:translate=""
+                >
+                  Standard measures
+                </h2>
+                <section class="pat-rich description"
+                         i18n:translate=""
+                >
+                  <p>
+                    Select one or more standard solutions to add to your action plan.
+                  </p>
+                </section>
+                <div class="pat-checklist pat-pick-list free-form">
+                  <label class="item"
+                         tal:repeat="solution solutions"
+                  >
+                    <input id="sm-${repeat/solution/number}"
+                           name="sm-${repeat/solution/number}"
+                           type="checkbox"
+                    />
+                    <span class="text">${solution/description}</span>
+                    <span class="functions"><em class="small pat-button icon-plus-circle"
+                          i18n:translate="button_add"
+                      >Add</em></span>
+                  </label>
+                </div>
+              </div>
+            </tal:solutions>
 
             <div class="measures pat-clone"
                  id="ActionPlanItemForm"
@@ -144,6 +181,106 @@
                   </p>
                 </div>
               </tal:existing_measures>
+
+
+              <tal:solutions repeat="solution solutions">
+                <div class="measure pat-collapsible closed pat-depends"
+                     data-pat-depends="condition: sm-${repeat/solution/number}"
+                >
+                  <h2>
+                  ${solution/description}
+                  </h2>
+                  <p class="functions">
+                    <a class="icon-trash pat-forward"
+                       href="#pick-sm-${repeat/solution/number}"
+                       title="Remove this measure"
+                       i18n:attributes="title label_remove_measure"
+                       data-pat-forward="selector: #sm-${repeat/solution/number}"
+                       i18n:translate
+                    >Remove</a>
+                  </p>
+                  <section class="pat-rich">
+                    <h4 i18n:translate="label_description">
+                      Description
+                    </h4>
+                    <p>
+                      ${solution/action_plan}
+                      ${solution/prevention_plan}
+                    </p>
+                    <h4 i18n:translate="label_expertise">
+                      Expertise
+                    </h4>
+                    <p>
+                      ${solution/requirements}
+                    </p>
+                  </section>
+                  <fieldset class="vertical">
+                    <label>
+                      <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
+                      <dfn class="icon-help-circle iconified pat-tooltip"
+                           data-pat-tooltip="source: content; position-list: lt"
+                           i18n:translate="actionplan_measure_responsible_tooltip"
+                      >Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out.</dfn>
+                      <input class="responsible"
+                             name="solution.responsible:utf8:ustring:records"
+                             type="text"
+                      />
+                    </label>
+                    <label class="currency"
+                           tal:condition="python: 'budget' not in view.skip_fields"
+                    >
+                      <tal:span i18n:translate="label_action_plan_budget">Budget</tal:span>
+                      <em class="message error"
+                          tal:condition="exists:errors/budget"
+                          i18n:translate="error_invalid_budget"
+                      >Please enter the budget in whole Euros.</em>
+                      <dfn class="icon-help-circle iconified pat-tooltip"
+                           data-pat-tooltip="source: content; position-list: lt"
+                           i18n:translate="actionplan_measure_budget_tooltip"
+                      >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
+                      <span class="composed currency-field">
+                        <input class="currency"
+                               id="solution-budget-${repeat/solution/number}"
+                               min="0"
+                               name="solution.budget:records"
+                               type="number"
+                        />
+                      </span>
+                    </label>
+
+                    <label tal:define="
+                             date_error exists:errors/planning_start_date;
+                           "
+                    >
+                      <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
+                      <input class="pat-date-picker"
+                             id="solution-planning-start-${repeat/solution/number}"
+                             name="solution.planning_start:records"
+                             type="date"
+                             data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
+                             data-pat-validation="type: date; not-after: #solution-planning-end-${repeat/solution/number}; message-date: ${view/message_date_before}"
+                      />
+                    </label>
+
+                    <label tal:define="
+                             date_error exists:errors/planning_end_date;
+                           "
+                           tal:condition="python: 'planning_end' not in view.skip_fields"
+                    >
+                      <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
+
+                      <input class="pat-date-picker"
+                             id="solution-planning-end-${repeat/solution/number}"
+                             name="solution.planning_end:records"
+                             type="date"
+                             data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
+                             data-pat-validation="type: date; not-before: #solution-planning-start-${repeat/solution/number}; message-date: ${view/message_date_after}"
+                      />
+                    </label>
+
+                  </fieldset>
+                </div>
+              </tal:solutions>
 
 
               <div class="measure clone pat-collapsible"
@@ -318,6 +455,14 @@
                       type="button"
                       i18n:translate="label_add_measure"
               >Add another measure</button>
+              <tal:solutions condition="solutions">
+                <button class="pat-button icon-plus-circle pat-depends ${view/style_buttons}"
+                        data-pat-depends="${view/solutions_condition}"
+                        id="add-standard-measures"
+                        title="Add another measure"
+                        type="button"
+                >Select standard measures</button>
+              </tal:solutions>
             </div>
 
             <div class="measure pat-collapsible"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -42,145 +42,334 @@
               data-pat-inject="history: record; source: #step-4-topics; target: #step-4-topics &amp;&amp; source: #content; target: #content"
               data-pat-scroll="selector: #content; trigger: auto; offset: 0"
               data-pat-validation="disable-selector: button[name='next'], .remove-clone;
-                                     message-date: This value must be a valid date;
-                                     message-datetime: This value must be a valid date and time;
-                                     message-email: This value must be a valid email address;
-                                     message-number: This value must be a number;
-                                     message-min: ${view/message_positive_number};
-                                     message-required: This field is required;"
+                                   message-date: This value must be a valid date;
+                                   message-datetime: This value must be a valid date and time;
+                                   message-email: This value must be a valid email address;
+                                   message-number: This value must be a number;
+                                   message-min: ${view/message_positive_number};
+                                   message-required: This field is required;"
         >
-         <div id="content-pane">
-          <article class="rich pat-well warning"
-                   id="${view/risk_number}"
-          >
-            <tal:block condition="not:view/risk_present">
-              <h2 tal:content="risk/title"></h2>
-            </tal:block>
-            <tal:block define="
-                         use_problem_description view/use_problem_description;
-                       "
-                       condition="view/risk_present"
+          <div id="content-pane">
+            <article class="rich pat-well warning"
+                     id="${view/risk_number}"
             >
-              <h2 tal:condition="use_problem_description"
-                  tal:content="risk/problem_description"
-              >The fridges are checked daily.</h2>
-              <h2 tal:condition="not:use_problem_description"
-                  tal:content="risk/title"
-              >The fridges are checked daily.</h2>
-            </tal:block>
-            <tal:priority tal:define="
-                            show_statement python:True;
+              <tal:block condition="not:view/risk_present">
+                <h2 tal:content="risk/title"></h2>
+              </tal:block>
+              <tal:block define="
+                           use_problem_description view/use_problem_description;
+                         "
+                         condition="view/risk_present"
+              >
+                <h2 tal:condition="use_problem_description"
+                    tal:content="risk/problem_description"
+                >The fridges are checked daily.</h2>
+                <h2 tal:condition="not:use_problem_description"
+                    tal:content="risk/title"
+                >The fridges are checked daily.</h2>
+              </tal:block>
+              <tal:priority tal:define="
+                              show_statement python:True;
+                            "
+              >
+                <fieldset tal:define="
+                            value data/priority;
+                            readonly python:context.risk_type in ['top5'];
+                            skip_evaluation view/skip_evaluation;
                           "
-            >
-              <fieldset tal:define="
-                          value data/priority;
-                          readonly python:context.risk_type in ['top5'];
-                          skip_evaluation view/skip_evaluation;
-                        "
-                        tal:condition="not:view/skip_evaluation"
-              >
-                <input type="hidden" name="priority" value="${python:value}" tal:condition="python:readonly and not skip_evaluation" />
-                <label i18n:translate="risk_priority" tal:condition="python:not readonly and not skip_evaluation">This is a
-                  <select name="priority"
-                          i18n:name="priority_value"
-                  >
-                    <option selected="${python:'selected' if value=='low' else None}"
-                            value="low"
-                            i18n:translate="risk_priority_low"
-                    >low</option>
-                    <option selected="${python:'selected' if value=='medium' else None}"
-                            value="medium"
-                            i18n:translate="risk_priority_medium"
-                    >medium</option>
-                    <option selected="${python:'selected' if value=='high' else None}"
-                            value="high"
-                            i18n:translate="risk_priority_high"
-                    >high</option>
-                  </select>
-                  priority risk.</label>
-                <label i18n:translate="risk_priority" tal:condition="python:readonly and not skip_evaluation">
-                  This is a <strong i18n:name="priority_value" i18n:translate="">risk_priority_${value}</strong>
-                  priority risk.
-                </label>
-              </fieldset>
-              <metal:call use-macro="here/risk_macros/macros/risk_info_actionplan" />
-            </tal:priority>
-
-          </article>
-
-
-          <div class="measures pat-clone"
-               id="ActionPlanItemForm"
-               data-pat-clone="template: #measure-template; remove-behaviour: none; remove-confirmation: ${view/delete_confirmation}"
-          >
-
-            <!-- Existing Measures -->
-            <tal:existing_measures define="
-                                     measures view/get_existing_measures;
-                                   "
-                                   condition="view/use_existing_measures"
-            >
-              <div class="measure pat-collapsible"
-                   tal:repeat="measure measures"
-              >
-                <h2><tal:translate i18n:translate="label_existing_measure">Measure already implemented</tal:translate>
-                  ${repeat/measure/number}</h2>
-                <h4 i18n:translate="label_description">Description</h4>
-                <p>
-                  <tal:measure replace="structure python:measure[0]" />
-                </p>
-              </div>
-            </tal:existing_measures>
-
-
-            <div class="measure clone pat-collapsible"
-                 tal:define="
-                   measures view/solutions|python:[];
-                 "
-                 tal:repeat="actionplan action_plans"
-            >
-
-              <h2><tal:span condition="not:view/use_existing_measures" i18n:translate="Measure">Measure</tal:span>
-                <tal:span condition="view/use_existing_measures" i18n:translate="Additional Measure">Additional Measure</tal:span>
-                ${repeat/actionplan/number}</h2>
-              <input name="measure.id:records"
-                     type="hidden"
-                     value="${actionplan/id}"
-              />
-              <p class="functions">
-                <a class="icon-trash remove-clone"
-                   i18n:translate="label_remove_measure"
-                >Delete this measure</a>
-                <a class="icon-pencil pat-tooltip"
-                   href="#standard-solutions-${repeat/actionplan/number}"
-                   data-pat-tooltip="source:ajax"
-                   tal:condition="measures"
-                   i18n:translate="label_prefill"
-                >Pre-fill</a>
-              </p>
-              <tal:if_has_measures condition="measures">
-                <div id="standard-solutions-${repeat/actionplan/number}"
-                     hidden="hidden"
+                          tal:condition="not:view/skip_evaluation"
                 >
-                  <p class="info"
-                     i18n:translate="label_select_measure"
-                  >Select one or more of the known common measures provided.</p>
-                  <ol class="add-measure-menu">
-                    <li tal:repeat="measure measures">
-                      <a class="pat-inject close-panel title"
-                         href="#standard-solution-${repeat/measure/number}"
-                         data-pat-inject="target: #fields-${repeat/actionplan/number}; confirm: never; confirm-message: ${view/override_confirmation}"
-                      >
-                        <em class="iconified icon-plus-circle"
-                            i18n:translate="button_add"
-                        >Add</em><tal:measure replace="structure measure/description" /></a>
-                    </li>
-                  </ol>
+                  <input name="priority"
+                         type="hidden"
+                         value="${python:value}"
+                         tal:condition="python:readonly and not skip_evaluation"
+                  />
+                  <label tal:condition="python:not readonly and not skip_evaluation"
+                         i18n:translate="risk_priority"
+                  >This is a
+                    <select name="priority"
+                            i18n:name="priority_value"
+                    >
+                      <option selected="${python:'selected' if value=='low' else None}"
+                              value="low"
+                              i18n:translate="risk_priority_low"
+                      >low</option>
+                      <option selected="${python:'selected' if value=='medium' else None}"
+                              value="medium"
+                              i18n:translate="risk_priority_medium"
+                      >medium</option>
+                      <option selected="${python:'selected' if value=='high' else None}"
+                              value="high"
+                              i18n:translate="risk_priority_high"
+                      >high</option>
+                    </select>
+                  priority risk.
+                  </label>
+                  <label tal:condition="python:readonly and not skip_evaluation"
+                         i18n:translate="risk_priority"
+                  >
+                  This is a
+                    <strong i18n:name="priority_value"
+                            i18n:translate=""
+                    >risk_priority_${value}</strong>
+                  priority risk.
+                  </label>
+                </fieldset>
+                <metal:call use-macro="here/risk_macros/macros/risk_info_actionplan" />
+              </tal:priority>
+
+            </article>
+
+
+            <div class="measures pat-clone"
+                 id="ActionPlanItemForm"
+                 data-pat-clone="template: #measure-template; remove-behaviour: none; remove-confirmation: ${view/delete_confirmation}"
+            >
+
+              <!-- Existing Measures -->
+              <tal:existing_measures define="
+                                       measures view/get_existing_measures;
+                                     "
+                                     condition="view/use_existing_measures"
+              >
+                <div class="measure pat-collapsible"
+                     tal:repeat="measure measures"
+                >
+                  <h2><tal:translate i18n:translate="label_existing_measure">Measure already implemented</tal:translate>
+                  ${repeat/measure/number}
+                  </h2>
+                  <h4 i18n:translate="label_description">Description</h4>
+                  <p>
+                    <tal:measure replace="structure python:measure[0]" />
+                  </p>
                 </div>
-              </tal:if_has_measures>
+              </tal:existing_measures>
+
+
+              <div class="measure clone pat-collapsible"
+                   tal:define="
+                     measures view/solutions|python:[];
+                   "
+                   tal:repeat="actionplan action_plans"
+              >
+
+                <h2><tal:span condition="not:view/use_existing_measures"
+                            i18n:translate="Measure"
+                  >Measure</tal:span>
+                  <tal:span condition="view/use_existing_measures"
+                            i18n:translate="Additional Measure"
+                  >Additional Measure</tal:span>
+                ${repeat/actionplan/number}
+                </h2>
+                <input name="measure.id:records"
+                       type="hidden"
+                       value="${actionplan/id}"
+                />
+                <p class="functions">
+                  <a class="icon-trash remove-clone"
+                     i18n:translate="label_remove_measure"
+                  >Delete this measure</a>
+                  <a class="icon-pencil pat-tooltip"
+                     href="#standard-solutions-${repeat/actionplan/number}"
+                     data-pat-tooltip="source:ajax"
+                     tal:condition="measures"
+                     i18n:translate="label_prefill"
+                  >Pre-fill</a>
+                </p>
+                <tal:if_has_measures condition="measures">
+                  <div id="standard-solutions-${repeat/actionplan/number}"
+                       hidden="hidden"
+                  >
+                    <p class="info"
+                       i18n:translate="label_select_measure"
+                    >Select one or more of the known common measures provided.</p>
+                    <ol class="add-measure-menu">
+                      <li tal:repeat="measure measures">
+                        <a class="pat-inject close-panel title"
+                           href="#standard-solution-${repeat/measure/number}"
+                           data-pat-inject="target: #fields-${repeat/actionplan/number}; confirm: never; confirm-message: ${view/override_confirmation}"
+                        >
+                          <em class="iconified icon-plus-circle"
+                              i18n:translate="button_add"
+                          >Add</em><tal:measure replace="structure measure/description" /></a>
+                      </li>
+                    </ol>
+                  </div>
+                </tal:if_has_measures>
+
+                <fieldset class="vertical"
+                          id="fields-${repeat/actionplan/number}"
+                >
+                  <label><tal:label i18n:translate="label_description">Description</tal:label>
+                    <dfn class="icon-help-circle iconified pat-tooltip"
+                         data-pat-tooltip="source: content; position-list: lt"
+                         i18n:translate="actionplan_measure_tooltip"
+                    >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
+                    <textarea class="actionPlan"
+                              name="measure.action_plan:utf8:ustring:records"
+                              placeholder="General approach (to eliminate or reduce the risk)"
+                              rows="3"
+                              type="text"
+                              tal:content="actionplan/action_plan|nothing"
+                              i18n:attributes="placeholder label_measure_action_plan"
+                    ></textarea>
+                    <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
+                      <br />
+                      <textarea class="preventionPlan"
+                                name="measure.prevention_plan:utf8:ustring:records"
+                                placeholder="Specific action(s) required to implement this approach"
+                                rows="3"
+                                tal:content="actionplan/prevention_plan|nothing"
+                                i18n:attributes="placeholder label_measure_prevention_plan"
+                      ></textarea>
+                    </tal:preventionplan>
+                    <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+                      <br />
+                      <textarea class="requirements"
+                                name="measure.requirements:utf8:ustring:records"
+                                placeholder="Level of expertise and/or requirements needed"
+                                rows="3"
+                                tal:content="actionplan/requirements|nothing"
+                                i18n:attributes="placeholder label_measure_requirements"
+                      ></textarea>
+                    </tal:requirements>
+                  </label>
+                </fieldset>
+
+                <fieldset class="vertical"
+                          tal:define="
+                            number repeat/actionplan/number;
+                          "
+                >
+                  <label>
+                    <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
+                    <dfn class="icon-help-circle iconified pat-tooltip"
+                         data-pat-tooltip="source: content; position-list: lt"
+                         i18n:translate="actionplan_measure_responsible_tooltip"
+                    >Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out.</dfn>
+                    <input class="responsible"
+                           name="measure.responsible:utf8:ustring:records"
+                           type="text"
+                           value="${actionplan/responsible|nothing}"
+                    />
+                  </label>
+                  <label class="${python:'error' if exists('errors/budget') else None}"
+                         tal:condition="python: 'budget' not in view.skip_fields"
+                  >
+                    <tal:span i18n:translate="label_action_plan_budget">Budget</tal:span>
+                    <em class="message error"
+                        tal:condition="exists:errors/budget"
+                        i18n:translate="error_invalid_budget"
+                    >Please enter the budget in whole Euros.</em>
+                    <dfn class="icon-help-circle iconified pat-tooltip"
+                         data-pat-tooltip="source: content; position-list: lt"
+                         i18n:translate="actionplan_measure_budget_tooltip"
+                    >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
+                    <span class="composed currency-field">
+                      <input class="currency"
+                             id="input-budget-${number}"
+                             min="0"
+                             name="measure.budget:records"
+                             type="number"
+                             value="${actionplan/budget|nothing}"
+                      />
+                    </span>
+                  </label>
+
+                  <label tal:define="
+                           date_error exists:errors/planning_start_date;
+                         "
+                  >
+                    <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
+                    <input class="pat-date-picker"
+                           id="planning-start-${number}"
+                           name="measure.planning_start:records"
+                           type="date"
+                           value="${actionplan/planning_start|nothing}"
+                           data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
+                           data-pat-validation="type: date; not-after: #planning-end-${number}; message-date: ${view/message_date_before}"
+                    />
+                  </label>
+
+                  <label tal:define="
+                           date_error exists:errors/planning_end_date;
+                         "
+                         tal:condition="python: 'planning_end' not in view.skip_fields"
+                  >
+                    <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
+
+                    <input class="pat-date-picker"
+                           id="planning-end-${number}"
+                           name="measure.planning_end:records"
+                           type="date"
+                           value="${actionplan/planning_end|nothing}"
+                           data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
+                           data-pat-validation="type: date; not-before: #planning-start-${number}; message-date: ${view/message_date_after}"
+                    />
+                  </label>
+                </fieldset>
+              </div>
+            </div>
+
+            <div class="button-bar">
+              <button class="add-clone pat-button icon-plus-circle ${view/style_buttons}"
+                      id="addMeasureButton"
+                      title="Add another measure"
+                      type="button"
+                      i18n:translate="label_add_measure"
+              >Add another measure</button>
+            </div>
+
+            <div class="measure pat-collapsible"
+                 id="measure-template"
+                 hidden="hidden"
+            >
+              <tal:get_measures define="
+                                  measures view/solutions|python:[];
+                                "
+              >
+                <h2><tal:span condition="not:view/use_existing_measures"
+                            i18n:translate="Measure"
+                  >Measure</tal:span>
+                  <tal:span condition="view/use_existing_measures"
+                            i18n:translate="Additional Measure"
+                  >Additional Measure</tal:span>
+                #{1}
+                </h2>
+                <p class="functions">
+                  <a class="icon-trash remove-clone"
+                     i18n:translate="label_remove_measure"
+                  >Delete this measure</a>
+                  <a class="icon-pencil pat-tooltip"
+                     href="#standard-solutions-#{1}"
+                     data-pat-tooltip="source: ajax"
+                     tal:condition="measures"
+                     i18n:translate="label_prefill"
+                  >Pre-fill</a>
+                </p>
+
+                <tal:if_has_measures condition="measures">
+                  <div id="standard-solutions-#{1}"
+                       hidden="hidden"
+                  >
+                    <p class="info"
+                       i18n:translate="label_select_measure"
+                    >Select one or more of the known common measures provided.</p>
+                    <ol class="add-measure-menu">
+                      <li tal:repeat="solution measures">
+                        <a class="pat-inject close-panel title"
+                           href="#standard-solution-${repeat/solution/number}"
+                           data-pat-inject="target: #fields-#{1}; confirm: never; confirm-message: ${view/override_confirmation}"
+                        >
+                          <em class="iconified icon-plus-circle">Add</em>${solution/description}</a>
+                      </li>
+                    </ol>
+                  </div>
+                </tal:if_has_measures>
+              </tal:get_measures>
 
               <fieldset class="vertical"
-                        id="fields-${repeat/actionplan/number}"
+                        id="fields-#{1}"
               >
                 <label><tal:label i18n:translate="label_description">Description</tal:label>
                   <dfn class="icon-help-circle iconified pat-tooltip"
@@ -188,41 +377,34 @@
                        i18n:translate="actionplan_measure_tooltip"
                   >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
                   <textarea class="actionPlan"
+                            autofocus="autofocus"
                             name="measure.action_plan:utf8:ustring:records"
                             placeholder="General approach (to eliminate or reduce the risk)"
                             rows="3"
-                            type="text"
-                            tal:content="actionplan/action_plan|nothing"
                             i18n:attributes="placeholder label_measure_action_plan"
                   ></textarea>
-                  <tal:preventionPlan condition="python: 'prevention_plan' not in view.skip_fields">
-                  <br />
-                  <textarea class="preventionPlan"
-                            name="measure.prevention_plan:utf8:ustring:records"
-                            placeholder="Specific action(s) required to implement this approach"
-                            rows="3"
-                            tal:content="actionplan/prevention_plan|nothing"
-                            i18n:attributes="placeholder label_measure_prevention_plan"
-                  ></textarea>
-                  </tal:preventionPlan>
+                  <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
+                    <br />
+                    <textarea class="preventionPlan"
+                              name="measure.prevention_plan:utf8:ustring:records"
+                              placeholder="Specific action(s) required to implement this approach"
+                              rows="3"
+                              i18n:attributes="placeholder label_measure_prevention_plan"
+                    ></textarea>
+                  </tal:preventionplan>
                   <tal:requirements condition="python: 'requirements' not in view.skip_fields">
-                  <br />
-                  <textarea class="requirements"
-                            name="measure.requirements:utf8:ustring:records"
-                            placeholder="Level of expertise and/or requirements needed"
-                            rows="3"
-                            tal:content="actionplan/requirements|nothing"
-                            i18n:attributes="placeholder label_measure_requirements"
-                  ></textarea>
+                    <br />
+                    <textarea class="requirements"
+                              name="measure.requirements:utf8:ustring:records"
+                              placeholder="Level of expertise and/or requirements needed"
+                              rows="3"
+                              i18n:attributes="placeholder label_measure_requirements"
+                    ></textarea>
                   </tal:requirements>
                 </label>
               </fieldset>
 
-              <fieldset class="vertical"
-                        tal:define="
-                          number repeat/actionplan/number;
-                        "
-              >
+              <fieldset class="vertical">
                 <label>
                   <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
                   <dfn class="icon-help-circle iconified pat-tooltip"
@@ -232,218 +414,62 @@
                   <input class="responsible"
                          name="measure.responsible:utf8:ustring:records"
                          type="text"
-                         value="${actionplan/responsible|nothing}"
                   />
                 </label>
-                <label tal:condition="python: 'budget' not in view.skip_fields"
-                    class="${python:'error' if exists('errors/budget') else None}">
+                <label class="currency"
+                       tal:condition="python: 'budget' not in view.skip_fields"
+                >
                   <tal:span i18n:translate="label_action_plan_budget">Budget</tal:span>
-                  <em class="message error"
-                      tal:condition="exists:errors/budget"
-                      i18n:translate="error_invalid_budget"
-                  >Please enter the budget in whole Euros.</em>
                   <dfn class="icon-help-circle iconified pat-tooltip"
                        data-pat-tooltip="source: content; position-list: lt"
                        i18n:translate="actionplan_measure_budget_tooltip"
                   >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
                   <span class="composed currency-field">
                     <input class="currency"
-                           id="input-budget-${number}"
+                           id="input-budget-#{1}"
                            min="0"
                            name="measure.budget:records"
                            type="number"
-                           value="${actionplan/budget|nothing}"
                     />
                   </span>
                 </label>
-
-                <label tal:define="
-                         date_error exists:errors/planning_start_date;
-                       "
-                >
+                <label>
                   <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
                   <input class="pat-date-picker"
-                         id="planning-start-${number}"
+                         id="planning-start-#{1}"
                          name="measure.planning_start:records"
                          type="date"
-                         value="${actionplan/planning_start|nothing}"
                          data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                         data-pat-validation="type: date; not-after: #planning-end-${number}; message-date: ${view/message_date_before}"
+                         data-pat-validation="type: date; not-after: #planning-end-#{1}; message-date: ${view/message_date_before}"
                   />
                 </label>
-
-                <label tal:condition="python: 'planning_end' not in view.skip_fields"
-                      tal:define="
-                         date_error exists:errors/planning_end_date;
-                       "
-                >
+                <label tal:condition="python: 'planning_end' not in view.skip_fields">
                   <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
-
                   <input class="pat-date-picker"
-                         id="planning-end-${number}"
+                         id="planning-end-#{1}"
                          name="measure.planning_end:records"
                          type="date"
-                         value="${actionplan/planning_end|nothing}"
                          data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                         data-pat-validation="type: date; not-before: #planning-start-${number}; message-date: ${view/message_date_after}"
+                         data-pat-validation="type:date; not-before: #planning-start-#{1}; message-date: ${view/message_date_after}"
                   />
                 </label>
               </fieldset>
             </div>
-          </div>
 
-          <div class="button-bar">
-            <button class="add-clone pat-button icon-plus-circle ${view/style_buttons}"
-                    id="addMeasureButton"
-                    title="Add another measure"
-                    type="button"
-                    i18n:translate="label_add_measure"
-            >Add another measure</button>
-          </div>
-
-          <div class="measure pat-collapsible"
-               id="measure-template"
-               hidden="hidden"
-          >
-            <tal:get_measures define="
-                                measures view/solutions|python:[];
-                              "
-            >
-              <h2><tal:span condition="not:view/use_existing_measures" i18n:translate="Measure">Measure</tal:span>
-                <tal:span condition="view/use_existing_measures" i18n:translate="Additional Measure">Additional Measure</tal:span>
-                #{1}</h2>
-              <p class="functions">
-                <a class="icon-trash remove-clone"
-                   i18n:translate="label_remove_measure"
-                >Delete this measure</a>
-                <a class="icon-pencil pat-tooltip"
-                   href="#standard-solutions-#{1}"
-                   data-pat-tooltip="source: ajax"
-                   tal:condition="measures"
-                   i18n:translate="label_prefill"
-                >Pre-fill</a>
-              </p>
-
-              <tal:if_has_measures condition="measures">
-                <div id="standard-solutions-#{1}"
-                     hidden="hidden"
-                >
-                  <p class="info"
-                     i18n:translate="label_select_measure"
-                  >Select one or more of the known common measures provided.</p>
-                  <ol class="add-measure-menu">
-                    <li tal:repeat="solution measures">
-                      <a class="pat-inject close-panel title"
-                         href="#standard-solution-${repeat/solution/number}"
-                         data-pat-inject="target: #fields-#{1}; confirm: never; confirm-message: ${view/override_confirmation}"
-                      >
-                        <em class="iconified icon-plus-circle">Add</em>${solution/description}</a>
-                    </li>
-                  </ol>
-                </div>
-              </tal:if_has_measures>
-            </tal:get_measures>
-
-            <fieldset class="vertical"
-                      id="fields-#{1}"
-            >
-              <label><tal:label i18n:translate="label_description">Description</tal:label>
-                <dfn class="icon-help-circle iconified pat-tooltip"
-                     data-pat-tooltip="source: content; position-list: lt"
-                     i18n:translate="actionplan_measure_tooltip"
-                >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
-                <textarea class=" actionPlan"
-                          autofocus="autofocus"
-                          name="measure.action_plan:utf8:ustring:records"
-                          placeholder="General approach (to eliminate or reduce the risk)"
-                          rows="3"
-                          i18n:attributes="placeholder label_measure_action_plan"
-                ></textarea>
-                <tal:preventionPlan condition="python: 'prevention_plan' not in view.skip_fields">
-                <br />
-                <textarea class="preventionPlan"
-                          name="measure.prevention_plan:utf8:ustring:records"
-                          placeholder="Specific action(s) required to implement this approach"
-                          rows="3"
-                          i18n:attributes="placeholder label_measure_prevention_plan"
-                ></textarea>
-                </tal:preventionPlan>
-                <tal:requirements condition="python: 'requirements' not in view.skip_fields">
-                <br />
-                <textarea class="requirements"
-                          name="measure.requirements:utf8:ustring:records"
-                          placeholder="Level of expertise and/or requirements needed"
-                          rows="3"
-                          i18n:attributes="placeholder label_measure_requirements"
-                ></textarea>
-                </tal:requirements>
-              </label>
+            <fieldset id="comments">
+              <textarea id="commentsField"
+                        cols="70"
+                        name="comment:utf8:ustring"
+                        placeholder="Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
+                        rows="3"
+                        tal:content="data/comment|nothing"
+                        i18n:attributes="placeholder label_comment"
+              ></textarea>
             </fieldset>
-
-            <fieldset class="vertical">
-              <label>
-                <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
-                <dfn class="icon-help-circle iconified pat-tooltip"
-                     data-pat-tooltip="source: content; position-list: lt"
-                     i18n:translate="actionplan_measure_responsible_tooltip"
-                >Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out.</dfn>
-                <input class="responsible"
-                       name="measure.responsible:utf8:ustring:records"
-                       type="text"
-                />
-              </label>
-              <label class="currency" tal:condition="python: 'budget' not in view.skip_fields">
-                <tal:span i18n:translate="label_action_plan_budget">Budget</tal:span>
-                <dfn class="icon-help-circle iconified pat-tooltip"
-                     data-pat-tooltip="source: content; position-list: lt"
-                     i18n:translate="actionplan_measure_budget_tooltip"
-                >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
-                <span class="composed currency-field">
-                  <input class="currency"
-                         id="input-budget-#{1}"
-                         min="0"
-                         name="measure.budget:records"
-                         type="number"
-                  />
-                </span>
-              </label>
-              <label>
-                <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
-                <input class="pat-date-picker"
-                       id="planning-start-#{1}"
-                       name="measure.planning_start:records"
-                       type="date"
-                       data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                       data-pat-validation="type: date; not-after: #planning-end-#{1}; message-date: ${view/message_date_before}"
-                />
-              </label>
-              <label tal:condition="python: 'planning_end' not in view.skip_fields">
-                <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
-                <input class="pat-date-picker"
-                       id="planning-end-#{1}"
-                       name="measure.planning_end:records"
-                       type="date"
-                       data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                       data-pat-validation="type:date; not-before: #planning-start-#{1}; message-date: ${view/message_date_after}"
-                />
-              </label>
-            </fieldset>
-          </div>
-
-          <fieldset id="comments">
-            <textarea id="commentsField"
-                      cols="70"
-                      name="comment:utf8:ustring"
-                      placeholder="Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-                      rows="3"
-                      tal:content="data/comment|nothing"
-                      i18n:attributes="placeholder label_comment"
-            ></textarea>
-          </fieldset>
 
           </div>
           <p class="button-bar"
-               id="nav-bar"
+             id="nav-bar"
           >
             <button class="pat-button back"
                     name="next"
@@ -463,23 +489,23 @@
 
 
 
-        <tal:loop repeat="solution view/solutions|python:[]">
-          <fieldset class="vertical"
-                    id="standard-solution-${repeat/solution/number}"
-                    hidden="hidden"
-          >
-            <label><tal:label i18n:translate="label_description">Description</tal:label>
-              <dfn class="icon-help-circle iconified pat-tooltip"
-                   data-pat-tooltip="source: content; position-list: lt"
-                   i18n:translate="actionplan_measure_tooltip"
-              >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
-              <textarea class="actionPlan"
-                        name="measure.action_plan:utf8:ustring:records"
-                        placeholder="General approach (to eliminate or reduce the risk)"
-                        rows="3"
-                        i18n:attributes="placeholder label_measure_action_plan"
-              >${solution/action_plan}</textarea>
-              <tal:preventionPlan condition="python: 'prevention_plan' not in view.skip_fields">
+      <tal:loop repeat="solution view/solutions|python:[]">
+        <fieldset class="vertical"
+                  id="standard-solution-${repeat/solution/number}"
+                  hidden="hidden"
+        >
+          <label><tal:label i18n:translate="label_description">Description</tal:label>
+            <dfn class="icon-help-circle iconified pat-tooltip"
+                 data-pat-tooltip="source: content; position-list: lt"
+                 i18n:translate="actionplan_measure_tooltip"
+            >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
+            <textarea class="actionPlan"
+                      name="measure.action_plan:utf8:ustring:records"
+                      placeholder="General approach (to eliminate or reduce the risk)"
+                      rows="3"
+                      i18n:attributes="placeholder label_measure_action_plan"
+            >${solution/action_plan}</textarea>
+            <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
               <br />
               <textarea class="preventionPlan"
                         name="measure.prevention_plan:utf8:ustring:records"
@@ -487,8 +513,8 @@
                         rows="3"
                         i18n:attributes="placeholder label_measure_prevention_plan"
               >${solution/prevention_plan}</textarea>
-              </tal:preventionPlan>
-              <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+            </tal:preventionplan>
+            <tal:requirements condition="python: 'requirements' not in view.skip_fields">
               <br />
               <textarea class="requirements"
                         name="measure.requirements:utf8:ustring:records"
@@ -496,10 +522,10 @@
                         rows="3"
                         i18n:attributes="placeholder label_measure_requirements"
               >${solution/requirements}</textarea>
-              </tal:requirements>
-            </label>
-          </fieldset>
-        </tal:loop>
+            </tal:requirements>
+          </label>
+        </fieldset>
+      </tal:loop>
     </metal:slot>
   </body>
 </html>

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -29,11 +29,6 @@
                "
       >
 
-        <!-- TODO: This needs to be integrated into site's CSS somehow -->
-        <style>
-          .measures .measure .functions a.disabled { display: none; }
-        </style>
-
         <!-- Disable validation on the action plan, since an empty budget field falsely gets claimed as being required! -->
         <form class="Xpat-validation pat-inject pat-scroll"
               action="${context/absolute_url}/@@actionplan"
@@ -145,6 +140,7 @@
                          tal:repeat="solution solutions"
                   >
                     <input id="sm-${solution/id}"
+                           checked="${python: 'checked' if solution['id'] in view.active_standard_measures else None}"
                            name="sm-${solution/id}"
                            type="checkbox"
                     />
@@ -193,16 +189,31 @@
                     <a class="icon-trash pat-forward"
                        href="#pick-sm-${solution/id}"
                        title="Remove this measure"
-                       i18n:attributes="title label_remove_measure"
                        data-pat-forward="selector: #sm-${solution/id}"
-                       i18n:translate
+                       i18n:attributes="title label_remove_measure"
+                       i18n:translate=""
                     >Remove</a>
                   </p>
-                  <input name="measure.plan_type:records" type="hidden" value="measure_standard" />
-                  <input name="measure.solution_id:records" type="hidden" value="${solution/id}" />
-                  <input name="measure.action_plan:utf8:ustring:records" type="hidden" value="${solution/action_plan}" />
-                  <input name="measure.prevention_plan:utf8:ustring:records" type="hidden" value="${solution/prevention_plan}" />
-                  <input name="measure.requirements:utf8:ustring:records" type="hidden" value="${solution/requirements}" />
+                  <input name="measure.plan_type:records"
+                         type="hidden"
+                         value="measure_standard"
+                  />
+                  <input name="measure.solution_id:records"
+                         type="hidden"
+                         value="${solution/id}"
+                  />
+                  <input name="measure.action_plan:utf8:ustring:records"
+                         type="hidden"
+                         value="${solution/action_plan}"
+                  />
+                  <input name="measure.prevention_plan:utf8:ustring:records"
+                         type="hidden"
+                         value="${solution/prevention_plan}"
+                  />
+                  <input name="measure.requirements:utf8:ustring:records"
+                         type="hidden"
+                         value="${solution/requirements}"
+                  />
                   <section class="pat-rich">
                     <h4 i18n:translate="label_description">
                       Description
@@ -218,7 +229,11 @@
                       ${solution/requirements}
                     </p>
                   </section>
-                  <fieldset class="vertical">
+                  <fieldset class="vertical"
+                            tal:define="
+                              measure python:view.active_standard_measures.get(solution['id'], None);
+                            "
+                  >
                     <label>
                       <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
                       <dfn class="icon-help-circle iconified pat-tooltip"
@@ -228,6 +243,7 @@
                       <input class="responsible"
                              name="measure.responsible:utf8:ustring:records"
                              type="text"
+                             value="${python:measure.responsible if measure else None}"
                       />
                     </label>
                     <label class="currency"
@@ -248,6 +264,7 @@
                                min="0"
                                name="measure.budget:records"
                                type="number"
+                               value="${python:measure.budget if measure else None}"
                         />
                       </span>
                     </label>
@@ -261,6 +278,7 @@
                              id="solution-planning-start-${solution/id}"
                              name="measure.planning_start:records"
                              type="date"
+                             value="${python:measure.planning_start if measure else None}"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
                              data-pat-validation="type: date; not-after: #solution-planning-end-${solution/id}; message-date: ${view/message_date_before}"
                       />
@@ -277,6 +295,7 @@
                              id="solution-planning-end-${solution/id}"
                              name="measure.planning_end:records"
                              type="date"
+                             value="${python:measure.planning_end if measure else None}"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
                              data-pat-validation="type: date; not-before: #solution-planning-start-${solution/id}; message-date: ${view/message_date_after}"
                       />
@@ -286,171 +305,174 @@
                 </div>
               </tal:solutions>
 
-
-              <div class="measure clone pat-collapsible"
-                   tal:define="
-                     measures view/solutions|python:[];
-                   "
-                   tal:repeat="actionplan action_plans"
-              >
-
-                <h2><tal:span condition="not:view/use_existing_measures"
-                            i18n:translate="Measure"
-                  >Measure</tal:span>
-                  <tal:span condition="view/use_existing_measures"
-                            i18n:translate="Additional Measure"
-                  >Additional Measure</tal:span>
-                ${repeat/actionplan/number}
-                </h2>
-                <input name="measure.id:records"
-                       type="hidden"
-                       value="${actionplan/id}"
-                />
-                <input name="measure.plan_type:records" type="hidden" value="measure_custom" />
-                <p class="functions">
-                  <a class="icon-trash remove-clone"
-                     i18n:translate="label_remove_measure"
-                  >Delete this measure</a>
-                  <a class="icon-pencil pat-tooltip"
-                     href="#standard-solutions-${repeat/actionplan/number}"
-                     data-pat-tooltip="source:ajax"
-                     tal:condition="measures"
-                     i18n:translate="label_prefill"
-                  >Pre-fill</a>
-                </p>
-                <tal:if_has_measures condition="measures">
-                  <div id="standard-solutions-${repeat/actionplan/number}"
-                       hidden="hidden"
-                  >
-                    <p class="info"
-                       i18n:translate="label_select_measure"
-                    >Select one or more of the known common measures provided.</p>
-                    <ol class="add-measure-menu">
-                      <li tal:repeat="measure measures">
-                        <a class="pat-inject close-panel title"
-                           href="#standard-solution-${repeat/measure/number}"
-                           data-pat-inject="target: #fields-${repeat/actionplan/number}; confirm: never; confirm-message: ${view/override_confirmation}"
-                        >
-                          <em class="iconified icon-plus-circle"
-                              i18n:translate="button_add"
-                          >Add</em><tal:measure replace="structure measure/description" /></a>
-                      </li>
-                    </ol>
-                  </div>
-                </tal:if_has_measures>
-
-                <fieldset class="vertical"
-                          id="fields-${repeat/actionplan/number}"
+              <tal:actionplans repeat="actionplan action_plans">
+                <div class="measure clone pat-collapsible"
+                     tal:define="
+                       measures view/solutions|python:[];
+                     "
+                     tal:condition="python:actionplan.plan_type=='measure_custom'"
                 >
-                  <label><tal:label i18n:translate="label_description">Description</tal:label>
-                    <dfn class="icon-help-circle iconified pat-tooltip"
-                         data-pat-tooltip="source: content; position-list: lt"
-                         i18n:translate="actionplan_measure_tooltip"
-                    >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
-                    <textarea class="actionPlan"
-                              name="measure.action_plan:utf8:ustring:records"
-                              placeholder="General approach (to eliminate or reduce the risk)"
-                              rows="3"
-                              type="text"
-                              tal:content="actionplan/action_plan|nothing"
-                              i18n:attributes="placeholder label_measure_action_plan"
-                    ></textarea>
-                    <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
-                      <br />
-                      <textarea class="preventionPlan"
-                                name="measure.prevention_plan:utf8:ustring:records"
-                                placeholder="Specific action(s) required to implement this approach"
-                                rows="3"
-                                tal:content="actionplan/prevention_plan|nothing"
-                                i18n:attributes="placeholder label_measure_prevention_plan"
-                      ></textarea>
-                    </tal:preventionplan>
-                    <tal:requirements condition="python: 'requirements' not in view.skip_fields">
-                      <br />
-                      <textarea class="requirements"
-                                name="measure.requirements:utf8:ustring:records"
-                                placeholder="Level of expertise and/or requirements needed"
-                                rows="3"
-                                tal:content="actionplan/requirements|nothing"
-                                i18n:attributes="placeholder label_measure_requirements"
-                      ></textarea>
-                    </tal:requirements>
-                  </label>
-                </fieldset>
+                  <h2><tal:span condition="not:view/use_existing_measures"
+                              i18n:translate="Measure"
+                    >Measure</tal:span>
+                    <tal:span condition="view/use_existing_measures"
+                              i18n:translate="Additional Measure"
+                    >Additional Measure</tal:span>
+                  ${repeat/actionplan/number}
+                  </h2>
+                  <input name="measure.id:records"
+                         type="hidden"
+                         value="${actionplan/id}"
+                  />
+                  <input name="measure.plan_type:records"
+                         type="hidden"
+                         value="measure_custom"
+                  />
+                  <p class="functions">
+                    <a class="icon-trash remove-clone"
+                       i18n:translate="label_remove_measure"
+                    >Delete this measure</a>
+                    <a class="icon-pencil pat-tooltip"
+                       href="#standard-solutions-${repeat/actionplan/number}"
+                       data-pat-tooltip="source:ajax"
+                       tal:condition="measures"
+                       i18n:translate="label_prefill"
+                    >Pre-fill</a>
+                  </p>
+                  <tal:if_has_measures condition="measures">
+                    <div id="standard-solutions-${repeat/actionplan/number}"
+                         hidden="hidden"
+                    >
+                      <p class="info"
+                         i18n:translate="label_select_measure"
+                      >Select one or more of the known common measures provided.</p>
+                      <ol class="add-measure-menu">
+                        <li tal:repeat="measure measures">
+                          <a class="pat-inject close-panel title"
+                             href="#standard-solution-${repeat/measure/number}"
+                             data-pat-inject="target: #fields-${repeat/actionplan/number}; confirm: never; confirm-message: ${view/override_confirmation}"
+                          >
+                            <em class="iconified icon-plus-circle"
+                                i18n:translate="button_add"
+                            >Add</em><tal:measure replace="structure measure/description" /></a>
+                        </li>
+                      </ol>
+                    </div>
+                  </tal:if_has_measures>
 
-                <fieldset class="vertical"
-                          tal:define="
-                            number repeat/actionplan/number;
-                          "
-                >
-                  <label>
-                    <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
-                    <dfn class="icon-help-circle iconified pat-tooltip"
-                         data-pat-tooltip="source: content; position-list: lt"
-                         i18n:translate="actionplan_measure_responsible_tooltip"
-                    >Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out.</dfn>
-                    <input class="responsible"
-                           name="measure.responsible:utf8:ustring:records"
-                           type="text"
-                           value="${actionplan/responsible|nothing}"
-                    />
-                  </label>
-                  <label class="${python:'error' if exists('errors/budget') else None}"
-                         tal:condition="python: 'budget' not in view.skip_fields"
+                  <fieldset class="vertical"
+                            id="fields-${repeat/actionplan/number}"
                   >
-                    <tal:span i18n:translate="label_action_plan_budget">Budget</tal:span>
-                    <em class="message error"
-                        tal:condition="exists:errors/budget"
-                        i18n:translate="error_invalid_budget"
-                    >Please enter the budget in whole Euros.</em>
-                    <dfn class="icon-help-circle iconified pat-tooltip"
-                         data-pat-tooltip="source: content; position-list: lt"
-                         i18n:translate="actionplan_measure_budget_tooltip"
-                    >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
-                    <span class="composed currency-field">
-                      <input class="currency"
-                             id="input-budget-${number}"
-                             min="0"
-                             name="measure.budget:records"
-                             type="number"
-                             value="${actionplan/budget|nothing}"
+                    <label><tal:label i18n:translate="label_description">Description</tal:label>
+                      <dfn class="icon-help-circle iconified pat-tooltip"
+                           data-pat-tooltip="source: content; position-list: lt"
+                           i18n:translate="actionplan_measure_tooltip"
+                      >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
+                      <textarea class="actionPlan"
+                                name="measure.action_plan:utf8:ustring:records"
+                                placeholder="General approach (to eliminate or reduce the risk)"
+                                rows="3"
+                                type="text"
+                                tal:content="actionplan/action_plan|nothing"
+                                i18n:attributes="placeholder label_measure_action_plan"
+                      ></textarea>
+                      <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
+                        <br />
+                        <textarea class="preventionPlan"
+                                  name="measure.prevention_plan:utf8:ustring:records"
+                                  placeholder="Specific action(s) required to implement this approach"
+                                  rows="3"
+                                  tal:content="actionplan/prevention_plan|nothing"
+                                  i18n:attributes="placeholder label_measure_prevention_plan"
+                        ></textarea>
+                      </tal:preventionplan>
+                      <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+                        <br />
+                        <textarea class="requirements"
+                                  name="measure.requirements:utf8:ustring:records"
+                                  placeholder="Level of expertise and/or requirements needed"
+                                  rows="3"
+                                  tal:content="actionplan/requirements|nothing"
+                                  i18n:attributes="placeholder label_measure_requirements"
+                        ></textarea>
+                      </tal:requirements>
+                    </label>
+                  </fieldset>
+
+                  <fieldset class="vertical"
+                            tal:define="
+                              number repeat/actionplan/number;
+                            "
+                  >
+                    <label>
+                      <tal:span i18n:translate="label_action_plan_responsible">Who is responsible?</tal:span>
+                      <dfn class="icon-help-circle iconified pat-tooltip"
+                           data-pat-tooltip="source: content; position-list: lt"
+                           i18n:translate="actionplan_measure_responsible_tooltip"
+                      >Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out.</dfn>
+                      <input class="responsible"
+                             name="measure.responsible:utf8:ustring:records"
+                             type="text"
+                             value="${actionplan/responsible|nothing}"
                       />
-                    </span>
-                  </label>
+                    </label>
+                    <label class="${python:'error' if exists('errors/budget') else None}"
+                           tal:condition="python: 'budget' not in view.skip_fields"
+                    >
+                      <tal:span i18n:translate="label_action_plan_budget">Budget</tal:span>
+                      <em class="message error"
+                          tal:condition="exists:errors/budget"
+                          i18n:translate="error_invalid_budget"
+                      >Please enter the budget in whole Euros.</em>
+                      <dfn class="icon-help-circle iconified pat-tooltip"
+                           data-pat-tooltip="source: content; position-list: lt"
+                           i18n:translate="actionplan_measure_budget_tooltip"
+                      >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
+                      <span class="composed currency-field">
+                        <input class="currency"
+                               id="input-budget-${number}"
+                               min="0"
+                               name="measure.budget:records"
+                               type="number"
+                               value="${actionplan/budget|nothing}"
+                        />
+                      </span>
+                    </label>
 
-                  <label tal:define="
-                           date_error exists:errors/planning_start_date;
-                         "
-                  >
-                    <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
-                    <input class="pat-date-picker"
-                           id="planning-start-${number}"
-                           name="measure.planning_start:records"
-                           type="date"
-                           value="${actionplan/planning_start|nothing}"
-                           data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                           data-pat-validation="type: date; not-after: #planning-end-${number}; message-date: ${view/message_date_before}"
-                    />
-                  </label>
+                    <label tal:define="
+                             date_error exists:errors/planning_start_date;
+                           "
+                    >
+                      <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
+                      <input class="pat-date-picker"
+                             id="planning-start-${number}"
+                             name="measure.planning_start:records"
+                             type="date"
+                             value="${actionplan/planning_start|nothing}"
+                             data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
+                             data-pat-validation="type: date; not-after: #planning-end-${number}; message-date: ${view/message_date_before}"
+                      />
+                    </label>
 
-                  <label tal:define="
-                           date_error exists:errors/planning_end_date;
-                         "
-                         tal:condition="python: 'planning_end' not in view.skip_fields"
-                  >
-                    <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
+                    <label tal:define="
+                             date_error exists:errors/planning_end_date;
+                           "
+                           tal:condition="python: 'planning_end' not in view.skip_fields"
+                    >
+                      <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
 
-                    <input class="pat-date-picker"
-                           id="planning-end-${number}"
-                           name="measure.planning_end:records"
-                           type="date"
-                           value="${actionplan/planning_end|nothing}"
-                           data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                           data-pat-validation="type: date; not-before: #planning-start-${number}; message-date: ${view/message_date_after}"
-                    />
-                  </label>
-                </fieldset>
-              </div>
+                      <input class="pat-date-picker"
+                             id="planning-end-${number}"
+                             name="measure.planning_end:records"
+                             type="date"
+                             value="${actionplan/planning_end|nothing}"
+                             data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
+                             data-pat-validation="type: date; not-before: #planning-start-${number}; message-date: ${view/message_date_after}"
+                      />
+                    </label>
+                  </fieldset>
+                </div>
+              </tal:actionplans>
             </div>
 
             <div class="button-bar">
@@ -462,10 +484,10 @@
               >Add another measure</button>
               <tal:solutions condition="solutions">
                 <button class="pat-button icon-plus-circle pat-depends ${view/style_buttons}"
-                        data-pat-depends="${view/solutions_condition}"
                         id="add-standard-measures"
                         title="Add another measure"
                         type="button"
+                        data-pat-depends="${view/solutions_condition}"
                 >Select standard measures</button>
               </tal:solutions>
             </div>

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -129,10 +129,10 @@
                   Standard measures
                 </h2>
                 <section class="pat-rich description"
-                         i18n:translate=""
+                         i18n:translate="label_select_measure"
                 >
                   <p>
-                    Select one or more standard solutions to add to your action plan.
+                    Select one or more of the known common measures provided.
                   </p>
                 </section>
                 <div class="pat-checklist pat-pick-list free-form">

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -334,7 +334,7 @@
                       <dfn class="icon-help-circle iconified pat-tooltip"
                            data-pat-tooltip="source: content; position-list: lt"
                            i18n:translate="actionplan_measure_tooltip"
-                      >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
+                      >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)</dfn>
                       <textarea class="actionPlan"
                                 name="measure.action:utf8:ustring:records"
                                 placeholder="General approach (to eliminate or reduce the risk)"
@@ -346,6 +346,11 @@
                     </label>
                     <tal:requirements condition="python: 'requirements' not in view.skip_fields">
                       <label><tal:label i18n:translate="label_expertise">Expertise</tal:label>
+                      <dfn class="icon-help-circle iconified pat-tooltip"
+                           data-pat-tooltip="source: content; position-list: lt"
+                           i18n:translate="actionplan_requirements_tooltip"
+                      >Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
+
                         <textarea class="requirements"
                                   name="measure.requirements:utf8:ustring:records"
                                   placeholder="Level of expertise and/or requirements needed"
@@ -476,7 +481,7 @@
                   <dfn class="icon-help-circle iconified pat-tooltip"
                        data-pat-tooltip="source: content; position-list: lt"
                        i18n:translate="actionplan_measure_tooltip"
-                  >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
+                  >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)</dfn>
                   <textarea class="actionPlan"
                             autofocus="autofocus"
                             name="measure.action:utf8:ustring:records"
@@ -487,6 +492,10 @@
                 </label>
                 <tal:requirements condition="python: 'requirements' not in view.skip_fields">
                   <label><tal:label i18n:translate="label_expertise">Expertise</tal:label>
+                    <dfn class="icon-help-circle iconified pat-tooltip"
+                         data-pat-tooltip="source: content; position-list: lt"
+                         i18n:translate="actionplan_requirements_tooltip"
+                    >Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
                     <textarea class="requirements"
                               name="measure.requirements:utf8:ustring:records"
                               placeholder="Level of expertise and/or requirements needed"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -307,9 +307,6 @@
 
               <tal:actionplans repeat="actionplan action_plans">
                 <div class="measure clone pat-collapsible"
-                     tal:define="
-                       measures view/solutions|python:[];
-                     "
                      tal:condition="python:actionplan.plan_type=='measure_custom'"
                 >
                   <h2><tal:span condition="not:view/use_existing_measures"
@@ -332,33 +329,7 @@
                     <a class="icon-trash remove-clone"
                        i18n:translate="label_remove_measure"
                     >Delete this measure</a>
-                    <a class="icon-pencil pat-tooltip"
-                       href="#standard-solutions-${repeat/actionplan/number}"
-                       data-pat-tooltip="source:ajax"
-                       tal:condition="measures"
-                       i18n:translate="label_prefill"
-                    >Pre-fill</a>
                   </p>
-                  <tal:if_has_measures condition="measures">
-                    <div id="standard-solutions-${repeat/actionplan/number}"
-                         hidden="hidden"
-                    >
-                      <p class="info"
-                         i18n:translate="label_select_measure"
-                      >Select one or more of the known common measures provided.</p>
-                      <ol class="add-measure-menu">
-                        <li tal:repeat="measure measures">
-                          <a class="pat-inject close-panel title"
-                             href="#standard-solution-${repeat/measure/number}"
-                             data-pat-inject="target: #fields-${repeat/actionplan/number}; confirm: never; confirm-message: ${view/override_confirmation}"
-                          >
-                            <em class="iconified icon-plus-circle"
-                                i18n:translate="button_add"
-                            >Add</em><tal:measure replace="structure measure/description" /></a>
-                        </li>
-                      </ol>
-                    </div>
-                  </tal:if_has_measures>
 
                   <fieldset class="vertical"
                             id="fields-${repeat/actionplan/number}"
@@ -496,49 +467,20 @@
                  id="measure-template"
                  hidden="hidden"
             >
-              <tal:get_measures define="
-                                  measures view/solutions|python:[];
-                                "
-              >
-                <h2><tal:span condition="not:view/use_existing_measures"
-                            i18n:translate="Measure"
-                  >Measure</tal:span>
-                  <tal:span condition="view/use_existing_measures"
-                            i18n:translate="Additional Measure"
-                  >Additional Measure</tal:span>
-                #{1}
-                </h2>
-                <p class="functions">
-                  <a class="icon-trash remove-clone"
-                     i18n:translate="label_remove_measure"
-                  >Delete this measure</a>
-                  <a class="icon-pencil pat-tooltip"
-                     href="#standard-solutions-#{1}"
-                     data-pat-tooltip="source: ajax"
-                     tal:condition="measures"
-                     i18n:translate="label_prefill"
-                  >Pre-fill</a>
-                </p>
 
-                <tal:if_has_measures condition="measures">
-                  <div id="standard-solutions-#{1}"
-                       hidden="hidden"
-                  >
-                    <p class="info"
-                       i18n:translate="label_select_measure"
-                    >Select one or more of the known common measures provided.</p>
-                    <ol class="add-measure-menu">
-                      <li tal:repeat="solution measures">
-                        <a class="pat-inject close-panel title"
-                           href="#standard-solution-${repeat/solution/number}"
-                           data-pat-inject="target: #fields-#{1}; confirm: never; confirm-message: ${view/override_confirmation}"
-                        >
-                          <em class="iconified icon-plus-circle">Add</em>${solution/description}</a>
-                      </li>
-                    </ol>
-                  </div>
-                </tal:if_has_measures>
-              </tal:get_measures>
+              <h2><tal:span condition="not:view/use_existing_measures"
+                          i18n:translate="Measure"
+                >Measure</tal:span>
+                <tal:span condition="view/use_existing_measures"
+                          i18n:translate="Additional Measure"
+                >Additional Measure</tal:span>
+              #{1}
+              </h2>
+              <p class="functions">
+                <a class="icon-trash remove-clone"
+                   i18n:translate="label_remove_measure"
+                >Delete this measure</a>
+              </p>
 
               <fieldset class="vertical"
                         id="fields-#{1}"
@@ -658,46 +600,6 @@
           </p>
         </form>
       </tal:def>
-
-
-
-      <tal:loop repeat="solution view/solutions|python:[]">
-        <fieldset class="vertical"
-                  id="standard-solution-${repeat/solution/number}"
-                  hidden="hidden"
-        >
-          <label><tal:label i18n:translate="label_description">Description</tal:label>
-            <dfn class="icon-help-circle iconified pat-tooltip"
-                 data-pat-tooltip="source: content; position-list: lt"
-                 i18n:translate="actionplan_measure_tooltip"
-            >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
-            <textarea class="actionPlan"
-                      name="measure.action_plan:utf8:ustring:records"
-                      placeholder="General approach (to eliminate or reduce the risk)"
-                      rows="3"
-                      i18n:attributes="placeholder label_measure_action_plan"
-            >${solution/action_plan}</textarea>
-            <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
-              <br />
-              <textarea class="preventionPlan"
-                        name="measure.prevention_plan:utf8:ustring:records"
-                        placeholder="Specific action(s) required to implement this approach"
-                        rows="3"
-                        i18n:attributes="placeholder label_measure_prevention_plan"
-              >${solution/prevention_plan}</textarea>
-            </tal:preventionplan>
-            <tal:requirements condition="python: 'requirements' not in view.skip_fields">
-              <br />
-              <textarea class="requirements"
-                        name="measure.requirements:utf8:ustring:records"
-                        placeholder="Level of expertise and/or requirements needed"
-                        rows="3"
-                        i18n:attributes="placeholder label_measure_requirements"
-              >${solution/requirements}</textarea>
-            </tal:requirements>
-          </label>
-        </fieldset>
-      </tal:loop>
     </metal:slot>
   </body>
 </html>

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -172,7 +172,7 @@
                   </h2>
                   <h4 i18n:translate="label_description">Description</h4>
                   <p>
-                    <tal:measure replace="structure python:measure[0]" />
+                    <tal:measure replace="structure measure/action" />
                   </p>
                 </div>
               </tal:existing_measures>

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -145,8 +145,8 @@
                   <label class="item"
                          tal:repeat="solution solutions"
                   >
-                    <input id="sm-${repeat/solution/number}"
-                           name="sm-${repeat/solution/number}"
+                    <input id="sm-${solution/id}"
+                           name="sm-${solution/id}"
                            type="checkbox"
                     />
                     <span class="text">${solution/description}</span>
@@ -185,17 +185,17 @@
 
               <tal:solutions repeat="solution solutions">
                 <div class="measure pat-collapsible closed pat-depends"
-                     data-pat-depends="condition: sm-${repeat/solution/number}"
+                     data-pat-depends="condition: sm-${solution/id}"
                 >
                   <h2>
                   ${solution/description}
                   </h2>
                   <p class="functions">
                     <a class="icon-trash pat-forward"
-                       href="#pick-sm-${repeat/solution/number}"
+                       href="#pick-sm-${solution/id}"
                        title="Remove this measure"
                        i18n:attributes="title label_remove_measure"
-                       data-pat-forward="selector: #sm-${repeat/solution/number}"
+                       data-pat-forward="selector: #sm-${solution/id}"
                        i18n:translate
                     >Remove</a>
                   </p>
@@ -240,7 +240,7 @@
                       >Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary.</dfn>
                       <span class="composed currency-field">
                         <input class="currency"
-                               id="solution-budget-${repeat/solution/number}"
+                               id="solution-budget-${solution/id}"
                                min="0"
                                name="solution.budget:records"
                                type="number"
@@ -254,11 +254,11 @@
                     >
                       <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
                       <input class="pat-date-picker"
-                             id="solution-planning-start-${repeat/solution/number}"
+                             id="solution-planning-start-${solution/id}"
                              name="solution.planning_start:records"
                              type="date"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                             data-pat-validation="type: date; not-after: #solution-planning-end-${repeat/solution/number}; message-date: ${view/message_date_before}"
+                             data-pat-validation="type: date; not-after: #solution-planning-end-${solution/id}; message-date: ${view/message_date_before}"
                       />
                     </label>
 
@@ -270,11 +270,11 @@
                       <tal:label i18n:translate="label_action_plan_end">Planning end</tal:label>
 
                       <input class="pat-date-picker"
-                             id="solution-planning-end-${repeat/solution/number}"
+                             id="solution-planning-end-${solution/id}"
                              name="solution.planning_end:records"
                              type="date"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
-                             data-pat-validation="type: date; not-before: #solution-planning-start-${repeat/solution/number}; message-date: ${view/message_date_after}"
+                             data-pat-validation="type: date; not-before: #solution-planning-start-${solution/id}; message-date: ${view/message_date_after}"
                       />
                     </label>
 

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -26,7 +26,6 @@
       <tal:def define="
                  errors python:exists('actionplan/errors') and actionplan['errors'] or {};
                  action_plans data/action_plans;
-                 action_plans python:len(action_plans) and action_plans or data.empty_action_plan;
                "
       >
 
@@ -185,7 +184,7 @@
 
               <tal:solutions repeat="solution solutions">
                 <div class="measure pat-collapsible closed pat-depends"
-                     data-pat-depends="condition: sm-${solution/id}"
+                     data-pat-depends="condition: sm-${solution/id};"
                 >
                   <h2>
                   ${solution/description}
@@ -199,6 +198,11 @@
                        i18n:translate
                     >Remove</a>
                   </p>
+                  <input name="measure.plan_type:records" type="hidden" value="measure_standard" />
+                  <input name="measure.solution_id:records" type="hidden" value="${solution/id}" />
+                  <input name="measure.action_plan:utf8:ustring:records" type="hidden" value="${solution/action_plan}" />
+                  <input name="measure.prevention_plan:utf8:ustring:records" type="hidden" value="${solution/prevention_plan}" />
+                  <input name="measure.requirements:utf8:ustring:records" type="hidden" value="${solution/requirements}" />
                   <section class="pat-rich">
                     <h4 i18n:translate="label_description">
                       Description
@@ -222,7 +226,7 @@
                            i18n:translate="actionplan_measure_responsible_tooltip"
                       >Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out.</dfn>
                       <input class="responsible"
-                             name="solution.responsible:utf8:ustring:records"
+                             name="measure.responsible:utf8:ustring:records"
                              type="text"
                       />
                     </label>
@@ -242,7 +246,7 @@
                         <input class="currency"
                                id="solution-budget-${solution/id}"
                                min="0"
-                               name="solution.budget:records"
+                               name="measure.budget:records"
                                type="number"
                         />
                       </span>
@@ -255,7 +259,7 @@
                       <tal:label i18n:translate="label_action_plan_start">Planning start</tal:label>
                       <input class="pat-date-picker"
                              id="solution-planning-start-${solution/id}"
-                             name="solution.planning_start:records"
+                             name="measure.planning_start:records"
                              type="date"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
                              data-pat-validation="type: date; not-after: #solution-planning-end-${solution/id}; message-date: ${view/message_date_before}"
@@ -271,7 +275,7 @@
 
                       <input class="pat-date-picker"
                              id="solution-planning-end-${solution/id}"
-                             name="solution.planning_end:records"
+                             name="measure.planning_end:records"
                              type="date"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
                              data-pat-validation="type: date; not-before: #solution-planning-start-${solution/id}; message-date: ${view/message_date_after}"
@@ -302,6 +306,7 @@
                        type="hidden"
                        value="${actionplan/id}"
                 />
+                <input name="measure.plan_type:records" type="hidden" value="measure_custom" />
                 <p class="functions">
                   <a class="icon-trash remove-clone"
                      i18n:translate="label_remove_measure"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -445,6 +445,7 @@
                         title="Add another measure"
                         type="button"
                         data-pat-depends="${view/solutions_condition}"
+                        i18n:translate="label_select_standard_measures"
                 >Select standard measures</button>
               </tal:solutions>
               <button class="add-clone pat-button icon-plus-circle ${view/style_buttons}"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -128,10 +128,8 @@
                 >
                   Standard measures
                 </h2>
-                <section class="pat-rich description"
-                         i18n:translate="label_select_measure"
-                >
-                  <p>
+                <section class="pat-rich description">
+                  <p i18n:translate="label_select_measure">
                     Select one or more of the known common measures provided.
                   </p>
                 </section>
@@ -169,7 +167,7 @@
                 <div class="measure pat-collapsible"
                      tal:repeat="measure measures"
                 >
-                  <h2><tal:translate i18n:translate="label_existing_measure">Measure already implemented</tal:translate>
+                  <h2><tal:translate i18n:translate="label_implemented_measure">Implemented measure</tal:translate>
                   ${repeat/measure/number}
                   </h2>
                   <h4 i18n:translate="label_description">Description</h4>
@@ -449,7 +447,7 @@
                       title="Add another measure"
                       type="button"
                       i18n:translate="label_extra_add_measure"
-              >Add extra measure</button>
+              >Add an extra measure</button>
             </div>
 
             <div class="measure pat-collapsible"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -217,12 +217,14 @@
                     <p>
                       ${solution/action}
                     </p>
-                    <h4 i18n:translate="label_expertise">
-                      Expertise
-                    </h4>
-                    <p>
-                      ${solution/requirements}
-                    </p>
+                    <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+                      <h4 i18n:translate="label_expertise">
+                        Expertise
+                      </h4>
+                      <p>
+                        ${solution/requirements}
+                      </p>
+                    </tal:requirements>
                   </section>
                   <fieldset class="vertical"
                             tal:define="

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -219,8 +219,7 @@
                       Description
                     </h4>
                     <p>
-                      ${solution/action_plan}
-                      ${solution/prevention_plan}
+                      ${solution/action}
                     </p>
                     <h4 i18n:translate="label_expertise">
                       Expertise

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -25,7 +25,7 @@
       <tal:block replace="tile:statusmessages" />
       <tal:def define="
                  errors python:exists('actionplan/errors') and actionplan['errors'] or {};
-                 action_plans data/action_plans;
+                 action_plans data/custom_measures;
                "
       >
 
@@ -302,7 +302,6 @@
 
               <tal:actionplans repeat="actionplan action_plans">
                 <div class="measure clone pat-collapsible"
-                     tal:condition="python:actionplan.plan_type=='measure_custom'"
                 >
                   <h2><tal:span condition="not:view/use_existing_measures"
                               i18n:translate="Measure"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -214,8 +214,8 @@
                     <h4 i18n:translate="label_description">
                       Description
                     </h4>
-                    <p>
-                      ${solution/action}
+                    <p tal:content="structure solution/action_markup">
+                      Action
                     </p>
                     <tal:requirements condition="python: 'requirements' not in view.skip_fields and solution['requirements']">
                       <h4 i18n:translate="label_expertise">

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -432,12 +432,6 @@
             </div>
 
             <div class="button-bar">
-              <button class="add-clone pat-button icon-plus-circle ${view/style_buttons}"
-                      id="addMeasureButton"
-                      title="Add another measure"
-                      type="button"
-                      i18n:translate="label_extra_add_measure"
-              >Add extra measure</button>
               <tal:solutions condition="solutions">
                 <button class="pat-button icon-plus-circle pat-depends ${view/style_buttons}"
                         id="add-standard-measures"
@@ -446,6 +440,12 @@
                         data-pat-depends="${view/solutions_condition}"
                 >Select standard measures</button>
               </tal:solutions>
+              <button class="add-clone pat-button icon-plus-circle ${view/style_buttons}"
+                      id="addMeasureButton"
+                      title="Add another measure"
+                      type="button"
+                      i18n:translate="label_extra_add_measure"
+              >Add extra measure</button>
             </div>
 
             <div class="measure pat-collapsible"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -120,7 +120,7 @@
             <tal:solutions condition="solutions">
               <div class="pat-modal-pop-over pat-collapsible closed pat-depends"
                    id="measures-panel"
-                   data-pat-collapsible="open-trigger: #add-standard-measures"
+                   data-pat-collapsible="open-trigger: #add-standard-measures; close-trigger: #close-standard-measures"
                    data-pat-depends="${view/solutions_condition}"
               >
                 <h2 class="title"
@@ -151,6 +151,8 @@
                   </label>
                 </div>
               </div>
+              <button id="close-standard-measures"
+                      type="button">Close panel</button>
             </tal:solutions>
 
             <div class="measures pat-clone"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -30,7 +30,7 @@
       >
 
         <!-- Disable validation on the action plan, since an empty budget field falsely gets claimed as being required! -->
-        <form class="Xpat-validation pat-inject pat-scroll"
+        <form class="pat-validation pat-inject pat-scroll"
               action="${context/absolute_url}/@@actionplan"
               method="post"
               data-pat-inject="history: record; source: #step-4-topics; target: #step-4-topics &amp;&amp; source: #content; target: #content"
@@ -274,7 +274,7 @@
                       <input class="pat-date-picker"
                              id="solution-planning-start-${solution/id}"
                              name="measure.planning_start:records"
-                             type="date"
+                             type="text"
                              value="${python:measure.planning_start if measure else None}"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
                              data-pat-validation="type: date; not-after: #solution-planning-end-${solution/id}; message-date: ${view/message_date_before}"
@@ -291,7 +291,7 @@
                       <input class="pat-date-picker"
                              id="solution-planning-end-${solution/id}"
                              name="measure.planning_end:records"
-                             type="date"
+                             type="text"
                              value="${python:measure.planning_end if measure else None}"
                              data-pat-date-picker="behavior: styled; week-numbers: show; i18n: ${webhelpers/country_url}/@@date-picker-i18n.json"
                              data-pat-validation="type: date; not-before: #solution-planning-start-${solution/id}; message-date: ${view/message_date_after}"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -179,7 +179,7 @@
 
 
               <tal:solutions repeat="solution solutions">
-                <div class="measure pat-collapsible closed pat-depends"
+                <div class="measure pat-collapsible pat-depends"
                      data-pat-depends="condition: sm-${solution/id};"
                 >
                   <h2>

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -217,7 +217,7 @@
                     <p>
                       ${solution/action}
                     </p>
-                    <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+                    <tal:requirements condition="python: 'requirements' not in view.skip_fields and solution['requirements']">
                       <h4 i18n:translate="label_expertise">
                         Expertise
                       </h4>

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -451,8 +451,8 @@
                       id="addMeasureButton"
                       title="Add another measure"
                       type="button"
-                      i18n:translate="label_add_measure"
-              >Add another measure</button>
+                      i18n:translate="label_extra_add_measure"
+              >Add extra measure</button>
               <tal:solutions condition="solutions">
                 <button class="pat-button icon-plus-circle pat-depends ${view/style_buttons}"
                         id="add-standard-measures"

--- a/src/euphorie/client/browser/templates/risk_actionplan.pt
+++ b/src/euphorie/client/browser/templates/risk_actionplan.pt
@@ -202,13 +202,9 @@
                          type="hidden"
                          value="${solution/id}"
                   />
-                  <input name="measure.action_plan:utf8:ustring:records"
+                  <input name="measure.action:utf8:ustring:records"
                          type="hidden"
-                         value="${solution/action_plan}"
-                  />
-                  <input name="measure.prevention_plan:utf8:ustring:records"
-                         type="hidden"
-                         value="${solution/prevention_plan}"
+                         value="${solution/action}"
                   />
                   <input name="measure.requirements:utf8:ustring:records"
                          type="hidden"
@@ -339,25 +335,16 @@
                            i18n:translate="actionplan_measure_tooltip"
                       >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
                       <textarea class="actionPlan"
-                                name="measure.action_plan:utf8:ustring:records"
+                                name="measure.action:utf8:ustring:records"
                                 placeholder="General approach (to eliminate or reduce the risk)"
                                 rows="3"
                                 type="text"
-                                tal:content="actionplan/action_plan|nothing"
+                                tal:content="actionplan/action|nothing"
                                 i18n:attributes="placeholder label_measure_action_plan"
                       ></textarea>
-                      <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
-                        <br />
-                        <textarea class="preventionPlan"
-                                  name="measure.prevention_plan:utf8:ustring:records"
-                                  placeholder="Specific action(s) required to implement this approach"
-                                  rows="3"
-                                  tal:content="actionplan/prevention_plan|nothing"
-                                  i18n:attributes="placeholder label_measure_prevention_plan"
-                        ></textarea>
-                      </tal:preventionplan>
-                      <tal:requirements condition="python: 'requirements' not in view.skip_fields">
-                        <br />
+                    </label>
+                    <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+                      <label><tal:label i18n:translate="label_expertise">Expertise</tal:label>
                         <textarea class="requirements"
                                   name="measure.requirements:utf8:ustring:records"
                                   placeholder="Level of expertise and/or requirements needed"
@@ -365,8 +352,8 @@
                                   tal:content="actionplan/requirements|nothing"
                                   i18n:attributes="placeholder label_measure_requirements"
                         ></textarea>
-                      </tal:requirements>
-                    </label>
+                      </label>
+                    </tal:requirements>
                   </fieldset>
 
                   <fieldset class="vertical"
@@ -491,30 +478,22 @@
                   >Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any).</dfn>
                   <textarea class="actionPlan"
                             autofocus="autofocus"
-                            name="measure.action_plan:utf8:ustring:records"
+                            name="measure.action:utf8:ustring:records"
                             placeholder="General approach (to eliminate or reduce the risk)"
                             rows="3"
                             i18n:attributes="placeholder label_measure_action_plan"
                   ></textarea>
-                  <tal:preventionplan condition="python: 'prevention_plan' not in view.skip_fields">
-                    <br />
-                    <textarea class="preventionPlan"
-                              name="measure.prevention_plan:utf8:ustring:records"
-                              placeholder="Specific action(s) required to implement this approach"
-                              rows="3"
-                              i18n:attributes="placeholder label_measure_prevention_plan"
-                    ></textarea>
-                  </tal:preventionplan>
-                  <tal:requirements condition="python: 'requirements' not in view.skip_fields">
-                    <br />
+                </label>
+                <tal:requirements condition="python: 'requirements' not in view.skip_fields">
+                  <label><tal:label i18n:translate="label_expertise">Expertise</tal:label>
                     <textarea class="requirements"
                               name="measure.requirements:utf8:ustring:records"
                               placeholder="Level of expertise and/or requirements needed"
                               rows="3"
                               i18n:attributes="placeholder label_measure_requirements"
                     ></textarea>
-                  </tal:requirements>
-                </label>
+                  </label>
+                </tal:requirements>
               </fieldset>
 
               <fieldset class="vertical">

--- a/src/euphorie/client/browser/templates/risk_identification_custom.pt
+++ b/src/euphorie/client/browser/templates/risk_identification_custom.pt
@@ -55,7 +55,7 @@
                         repeat="measure measures"
           >
             <label>
-              <input checked="${python:measure[1] and 'checked' or None}"
+              <input checked="${python:measure['active'] and 'checked' or None}"
                      name="measure-${repeat/measure/index}"
                      type="checkbox"
               />
@@ -65,7 +65,7 @@
                           name="present-measure-${repeat/measure/index}"
                           placeholder="${view/placeholder_add_extra}"
                           rows="3"
-                >${python:measure[0]}</textarea>
+                >${python:measure['text']}</textarea>
             </label>
           </tal:measures>
           <input type="hidden" name="handle_measures_in_place" value="1" />

--- a/src/euphorie/client/browser/templates/session-browser-sidebar.pt
+++ b/src/euphorie/client/browser/templates/session-browser-sidebar.pt
@@ -139,13 +139,14 @@
                   ></span
                 ></span>
                 <span class="field" tal:condition="not:session/published"></span>
-                <span class="tool meta field"
-                  ><tal:i18n i18n:translate="">based on</tal:i18n
-                  > <a class="pat-inject pat-switch"
+                <span class="tool meta field" i18n:translate="label_tool_based_on"
+                  >based on
+                  <a class="pat-inject pat-switch"
                      data-pat-switch="selector: body; remove: focus-*; add: focus-document &amp;&amp; selector: body; remove: osc-s-*; add: osc-s-off; store: local &amp;&amp;selector: body; remove: osc-size-*; add: osc-size-normal"
                      data-pat-inject="history: record"
                      href="${tool/absolute_url}?groupid=${request/groupid|string:}#content"
                      title="${tool/title}"
+                     i18n:name="tool_title"
                   >${tool/title}</a
                 ></span>
                 <a href="${tool/absolute_url}/++session++${session/id}/@@more_menu#more-menu"

--- a/src/euphorie/client/browser/templates/webhelpers.pt
+++ b/src/euphorie/client/browser/templates/webhelpers.pt
@@ -173,12 +173,32 @@
                         "
                         repeat="measure measures"
           >
-            <label>
+            <label tal:condition="python: measure['plan_type']=='in_place_standard'">
               <input checked="${python:measure['active'] and 'checked' or None}"
-                     name="measure-${python:'standard-' if measure['plan_type']=='in_place_standard' else 'custom-'}${measure/solution_id}"
+                     name="measure-standard-${measure/solution_id}"
                      type="checkbox"
               />
                 <tal:measure replace="structure python:measure['text']" />
+            </label>
+
+            <label tal:condition="python: measure['plan_type']=='in_place_custom'"
+                   class="clone">
+              <input checked="checked"
+                     disabled="disabled"
+                     name="measure-custom-${measure/solution_id}"
+                     type="checkbox"
+              />
+              <textarea cols="50"
+                        autofocus="autofocus"
+                        name="measure-custom-${measure/solution_id}"
+                        placeholder="${view/placeholder_add_extra}"
+                        rows="3"
+                        tal:content="structure python:measure['text']"
+              ></textarea>
+              <button class="icon-trash iconified remove-clone"
+                      title="${view/button_remove_extra}"
+              >Remove</button>
+
             </label>
           </tal:measures>
           <input type="hidden" name="handle_measures_in_place" value="1" />

--- a/src/euphorie/client/browser/templates/webhelpers.pt
+++ b/src/euphorie/client/browser/templates/webhelpers.pt
@@ -174,11 +174,11 @@
                         repeat="measure measures"
           >
             <label>
-              <input checked="${python:measure[1] and 'checked' or None}"
-                     name="measure-${repeat/measure/index}"
+              <input checked="${python:measure['active'] and 'checked' or None}"
+                     name="measure-${python:'standard-' if measure['plan_type']=='in_place_standard' else 'custom-'}${measure/solution_id}"
                      type="checkbox"
               />
-                <tal:measure replace="structure python:measure[0]" />
+                <tal:measure replace="structure python:measure['text']" />
             </label>
           </tal:measures>
           <input type="hidden" name="handle_measures_in_place" value="1" />

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -677,6 +677,12 @@ class SurveySession(BaseObject):
         ),
     )
 
+    migrated = schema.Column(
+        types.DateTime,
+        nullable=False,
+        default=functions.now(),
+    )
+
     # Allow this class to be subclassed in other projects
     __mapper_args__ = {
         'polymorphic_identity': 'euphorie',

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1143,17 +1143,33 @@ class Risk(SurveyTreeItem):
     image_data_scaled = schema.Column(types.LargeBinary())
     image_filename = schema.Column(types.UnicodeText())
 
-    @property
-    def standard_measures(self):
+    @memoize
+    def measures_of_type(self, plan_type):
         query = (
             Session.query(ActionPlan)
             .filter(
                 sql.and_(ActionPlan.risk_id == self.id),
-                ActionPlan.plan_type == "measure_standard",
+                ActionPlan.plan_type == plan_type,
             )
-            .order_by(ActionPlan.solution_id.desc())
+            .order_by(ActionPlan.id)
         )
-        return query
+        return query.all()
+
+    @property
+    def standard_measures(self):
+        return self.measures_of_type("measure_standard")
+
+    @property
+    def custom_measures(self):
+        return self.measures_of_type("measure_custom")
+
+    @property
+    def in_place_standard_measures(self):
+        return self.measures_of_type("in_place_standard")
+
+    @property
+    def in_place_custom_measures(self):
+        return self.measures_of_type("in_place_custom")
 
 
 class ActionPlan(BaseObject):

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1142,6 +1142,18 @@ class Risk(SurveyTreeItem):
     image_data_scaled = schema.Column(types.LargeBinary())
     image_filename = schema.Column(types.UnicodeText())
 
+    @property
+    def standard_measures(self):
+        query = (
+            Session.query(ActionPlan)
+            .filter(
+                sql.and_(ActionPlan.risk_id == self.id),
+                ActionPlan.plan_type == "measure_standard",
+            )
+            .order_by(ActionPlan.solution_id.desc())
+        )
+        return query
+
 
 class ActionPlan(BaseObject):
     """Action plans for a known risk."""

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -844,7 +844,7 @@ class SurveySession(BaseObject):
 
         statement = """\
         INSERT INTO action_plan (risk_id, action_plan, prevention_plan,
-                                        requirements, responsible, budget,
+                                        requirements, responsible, budget, plan_type,
                                         planning_start, planning_end)
                SELECT new_tree.id,
                       action_plan.action_plan,
@@ -852,6 +852,7 @@ class SurveySession(BaseObject):
                       action_plan.requirements,
                       action_plan.responsible,
                       action_plan.budget,
+                      action_plan.plan_type,
                       action_plan.planning_start,
                       action_plan.planning_end
                FROM action_plan JOIN risk ON action_plan.risk_id=risk.id
@@ -1162,6 +1163,19 @@ class ActionPlan(BaseObject):
     planning_start = schema.Column(types.Date())
     planning_end = schema.Column(types.Date())
     reference = schema.Column(types.Text())
+    plan_type = schema.Column(
+        Enum(
+            [
+                "measure_custom",
+                "measure_standard",
+                "in_place_standard",
+                "in_place_custom",
+            ]
+        ),
+        nullable=False,
+        index=True,
+    )
+    solution_id = schema.Column(types.Integer())
 
     risk = orm.relation(
         Risk,

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -843,12 +843,13 @@ class SurveySession(BaseObject):
         session.execute(statement)
 
         statement = """\
-        INSERT INTO action_plan (risk_id, action_plan, prevention_plan,
+        INSERT INTO action_plan (risk_id, action_plan, prevention_plan, action,
                                         requirements, responsible, budget, plan_type,
                                         planning_start, planning_end)
                SELECT new_tree.id,
                       action_plan.action_plan,
                       action_plan.prevention_plan,
+                      action_plan.action,
                       action_plan.requirements,
                       action_plan.responsible,
                       action_plan.budget,
@@ -1169,6 +1170,8 @@ class ActionPlan(BaseObject):
     )
     action_plan = schema.Column(types.UnicodeText())
     prevention_plan = schema.Column(types.UnicodeText())
+    # The column "action" is the synthesis of "action_plan" and "prevention_plan"
+    action = schema.Column(types.UnicodeText())
     requirements = schema.Column(types.UnicodeText())
     responsible = schema.Column(types.Unicode(256))
     budget = schema.Column(types.Integer())

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1186,6 +1186,7 @@ class ActionPlan(BaseObject):
         ),
         nullable=False,
         index=True,
+        default="measure_custom",
     )
     solution_id = schema.Column(types.Integer())
 

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1213,7 +1213,7 @@ class ActionPlan(BaseObject):
         index=True,
         default="measure_custom",
     )
-    solution_id = schema.Column(types.Integer())
+    solution_id = schema.Column(types.Unicode(20))
 
     risk = orm.relation(
         Risk,

--- a/src/euphorie/client/report.py
+++ b/src/euphorie/client/report.py
@@ -19,6 +19,7 @@ from openpyxl.workbook import Workbook
 from openpyxl.writer.excel import save_virtual_workbook
 from plone import api
 from plone.memoize.view import memoize
+from sqlalchemy import sql
 from urllib import quote
 from zope.i18n import translate
 
@@ -87,7 +88,13 @@ class ActionPlanTimeline(grok.View, survey._StatusHelper):
         measure_data = []
         for (module, risk) in risk_data:
             action_plan_q = self.sql_session.query(model.ActionPlan).filter(
-                model.ActionPlan.risk_id == risk.id
+                sql.and_(
+                    model.ActionPlan.risk_id == risk.id,
+                    sql.or_(
+                        model.ActionPlan.plan_type == 'measure_standard',
+                        model.ActionPlan.plan_type == 'measure_custom',
+                    )
+                )
             )
             # If the risk contains no action plan, add it as a single line
             # to the results
@@ -121,18 +128,10 @@ class ActionPlanTimeline(grok.View, survey._StatusHelper):
         ),
         (
             "measure",
-            "action_plan",
+            "action",
             _(
                 "label_measure_action_plan",
                 default=u"General approach " u"(to eliminate or reduce the risk)",
-            ),
-        ),
-        (
-            "measure",
-            "prevention_plan",
-            _(
-                "label_measure_prevention_plan",
-                default=u"Specific action(s) required to implement " u"this approach",
             ),
         ),
         (

--- a/src/euphorie/client/tests/test_report.py
+++ b/src/euphorie/client/tests/test_report.py
@@ -314,7 +314,7 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
                     identification='no',
                     action_plans=[
                         model.ActionPlan(
-                            action_plan=u'Measure 1 for %s' % session.account.loginname
+                            action=u'Measure 1 for %s' % session.account.loginname
                         )
                     ]))
 
@@ -324,7 +324,7 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
 
         measures = view.get_measures()
         self.assertEqual(len(measures), 1)
-        self.assertEqual(measures[0][2].action_plan, 'Measure 1 for jane@example.com')
+        self.assertEqual(measures[0][2].action, 'Measure 1 for jane@example.com')
 
     def test_get_measures_order_by_start_date(self):
         view = self._get_timeline()
@@ -344,11 +344,11 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
                 identification='no',
                 action_plans=[
                     model.ActionPlan(
-                        action_plan=u'Plan 2',
+                        action=u'Plan 2',
                         planning_start=datetime.date(2011, 12, 15)
                     ),
                     model.ActionPlan(
-                        action_plan=u'Plan 1',
+                        action=u'Plan 1',
                         planning_start=datetime.date(2011, 11, 15)
                     )
                 ]
@@ -361,7 +361,7 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
 
         measures = view.get_measures()
         self.assertEqual(len(measures), 2)
-        self.assertEqual([row[2].action_plan for row in measures],
+        self.assertEqual([row[2].action for row in measures],
                          [u'Plan 1', u'Plan 2'])
 
     def test_priority_name_known_priority(self):
@@ -397,7 +397,7 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
             comment=u'Risk comment'
         )
         plan = model.ActionPlan(
-            action_plan=u'Plan 2',
+            action=u'Plan 2',
             planning_start=datetime.date(2011, 12, 15),
             budget=500
         )
@@ -417,24 +417,22 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
         self.assertEqual(sheet.cell('B2').value, None)
         # action plan
         self.assertEqual(sheet.cell('C2').value, u'Plan 2')
-        # prevention plan
-        self.assertEqual(sheet.cell('D2').value, None)
         # requirements
-        self.assertEqual(sheet.cell('E2').value, None)
+        self.assertEqual(sheet.cell('D2').value, None)
         # responsible
-        self.assertEqual(sheet.cell('F2').value, None)
+        self.assertEqual(sheet.cell('E2').value, None)
         # budget
-        self.assertEqual(sheet.cell('G2').value, 500)
+        self.assertEqual(sheet.cell('F2').value, 500)
         # module title
-        self.assertEqual(sheet.cell('H2').value, u'Top-level Module title')
+        self.assertEqual(sheet.cell('G2').value, u'Top-level Module title')
         # risk number
-        self.assertEqual(sheet.cell('I2').value, u'1.2.3')
+        self.assertEqual(sheet.cell('H2').value, u'1.2.3')
         # risk title
-        self.assertEqual(sheet.cell('J2').value, u'This is wrong.')
+        self.assertEqual(sheet.cell('I2').value, u'This is wrong.')
         # risk priority
-        self.assertEqual(sheet.cell('K2').value, u'High')
+        self.assertEqual(sheet.cell('J2').value, u'High')
         # risk comment
-        self.assertEqual(sheet.cell('L2').value, u'Risk comment')
+        self.assertEqual(sheet.cell('K2').value, u'Risk comment')
 
     def test_create_workbook_no_problem_description(self):
         view = self._get_timeline()
@@ -459,7 +457,7 @@ class ActionPlanTimelineTests(EuphorieIntegrationTestCase):
         survey.restrictedTraverse.return_value = zodb_node
         view.getRisks = lambda x: [(module, risk)]
         sheet = view.create_workbook().worksheets[0]
-        self.assertEqual(sheet.cell('J2').value, u'Risk title')
+        self.assertEqual(sheet.cell('I2').value, u'Risk title')
 
     def test_render_value(self):
         with api.env.adopt_user(user=self.account):

--- a/src/euphorie/client/utils.py
+++ b/src/euphorie/client/utils.py
@@ -222,17 +222,18 @@ def get_unactioned_nodes(ls, filter_for_measures=False):
             unactioned.append(n)
 
         elif n.type == 'risk':
-            if not n.action_plans:
+            action_plans = n.standard_measures + n.custom_measures
+            if not action_plans:
                 if filter_for_measures:
-                    if getattr(n, "existing_measures", None):
+                    if not (n.in_place_standard + n.in_place_custom):
                         unactioned.append(n)
                 else:
                     unactioned.append(n)
             else:
                 # It's possible that there is an action plan object, but
                 # that it's not yet fully populated
-                if n.action_plans[0] is None or \
-                        n.action_plans[0].action_plan is None:
+                if action_plans[0] is None or \
+                        action_plans[0].action is None:
                     unactioned.append(n)
 
     return remove_empty_modules(unactioned)
@@ -250,10 +251,12 @@ def get_actioned_nodes(ls):
         if n.type == 'module':
             actioned.append(n)
 
-        if n.type == 'risk' and len(n.action_plans):
+        if n.type == 'risk':
+            action_plans = n.standard_measures + n.custom_measures
+            if len(action_plans):
                 # It's possible that there is an action plan object, but
                 # it's not yet fully populated
-                plans = [p.action_plan for p in n.action_plans]
+                plans = [p.action for p in action_plans]
                 if plans[0] is not None:
                     actioned.append(n)
 

--- a/src/euphorie/content/solution.py
+++ b/src/euphorie/content/solution.py
@@ -52,7 +52,7 @@ class ISolution(form.Schema):
             default=u"Describe your general approach to eliminate or (if "
             u"the risk is not avoidable) reduce the risk."
         ),
-        required=True
+        required=False
     )
 
     prevention_plan = schema.Text(
@@ -67,6 +67,23 @@ class ISolution(form.Schema):
             u"implement this approach (to eliminate or to reduce the risk)."
         ),
         required=False
+    )
+
+    # This replaces action_plan and prevention_plan by concatenating the 2 fields.
+    action = schema.Text(
+        title=_(
+            "label_measure_action",
+            default=u"General approach (to eliminate or reduce the risk) + Specific action(s) "
+            u"required to implement this approach"
+        ),
+        description=_(
+            "help_measure_action",
+            default=u"Describe your general approach to eliminate or (if the risk is not avoidable) "
+            u"reduce the risk. + Describe the specific action(s) required to implement this approach "
+            u"(to eliminate or to reduce the risk)."
+        ),
+        required=True,
+
     )
 
     requirements = schema.Text(
@@ -123,7 +140,7 @@ def SearchableTextIndexer(obj):
     """
     return " ".join([
         obj.description, obj.action_plan or '', obj.prevention_plan or '',
-        obj.requirements or ''
+        obj.requirements or '', obj.action or ''
     ])
 
 
@@ -142,22 +159,11 @@ class Add(dexterity.AddForm):
     grok.name("euphorie.solution")
     grok.require("euphorie.content.AddNewRIEContent")
 
-    def __init__(self, context, request):
-        from euphorie.content.survey import get_tool_type
-        dexterity.AddForm.__init__(self, context, request)
-        # appconfig = getUtility(IAppConfig)
-        # settings = appconfig.get('euphorie')
-        # self.use_existing_measures = settings.get('use_existing_measures', False)
-        # self.tool_type = get_tool_type(context)
-
-    # def updateWidgets(self):
-    #     super(Add, self).updateWidgets()
-    #     tt = getUtility(IToolTypesInfo)
-    #     if not (
-    #         self.use_existing_measures and
-    #         self.tool_type in tt.types_existing_measures
-    #     ):
-    #         self.widgets["show_in_identification"].mode = "hidden"
+    def updateWidgets(self):
+        super(Add, self).updateWidgets()
+        self.widgets["action_plan"].mode = "hidden"
+        self.widgets["prevention_plan"].mode = "hidden"
+        self.widgets["action"].rows = 15
 
 
 class Edit(form.SchemaEditForm):
@@ -166,19 +172,8 @@ class Edit(form.SchemaEditForm):
     grok.layer(NuPloneSkin)
     grok.name("edit")
 
-    # def __init__(self, context, request):
-    #     from euphorie.content.survey import get_tool_type
-    #     appconfig = getUtility(IAppConfig)
-    #     settings = appconfig.get('euphorie')
-    #     self.use_existing_measures = settings.get('use_existing_measures', False)
-    #     self.tool_type = get_tool_type(context)
-    #     form.SchemaEditForm.__init__(self, context, request)
-
-    # def updateWidgets(self):
-    #     super(Edit, self).updateWidgets()
-    #     tt = getUtility(IToolTypesInfo)
-    #     if not (
-    #         self.use_existing_measures and
-    #         self.tool_type in tt.types_existing_measures
-    #     ):
-    #         self.widgets["show_in_identification"].mode = "hidden"
+    def updateWidgets(self):
+        super(Edit, self).updateWidgets()
+        self.widgets["action_plan"].mode = "hidden"
+        self.widgets["prevention_plan"].mode = "hidden"
+        self.widgets["action"].rows = 15

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -675,7 +675,7 @@ msgid "Montenegro"
 msgstr "Черна гора"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -719,7 +719,7 @@ msgstr "Не"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1581,10 +1581,6 @@ msgstr "За нас"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Създадено от ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "въз основа на"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4424,6 +4420,11 @@ msgstr "средно"
 msgid "label_title"
 msgstr "Име"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "въз основа на ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4836,7 +4837,7 @@ msgid "optional"
 msgstr "Незадължително"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5489,6 +5490,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Да"
+
+#~ msgid "based on"
+#~ msgstr "въз основа на"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Добави друга мярка"

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -585,7 +585,7 @@ msgstr "Информация"
 msgid "Information"
 msgstr "Информация"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Невалиден формат на файла на изображението. Моля, използвайте PNG, JPEG или "
@@ -1053,7 +1053,7 @@ msgstr "Стандарт"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Основни мерки"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1127,7 +1127,7 @@ msgstr ""
 "Основната структура на Инструмента за онлайн интерактивна оценка на риска се "
 "състои от:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1542,13 +1542,12 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Опишете: 3) "
-"експертното ниво, което е необходимо, за да бъде изпълнена мярката, например "
-"„здрав разум (не са необходими познания по БЗР)”, “не са нужни определени "
-"експертни познания по БЗР, но се изискват минимални познания или обучение по "
-"БЗР и/или консултация с ръководство по БЗР”, или “необходимо е експертно "
-"ниво по БЗР”. Тук можете да опишете и други допълнителни изисквания (ако има "
-"такива)."
+"Опишете: 3) експертното ниво, което е необходимо, за да бъде изпълнена "
+"мярката, например „здрав разум (не са необходими познания по БЗР)”, “не са "
+"нужни определени експертни познания по БЗР, но се изискват минимални "
+"познания или обучение по БЗР и/или консултация с ръководство по БЗР”, или "
+"“необходимо е експертно ниво по БЗР”. Тук можете да опишете и други "
+"допълнителни изисквания (ако има такива)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2210,17 +2209,17 @@ msgid "error_password_mismatch"
 msgstr "Паролите не съвпадат"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Тази дата трябва да съвпада или да е след началната дата."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Тази дата трябва да е преди или да съвпада с крайната дата."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Тази стойност трябва да е положително цяло число."
 
@@ -3002,7 +3001,7 @@ msgstr ""
 "започнете с копие на съществуващ OiRA инструмент.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Посочете колко често този риск се среща в нормална ситуация."
 
@@ -3014,12 +3013,12 @@ msgstr ""
 "подразбиране. Той/тя все пак ще може да промени приоритета."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Посочете колко вероятно е този риск да се срещне в нормална ситуация."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Посочете сериозността, ако този риск възникне."
 
@@ -3297,7 +3296,7 @@ msgstr "Ако не посочите име, то ще бъде взето от 
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Информационен панел"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3656,7 +3655,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3804,9 +3803,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Добави мерки"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4100,7 +4099,7 @@ msgstr "Преглед"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Назад"
@@ -4264,7 +4263,7 @@ msgstr "Запазете и добавете друг риск."
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Запазване и продължаване"
 
@@ -4307,6 +4306,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Изберете основни мерки"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5380,7 +5384,7 @@ msgstr "Съдържание"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Скрий/Покажи меню"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} пред контролните органи (Инспекцията по труда)"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Добавяне на информация от библиотеката
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -267,7 +267,7 @@ msgstr "наличните OiRA инструменти"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr "Страни-кандидати"
 msgid "Candidate country"
 msgstr "Страна-кандидат"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Промяна на имейл адрес"
 
@@ -333,11 +333,11 @@ msgstr ""
 "Съдържа: цялата информация и данни, въведени от вас в рамките на процеса на "
 "оценяване на риска"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Съдържа:  обзор на мерките, които трябва да бъдат изпълнени."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Съдържа: преглед на идентифицираните рискове"
 
@@ -376,15 +376,15 @@ msgstr "Информация за страна и групиране за кли
 msgid "Country manager"
 msgstr "Мениджър за страната"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Криейтив комънс договор-ShareAlike версия 2.5 Стандартен лиценз"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Лиценз Криейтив комънс"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -442,15 +442,15 @@ msgstr "Изтегляне на плана за действие"
 msgid "Download the full report"
 msgstr "Изтегляне на пълния доклад"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Изтегляне на  обзор на мерките"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Изтегляне на преглед на рисковете"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Електронна поща"
@@ -524,7 +524,7 @@ msgstr "Папка"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Формат: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Формат: Portable Document Format (.pdf)"
 
@@ -532,7 +532,7 @@ msgstr "Формат: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Германия"
 
@@ -560,7 +560,7 @@ msgstr ""
 "разполагате, а по-късно, при възможност,  да продължите от мястото, където "
 "сте прекъснали."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Искам да споделя следното с вас"
 
@@ -576,8 +576,7 @@ msgstr ""
 msgid "Important"
 msgstr "Важно"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Информация"
 
@@ -586,7 +585,7 @@ msgstr "Информация"
 msgid "Information"
 msgstr "Информация"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Невалиден формат на файла на изображението. Моля, използвайте PNG, JPEG или "
@@ -623,11 +622,11 @@ msgstr "Косово"
 msgid "Last saved"
 msgstr "запазено"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Научете повече за този инструмент…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -639,7 +638,7 @@ msgstr "Вход"
 msgid "Manage"
 msgstr "Управление"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Мярка"
@@ -658,14 +657,14 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "следите и оценявате дали са приложени необходимите мерки"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Проследяване на мерките, които трябва да бъдат изпълнени през следващите три "
 "месеца."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 "Проследяване дали са предприети съответни действия по отношение на "
@@ -796,12 +795,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Онлайн помощ"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Обзор на мерките"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Преглед на рисковете"
@@ -819,8 +820,8 @@ msgstr ""
 "работа, работодатели, представители на Служби по трудова медицина и т.н.)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Информиране на заинтересованите лица."
 
@@ -851,9 +852,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Прегледайте примерите под формуляра."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Отложено разглеждане"
 
@@ -894,7 +895,7 @@ msgstr "представите доказателства пред контро�
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Прочетете повече"
 
@@ -928,8 +929,8 @@ msgstr ""
 "можете да продължите предишни оценки или да започнете нови."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Премахване"
 
@@ -950,11 +951,11 @@ msgstr "Риск"
 msgid "Risk assessments made with this tool"
 msgstr "Оценка на риска, извършена с този инструмент"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Правилно"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Внимание"
 
@@ -1033,7 +1034,7 @@ msgstr "Споделете инструмента за ОiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Показване на библиотека от падащо меню ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Вход"
 
@@ -1049,6 +1050,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Стандарт"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1103,7 +1108,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Холандия"
 
@@ -1122,7 +1127,7 @@ msgstr ""
 "Основната структура на Инструмента за онлайн интерактивна оценка на риска се "
 "състои от:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1229,7 +1234,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Този инструмент заслужава да бъде познат в цял свят! Споделете го!"
 
@@ -1237,8 +1242,8 @@ msgstr "Този инструмент заслужава да бъде позн�
 msgid "Tip"
 msgstr "Съвет"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Превключете на екрана за помощ"
 
@@ -1250,9 +1255,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Без отговор"
 
@@ -1378,37 +1383,37 @@ msgid "Your password was successfully changed."
 msgstr "Вашата парола беше променена успешно."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Първичният код на приложението OiRA се лицензира според ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "Съдържанието на секторните инструменти OiRA е лицензирано според ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "Секторните инструменти на OiRA могат да бъдат използвани безплатно от всички "
 "потребители."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Повече информация за проекта OiRA (на английски език)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Стратегия на Европейската общност за безопасност и здраве при работа "
 "2007-2012 г."
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Опитът показва, че ${key}. Ето затова EU-OSHA разработи ${easy} (“OiRA” - "
@@ -1419,51 +1424,51 @@ msgstr ""
 "до наблюдаване и ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "лесно за използване и без никакви разходи уеб приложение"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "оценяване"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "определяне"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "правилната оценка на риска е от ключово значение за осигуряване на "
 "здравословни работни места"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "превантивни действия"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "докладване"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "поетапен процес на оценка на риска"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Уеб приложението OiRA предлага достъп до секторните инструменти за оценка на "
 "риска, създадени и поддържани от секторните организации на национално ниво."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} призовава за разработването на опростени инструменти, за да се "
@@ -1476,7 +1481,7 @@ msgstr ""
 "цели да преодолее."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Проектът OiRA и свързаното уеб приложение са разработени от ${eu-osha} на "
@@ -1489,13 +1494,13 @@ msgstr ""
 "професионалните съюзи FNV, CNV и MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Следните технически партньори допринесоха за разработването на проекта ОiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "На Агенцията също така бяха дадени стратегически и експертни съвети от "
@@ -1504,12 +1509,12 @@ msgstr ""
 "с интереси в Борда, от Комисията и от EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "микро- и малките предприятия имат някои недостатъци"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Макар и да има някои мерки, които не са свързани с разходи, повечето са. "
@@ -1517,7 +1522,7 @@ msgstr ""
 "годишния бюджет, ако е необходимо."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Назначете някой във Вашата фирма, който да поеме отговорността за "
@@ -1525,13 +1530,19 @@ msgstr ""
 "стъпките, описани в плана и/или отговорността да се погрижи те да бъдат "
 "изпълнени."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Опишете: 1) какъв е общият Ви подход за елиминиране или (ако рискът е "
 "неизбежен) намаляване на риска; 2) конкретните действия, които се изискват, "
-"за да бъде следван подходът (за елиминиране или намаляване на риска); 3) "
+"за да бъде следван подходът (за елиминиране или намаляване на риска)"
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Опишете: 3) "
 "експертното ниво, което е необходимо, за да бъде изпълнена мярката, например "
 "„здрав разум (не са необходими познания по БЗР)”, “не са нужни определени "
 "експертни познания по БЗР, но се изискват минимални познания или обучение по "
@@ -1598,7 +1609,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: положителни твърдения, които се съдържат в модули."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Добави"
 
@@ -1646,7 +1657,7 @@ msgstr "Отменяне"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "затвори"
 
@@ -1980,7 +1991,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Оценката на риска е  извършена автоматично от инструмента. Ще имате "
@@ -2033,7 +2044,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "След техническата разработка на инструмента през 2009 г., през 2010 г. (до "
@@ -2075,17 +2086,17 @@ msgid "effect_high"
 msgstr "Високо (много високо) ниво на сериозност"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Ниско ниво на сериозност"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Значително ниво на сериозност"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Високо (много високо) ниво на сериозност"
 
@@ -2163,7 +2174,7 @@ msgid "error_existing_login"
 msgstr "Това име за вход вече се използва."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Моля, въведете бюджета в цели евро."
 
@@ -2199,17 +2210,17 @@ msgid "error_password_mismatch"
 msgstr "Паролите не съвпадат"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Тази дата трябва да съвпада или да е след началната дата."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Тази дата трябва да е преди или да съвпада с крайната дата."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Тази стойност трябва да е положително цяло число."
 
@@ -2320,7 +2331,7 @@ msgstr ""
 "продължите, е необходимо да актуализирате тези промени."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2329,12 +2340,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "План за действие ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Идентификационен доклад ${title}"
 
@@ -2354,7 +2365,7 @@ msgid "french"
 msgstr "Опростени два критерия"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Почти никога"
 
@@ -2364,57 +2375,57 @@ msgid "frequency_almostnever"
 msgstr "Почти никога"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Постоянно"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Не много често"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Веднъж месечно"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Често"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Един път седмично"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Рядко"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Веднъж годишно"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Много често или редовно"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Най-малко един път на ден"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Редовно"
@@ -2442,12 +2453,12 @@ msgid "header_additional_content"
 msgstr "Допълнителна информация"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Допълнителни ресурси за оценка на риска"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Допълнителни ресурси за този модул"
 
@@ -2462,12 +2473,12 @@ msgid "header_country_managers"
 msgstr "Мениджъри за страни"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Разработка и пилотна фаза – 2009-2011 г."
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Партньори в разработването"
 
@@ -2503,18 +2514,18 @@ msgstr "Определяне"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Информация"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Официално стартиране на проекта – септември 2011 г."
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Правни източници и източници от политики"
 
@@ -2524,13 +2535,13 @@ msgid "header_legend"
 msgstr "Легенда"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Лицензи"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Вход"
@@ -2541,12 +2552,12 @@ msgid "header_main_image"
 msgstr "Главно изображение"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Мярка ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Мярка"
 
@@ -2572,12 +2583,12 @@ msgid "header_not_complicated"
 msgstr "Оценката не е сложна"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2612,7 +2623,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2632,7 +2643,7 @@ msgid "header_profile_questions"
 msgstr "Въпроси по профила"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Фази на проекта"
 
@@ -2648,7 +2659,7 @@ msgstr "Въпроси, на които е отговорено, за модул
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Регистрация"
 
@@ -2669,23 +2680,23 @@ msgid "header_risk_aware"
 msgstr "Знаете ли за всички рискове?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Какво е нивото на сериозност на нараняването ?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Колко често хора са изложени на риск?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Изберете приоритета на този риск"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Каква е вероятността това да се случи?"
 
@@ -2697,7 +2708,7 @@ msgid "header_risks"
 msgstr "Рискове"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2757,12 +2768,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2777,17 +2788,17 @@ msgid "header_welcome"
 msgstr "Добре дошли"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Какво е проектът OiRA (онлайн интерактивна оценка на риска)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Защо беше създаден проектът OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Коментари"
 
@@ -2808,142 +2819,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Средно приоритетен риск"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Високо приоритетен риск"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Високо приоритетен риск"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Високо приоритетен риск"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Високо приоритетен риск"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Ниско приоритетен риск"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Ниско приоритетен риск"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Ниско приоритетен риск"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Ниско приоритетен риск"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Средно приоритетен риск"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Средно приоритетен риск"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Средно приоритетен риск"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Средно приоритетен риск"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} риска не са разгледани"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} риска не са разгледани"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} риска не са разгледани"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} риска не са разгледани"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} риска са пропуснати"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} риска са пропуснати"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} риска са пропуснати"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} риска са пропуснати"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Вероятни рискове"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Вероятни рискове"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Вероятни рискове"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Вероятни рискове"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Съществуващи рискове"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Съществуващи рискове"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Съществуващи рискове"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Съществуващи рискове"
 
@@ -2963,7 +2974,7 @@ msgid "help_authentication"
 msgstr "Този текст трябва да обяснява как се извършва регистрация и вход."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Попълнете отговорите на следните въпроси. Въз основа на вашите отговори "
@@ -2991,7 +3002,7 @@ msgstr ""
 "започнете с копие на съществуващ OiRA инструмент.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Посочете колко често този риск се среща в нормална ситуация."
 
@@ -3003,12 +3014,12 @@ msgstr ""
 "подразбиране. Той/тя все пак ще може да промени приоритета."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Посочете колко вероятно е този риск да се срещне в нормална ситуация."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Посочете сериозността, ако този риск възникне."
 
@@ -3105,6 +3116,11 @@ msgstr ""
 "Качване на изображение. Уверете се, че Вашето изображение е в png, jpg или "
 "gif формат и не съдържа специални символи."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3120,7 +3136,7 @@ msgstr ""
 "подход (за елиминиране или намаляване на риска)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Опишете експертното ниво, което е необходимо за да се въведат мерките, "
@@ -3279,7 +3295,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Ако не посочите име, то ще бъде взето от въведените данни."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3366,7 +3382,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Тестова сесия"
 
@@ -3566,13 +3582,13 @@ msgstr "Акаунтът е заключен"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "План за действие"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Бюджет"
 
@@ -3582,27 +3598,22 @@ msgid "label_action_plan_download"
 msgstr "План за действие"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Планиране на края"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Кой носи отговорност?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Планиране на началото"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Добави друга мярка"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3645,8 +3656,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Моля, оставете коментарите, които може да имате по горния въпрос, в това "
@@ -3733,7 +3744,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Описание"
@@ -3763,7 +3774,7 @@ msgstr "Показване на специално уведомление за �
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Оценяване"
 
@@ -3783,10 +3794,19 @@ msgid "label_evaluation_phase"
 msgstr "Фаза на оценяване"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Мерки, които вече са изпълнени"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3861,7 +3881,7 @@ msgstr "Как да извършите оценка на риска"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Определяне"
 
@@ -3869,6 +3889,11 @@ msgstr "Определяне"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Файл с изображение"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3891,7 +3916,7 @@ msgid "label_language"
 msgstr "Език"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Правни източници и източници от политики"
@@ -3926,21 +3951,26 @@ msgstr "Лого"
 msgid "label_logo_selection"
 msgstr "Кое лого бихте желали да поставите в горния ляв ъгъл?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Общ подход (за елиминиране или намаляване на риска)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Конкретни действия, които се изискват, за да бъде следван този подход"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Експертно ниво и/или изисквания, които са необходими"
 
@@ -3998,25 +4028,25 @@ msgid "label_no"
 msgstr "Не"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Няма риск"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Няма риск"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Няма риск"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Няма риск"
@@ -4056,15 +4086,10 @@ msgstr "Парола"
 msgid "label_password_confirm"
 msgstr "Паролата отново"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Предварително попълване"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Подготовка"
 
@@ -4075,7 +4100,7 @@ msgstr "Преглед"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Назад"
@@ -4139,15 +4164,15 @@ msgstr "Можете да изтеглите пълен доклад и план
 msgid "label_register_first"
 msgstr "регистрирайте се"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Изтрий тази мярка"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Доклад"
 
@@ -4159,12 +4184,12 @@ msgstr ""
 "доклада, в това поле."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4184,49 +4209,49 @@ msgid "label_risk_type"
 msgstr "Вид на риска"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Риск без набелязани мерки"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Риск с набелязани мерки"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Риск без набелязани мерки"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Риск без набелязани мерки"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Риск без набелязани мерки"
@@ -4239,7 +4264,7 @@ msgstr "Запазете и добавете друг риск."
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Запазване и продължаване"
 
@@ -4264,7 +4289,7 @@ msgid "label_sector_title"
 msgstr "Име на сектор."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Изберете една или повече от предлаганите общи мерки."
 
@@ -4294,7 +4319,7 @@ msgid "label_show_less_hellip"
 msgstr "Показване на по-малко"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "Прочетете повече ${read_more} за този риск."
 
@@ -4324,7 +4349,7 @@ msgid "label_start_identification"
 msgstr "Стартиране на определянето на риска"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Стартиране"
 
@@ -4369,29 +4394,29 @@ msgid "label_surveygroup_title"
 msgstr "Име на импортирания OiRA инструмент"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "високо"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "ниско"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "средно"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Име"
 
@@ -4451,12 +4476,12 @@ msgid "label_user_title"
 msgstr "Име"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 мерки)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(без мерки)"
 
@@ -4504,7 +4529,7 @@ msgid "limitations"
 msgstr "ограничения"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Вход"
 
@@ -4596,7 +4621,7 @@ msgid "menu_import"
 msgstr "Импортиране на OiRA инструмент"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4702,32 +4727,32 @@ msgid "nav_usermanagement"
 msgstr "Управление на потребители"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Помощ"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Излизане"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Настройки"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Статус"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Моите оценки"
 
@@ -4777,27 +4802,27 @@ msgid "notice_country_manager"
 msgstr "Менджър за страна за ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Онлайн интерактивна"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Оценка на риска"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4817,7 +4842,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4829,7 +4854,7 @@ msgid "password_policy_conditions"
 msgstr "Вашата парола за потвърждение"
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Официалното стартиране на инструмента се планира за септември 2011 г., след "
@@ -4858,45 +4883,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Висок"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Нисък"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Среден"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Голяма"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Средна"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Малка"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% завършен"
 
@@ -4948,18 +4973,13 @@ msgstr "Нямате регистрация? Тогава, моля, ${register_
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4972,7 +4992,7 @@ msgstr ""
 "предимства:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4987,17 +5007,17 @@ msgstr ""
 "полето по-долу."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Този доклад се базира на OiRA инструмента '${title}' с дата на редакция "
@@ -5029,35 +5049,35 @@ msgid "request_an_email_reminder"
 msgstr "заявка за имейл напомняне"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Това е ${priority_value} приоритетен риск."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "високо"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "ниско"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "средно"
 
@@ -5077,7 +5097,7 @@ msgid "risk_solution_header"
 msgstr "Мярка ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Този риск все още е необходимо да бъде инвентаризиран."
@@ -5125,46 +5145,46 @@ msgid "select_add_existing_measure"
 msgstr "Изберете или добавете мерки, които вече са въведени."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Не много високо ниво на сериозност"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Необходимо е спиране на работа за по-малко от 3 дни"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Високо ниво на сериозност"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Необходимо е спиране на работа за повече от три дни"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Много високо ниво на серозност"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "необратими наранявания, неизлечима болест, смърт"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Ниско ниво на сериозност"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Не е необходимо спиране на работа"
 
@@ -5238,7 +5258,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "За нас"
 
@@ -5253,7 +5273,7 @@ msgid "title_account_settings"
 msgstr "Настройки на акаунта"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Смяна на парола"
@@ -5264,7 +5284,7 @@ msgid "title_client_help"
 msgstr "Помощен текст на клиента"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Мярка"
 
@@ -5299,7 +5319,7 @@ msgid "title_import_sector_survey"
 msgstr "Импортиране на сектор и OiRA инструментa"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Добавени рискове (от Вас)"
@@ -5326,8 +5346,8 @@ msgstr "Статус на ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Онлайн интерактивна оценка на риска"
 
@@ -5352,19 +5372,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Статус на ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Съдържание"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Този риск не присъства във Вашата организация, но тъй като секторната "
@@ -5372,7 +5392,7 @@ msgstr ""
 "включен в доклада."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Този риск не присъства във Вашата организация, но тъй като секторната "
@@ -5380,7 +5400,7 @@ msgstr ""
 "включен в доклада."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Този риск все още не е оценен, но тъй като той се счита с „висок приоритет“ "
@@ -5411,7 +5431,7 @@ msgid "use_it_to_full_report"
 msgstr "Използвайте го, за да"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Използвайте го, за да"
 
@@ -5421,12 +5441,12 @@ msgid "use_it_to_measures_report"
 msgstr "Използвайте го, за да"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Използвайте го, за да"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Използвайте го, за да"
 
@@ -5441,7 +5461,7 @@ msgid "warn_fix_errors"
 msgstr "Моля, поправете посочените грешки."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Отговорихте отрицателно на горното твърдение."
@@ -5465,6 +5485,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Да"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Добави друга мярка"
+
+#~ msgid "label_prefill"
+#~ msgstr "Предварително попълване"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Не са направени промени в мерките във Вашия план за действие."

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -676,7 +676,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -720,7 +720,7 @@ msgstr "No"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1571,10 +1571,6 @@ msgstr "Quant a"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Creat per l'${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "basada en"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4409,6 +4405,11 @@ msgstr "Mitjana"
 msgid "label_title"
 msgstr "Títol"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "basada en ${tool_title} "
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4818,7 +4819,7 @@ msgid "optional"
 msgstr "Opcional"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5464,6 +5465,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sí"
+
+#~ msgid "based on"
+#~ msgstr "basada en"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Afegir una altra mesura"

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -237,7 +237,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -586,7 +586,7 @@ msgstr "Informació"
 msgid "Information"
 msgstr "Informació"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "El format de fitxer de l’imatge no és vàlid. Si us plau, utilitzeu PNG, JPEG "
@@ -1053,7 +1053,7 @@ msgstr "Estàndard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Mesures pre-establertes"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1127,7 +1127,7 @@ msgstr ""
 "L’estructura bàsica d’una avaluació de riscos interactiva en línia "
 "consisteix en:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1526,15 +1526,14 @@ msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descrigui: 1) el seu enfocament general pel que fa a l'eliminació o —si el "
 "risc no es pot evitar— la reducció del risc; 2) les accions concretes que es "
-"requereixen per implementar aquest enfocament (per eliminar o reduir el "
-"risc)"
+"requereixen per implementar aquest enfocament (per eliminar o reduir el risc)"
 
 #. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Descrigui: 3) el nivell de competència necessari per implementar la mesura, per "
-"exemple, \"sentit comú (no calen coneixements sobre seguretat i salut "
+"Descrigui: 3) el nivell de competència necessari per implementar la mesura, "
+"per exemple, \"sentit comú (no calen coneixements sobre seguretat i salut "
 "laborals)\", \"no calen competències específiques sobre seguretat i salut "
 "laborals, però sí coneixements bàsics sobre el tema o formació i/o consulta "
 "d'orientació sobre el tema\" o \"expert en seguretat i salut laborals\". "
@@ -2197,17 +2196,17 @@ msgid "error_password_mismatch"
 msgstr "Les contrasenyes no coincideixen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Aquesta data ha de ser la data final o una data posterior."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Aquesta data ha de ser la data final o una data anterior."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Aquest valor ha de ser un número enter positiu."
 
@@ -2993,7 +2992,7 @@ msgstr ""
 "una còpia d'una eina OiRA existent."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indiqui amb quina freqüència es produeix aquest risc en una situació normal."
@@ -3006,13 +3005,13 @@ msgstr ""
 "així, l'usuari final podrà modificar-la."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indiqui la probabilitat que es produeixi aquest risc en una situació normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indiqui la gravetat en cas de produir-se aquest risc."
 
@@ -3289,7 +3288,7 @@ msgstr "Si no especifica cap títol, s'agafarà de la introducció."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Inici"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3645,7 +3644,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3793,9 +3792,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Afegir altres mesures"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4087,7 +4086,7 @@ msgstr "Previsualitzar"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
@@ -4250,7 +4249,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Desar i continuar"
 
@@ -4292,6 +4291,11 @@ msgstr "Iniciar una sessió nova escollint una de les eines sectorials següents
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Seleccionar mesures pre-establertes"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5358,7 +5362,7 @@ msgstr "Contingut"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Mostrar/ocultar menú"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,7 +83,7 @@ msgstr ""
 "${provide-evidence} corresponent a l’avaluació de riscos a disposició de les "
 "autoritats competents (Inspecció de Treball)"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr "Afegir contingut de la biblioteca"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -237,7 +237,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -268,7 +268,7 @@ msgstr "Eines OiRA disponibles"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -298,7 +298,7 @@ msgstr "Països candidats"
 msgid "Candidate country"
 msgstr "País candidat "
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Canviar l'adreça electrònica"
 
@@ -334,11 +334,11 @@ msgstr ""
 "Contingut: tota la informació i aportacions fetes durant l’elaboració de "
 "l'avaluació de riscos."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Conté: una visió general sobre les mesures que s'han d'aplicar."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Conté: una visió general sobre els riscos identificats"
 
@@ -377,16 +377,16 @@ msgstr "Agrupació i informació del país del client."
 msgid "Country manager"
 msgstr "Responsable nacional"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 "Llicència de Creative Commons Reconeixement-CompartirIgual 2.5 Genèrica"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Llicència de Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -444,15 +444,15 @@ msgstr "Descarregar el pla d'acció"
 msgid "Download the full report"
 msgstr "Descarregar  l'informe complet"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Descarregar la visió general sobre les mesures"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Descarregar la visió general sobre els riscos"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Correu electrònic"
@@ -526,7 +526,7 @@ msgstr "Carpeta"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Format: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Format: Portable Document Format (.pdf)"
 
@@ -534,7 +534,7 @@ msgstr "Format: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Alemanya"
 
@@ -561,7 +561,7 @@ msgstr ""
 "Tanmateix, podeu utilitzar les estones de què disposeu i reprendre "
 "l’avaluació en un altre moment en el mateix punt en què la vareu deixar."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Voldria compartir el següent enllaç"
 
@@ -577,8 +577,7 @@ msgstr ""
 msgid "Important"
 msgstr "Important"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informació"
 
@@ -587,7 +586,7 @@ msgstr "Informació"
 msgid "Information"
 msgstr "Informació"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "El format de fitxer de l’imatge no és vàlid. Si us plau, utilitzeu PNG, JPEG "
@@ -623,11 +622,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "desada"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Obteniu més informació sobre aquesta eina…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -639,7 +638,7 @@ msgstr "Inici de sessió"
 msgid "Manage"
 msgstr "Per gestionar"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Mesura"
@@ -662,13 +661,13 @@ msgstr ""
 "d’un accident, etc.)."
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Controlar les mesures que seran implementades durant els propers 3 mesos"
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Supervisar si els riscos/mesures es tracten adequadament."
 
@@ -797,12 +796,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Ajuda en línia"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Resum de mesures"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Resum de riscos"
@@ -821,8 +822,8 @@ msgstr ""
 "seguretat i salut en el treball, etc.)."
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Enviar informació a les persones concernides."
 
@@ -853,9 +854,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Si us plau, consulteu els exemples a la part inferior:"
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Posposat"
 
@@ -898,7 +899,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Més informació"
 
@@ -929,8 +930,8 @@ msgstr ""
 "continuar amb l’avaluació que esteu realitzant o per començar una de nova."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -951,11 +952,11 @@ msgstr "Risc"
 msgid "Risk assessments made with this tool"
 msgstr "Avaluacions de riscos realitzades amb aquesta eina"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Correcte"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Actuar"
 
@@ -1033,7 +1034,7 @@ msgstr "Compartiu aquesta eina OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Mostrar la biblioteca de ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Iniciar sessió"
 
@@ -1049,6 +1050,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Estàndard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1103,7 +1108,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Països Baixos"
 
@@ -1122,7 +1127,7 @@ msgstr ""
 "L’estructura bàsica d’una avaluació de riscos interactiva en línia "
 "consisteix en:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1229,7 +1234,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Aquesta eina cal que arribi a tothom. Compartiu-la!"
 
@@ -1237,8 +1242,8 @@ msgstr "Aquesta eina cal que arribi a tothom. Compartiu-la!"
 msgid "Tip"
 msgstr "Consell"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Activar la pantalla d'ajuda"
 
@@ -1250,9 +1255,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "No respost"
 
@@ -1370,36 +1375,36 @@ msgid "Your password was successfully changed."
 msgstr "La contrasenya s'ha modificat correctament."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "El codi font de l'aplicació OiRA té una llicència ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "El contingut de les eines sectorials d'OiRA té una ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "Tots els usuaris poden utilitzar les eines sectorials d'OiRA de manera "
 "gratuïta."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Més informació sobre el projecte OiRA (en anglès)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Estratègia Comunitària Europea de Salut i Seguretat en el Treball per al "
 "període 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "L'experiència demostra que ${key}. És per això que l'EU-OSHA ha desenvolupat "
@@ -1410,51 +1415,51 @@ msgstr ""
 "de mesures i acabant per la supervisió i els ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "aplicació web gratuïta i fàcil d'utilitzar"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "avaluació"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identificació"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "una avaluació adequada dels riscos és clau per aconseguir llocs de treball "
 "saludables"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "mesures de prevenció"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "informes"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "procés d'avaluació de riscos pas a pas"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "L'aplicació web OiRA proporciona accés a les eines sectorials d'avaluació de "
 "riscos creades i mantingudes per les organitzacions sectorials nacionals."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "L'${agency} reclama el desenvolupament d'eines simples per facilitar "
@@ -1467,7 +1472,7 @@ msgstr ""
 "la qual cosa el projecte OiRA té l'objectiu de solucionar."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "El projecte OiRA i l'aplicació web relacionada han estat desenvolupats per "
@@ -1479,14 +1484,14 @@ msgstr ""
 "a terme amb la participació i les aportacions dels sindicats FNV, CNV i MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Els socis tècnics següents van contribuir al desenvolupament del projecte "
 "OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "L'Agència també va rebre assessorament estratègic i d'experts per part d'un "
@@ -1495,12 +1500,12 @@ msgstr ""
 "designats pels grups d'interès del Comitè, per la Comissió i per l'EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "les micro i petites empreses presenten algunes deficiències"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Tot i que hi ha mesures que no comporten despeses, no són majoria. Per tant, "
@@ -1508,21 +1513,27 @@ msgstr ""
 "anual."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Nomeni una persona de l'empresa que sigui responsable de la implementació "
 "d'aquesta mesura. Aquesta persona tindrà autoritat per realitzar els passos "
 "descrits al pla i/o la responsabilitat d'assegurar-se que es duguin a terme."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descrigui: 1) el seu enfocament general pel que fa a l'eliminació o —si el "
 "risc no es pot evitar— la reducció del risc; 2) les accions concretes que es "
 "requereixen per implementar aquest enfocament (per eliminar o reduir el "
-"risc); 3) el nivell de competència necessari per implementar la mesura, per "
+"risc)"
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Descrigui: 3) el nivell de competència necessari per implementar la mesura, per "
 "exemple, \"sentit comú (no calen coneixements sobre seguretat i salut "
 "laborals)\", \"no calen competències específiques sobre seguretat i salut "
 "laborals, però sí coneixements bàsics sobre el tema o formació i/o consulta "
@@ -1588,7 +1599,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: sentències positives, incloses als mòduls."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Afegir"
 
@@ -1636,7 +1647,7 @@ msgstr "Cancel·lar"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Tancar"
 
@@ -1969,7 +1980,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "L'avaluació de riscos ha estat efectuada automàticament per l'eina. Podreu "
@@ -2020,7 +2031,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Després del desenvolupament tècnic de l'eina el 2009, durant el 2010 (i fins "
@@ -2062,17 +2073,17 @@ msgid "effect_high"
 msgstr "Gravetat elevada (molt elevada)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Gravetat baixa"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Gravetat significativa"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Gravetat elevada (molt elevada)"
 
@@ -2148,7 +2159,7 @@ msgid "error_existing_login"
 msgstr "Aquest nom d'inici de sessió ja està ocupat."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Introdueixi el pressupost mitjançant un import enter en euros."
 
@@ -2186,17 +2197,17 @@ msgid "error_password_mismatch"
 msgstr "Les contrasenyes no coincideixen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Aquesta data ha de ser la data final o una data posterior."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Aquesta data ha de ser la data final o una data anterior."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Aquest valor ha de ser un número enter positiu."
 
@@ -2307,7 +2318,7 @@ msgstr ""
 "de continuar, cal actualitzar aquests canvis."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 "Aquest risc s’ha establert com a existent per defecte. No es pot canviar."
@@ -2317,12 +2328,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Pla d'acció ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Informe d'identificació ${title}"
 
@@ -2342,7 +2353,7 @@ msgid "french"
 msgstr "Dos criteris simplificats"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Gairebé mai"
 
@@ -2352,57 +2363,57 @@ msgid "frequency_almostnever"
 msgstr "Gairebé mai"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Constantment"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "No gaire sovint"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Un cop per mes"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Sovint"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Un cop per setmana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Poc freqüent"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Un cop per any"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Amb molta freqüència o regularitat"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Com a mínim un cop per dia"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Freqüentment"
@@ -2428,12 +2439,12 @@ msgid "header_additional_content"
 msgstr "Contingut addicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Recursos addicionals per avaluar el risc"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Recursos additionals per a aquest mòdul"
 
@@ -2448,12 +2459,12 @@ msgid "header_country_managers"
 msgstr "Responsables nacionals"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Desenvolupament i fase pilot: 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Socis de desenvolupament"
 
@@ -2491,18 +2502,18 @@ msgstr "Identificació"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informació"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Llançament oficial del projecte: setembre del 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Referències legals i de la política"
 
@@ -2512,13 +2523,13 @@ msgid "header_legend"
 msgstr "Llegenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Llicències"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Inici de sessió"
@@ -2529,12 +2540,12 @@ msgid "header_main_image"
 msgstr "Imatge principal"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Mesura ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Mesura"
 
@@ -2560,12 +2571,12 @@ msgid "header_not_complicated"
 msgstr "L'avaluació no és complicada"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2600,7 +2611,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2620,7 +2631,7 @@ msgid "header_profile_questions"
 msgstr "Preguntes perfil"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Fases del projecte"
 
@@ -2636,7 +2647,7 @@ msgstr "Preguntes respostes per mòdul"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrar-se"
 
@@ -2657,23 +2668,23 @@ msgid "header_risk_aware"
 msgstr "És conscient de tots els riscos?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Fins a quin punt és greu aquest dany?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Amb quina freqüència hi ha persones exposades a aquest risc?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Seleccioni la prioritat d'aquest risc"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Quina probabilitat hi ha que es produeixi aquest risc?"
 
@@ -2685,7 +2696,7 @@ msgid "header_risks"
 msgstr "Riscos"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2745,12 +2756,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2765,19 +2776,19 @@ msgid "header_welcome"
 msgstr "Benvinguda"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "Què és el projecte OiRA (Online Interactive Risk Assessment, avaluació de "
 "riscos interactiva en línia)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Motius de la creació del projecte OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Comentaris"
 
@@ -2798,142 +2809,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Riscos de prioritat mitjana"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Risc de prioritat alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Riscos de prioritat alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Riscos de prioritat alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Riscos de prioritat alta"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Risc de prioritat baixa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Riscos de prioritat baixa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Riscos de prioritat baixa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Riscos de prioritat baixa"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Risc de prioritat mitjana"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Riscos de prioritat mitjana"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Riscos de prioritat mitjana"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Riscos de prioritat mitjana"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Risc posposat"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Riscos posposats"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Riscos posposats"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Riscos posposats"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Risc sense resposta"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Riscos sense resposta"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Riscos sense resposta"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Riscos sense resposta"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Possible risc"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Possibles riscos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Possibles riscos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Possibles riscos"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Riscos existents"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Riscos existents"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Riscos existents"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Riscos existents"
 
@@ -2954,7 +2965,7 @@ msgstr ""
 "Aquest text hauria d'explicar com realitzar el registre i l'inici de sessió."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Si us plau, contesteu les preguntes següents. A partir de les vostres "
@@ -2982,7 +2993,7 @@ msgstr ""
 "una còpia d'una eina OiRA existent."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indiqui amb quina freqüència es produeix aquest risc en una situació normal."
@@ -2995,13 +3006,13 @@ msgstr ""
 "així, l'usuari final podrà modificar-la."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indiqui la probabilitat que es produeixi aquest risc en una situació normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indiqui la gravetat en cas de produir-se aquest risc."
 
@@ -3095,6 +3106,11 @@ msgstr ""
 "Pugi una imatge. Asseguri's que la imatge tingui format .png, .jpg o .gif i "
 "que no contingui cap caràcter especial."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3110,7 +3126,7 @@ msgstr ""
 "enfocament (per eliminar o reduir el risc)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Descrigui el nivell de competència necessari per implementar la mesura, per "
@@ -3271,7 +3287,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Si no especifica cap títol, s'agafarà de la introducció."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3358,7 +3374,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Sessió de prova"
 
@@ -3555,13 +3571,13 @@ msgstr "El compte està bloquejat"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Pla d'acció"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Pressupost"
 
@@ -3571,27 +3587,22 @@ msgid "label_action_plan_download"
 msgstr "Pla d'acció"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Final de la planificació"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Qui n'és responsable?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Inici de la planificació"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Afegir una altra mesura"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3634,8 +3645,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Si us plau, deixeu en aquest camp qualsevol comentari que pugueu tenir sobre "
@@ -3722,7 +3733,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Descripció"
@@ -3752,7 +3763,7 @@ msgstr ""
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Avaluació"
 
@@ -3772,9 +3783,18 @@ msgid "label_evaluation_phase"
 msgstr "Fase d'avaluació"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3850,7 +3870,7 @@ msgstr "Preparant la seva avaluació de riscos"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identificació"
 
@@ -3858,6 +3878,11 @@ msgstr "Identificació"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Fitxer d'imatge"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3880,7 +3905,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referències legals i sobre polítiques"
@@ -3915,21 +3940,26 @@ msgstr "Logotip"
 msgid "label_logo_selection"
 msgstr "Quin logotip vol mostrar a la cantonada superior esquerra?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Enfocament general (per eliminar o reduir el risc)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Accions concretes requerides per implementar aquest enfocament"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Nivell de competència i/o requisits necessaris"
 
@@ -3985,25 +4015,25 @@ msgid "label_no"
 msgstr "No"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "No hi ha cap risc"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "No hi ha cap riscos"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "No hi ha cap riscos"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "No hi ha cap riscos"
@@ -4043,15 +4073,10 @@ msgstr "Contrasenya"
 msgid "label_password_confirm"
 msgstr "Repetició de la contrasenya"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Mesures predeterminades"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Preparació"
 
@@ -4062,7 +4087,7 @@ msgstr "Previsualitzar"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
@@ -4125,15 +4150,15 @@ msgstr "Podeu descarregar un informe complet i un pla d'acció."
 msgid "label_register_first"
 msgstr "registrar-se"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Esborrar aquesta mesura"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Informe"
 
@@ -4145,12 +4170,12 @@ msgstr ""
 "la pregunta de dalt."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4170,49 +4195,49 @@ msgid "label_risk_type"
 msgstr "Tipus de risc"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Risc amb mesura/es"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Risc sense mesura"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Riscos amb mesura/es"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Riscos amb mesura/es"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riscos amb mesura/es"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Riscos sense mesura"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Riscos sense mesura"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riscos sense mesura"
@@ -4225,7 +4250,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Desar i continuar"
 
@@ -4250,7 +4275,7 @@ msgid "label_sector_title"
 msgstr "Títol del sector."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Seleccioni una o més de les mesures comunes facilitades."
 
@@ -4279,7 +4304,7 @@ msgid "label_show_less_hellip"
 msgstr "Mostrar menys"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} sobre aquest risc."
 
@@ -4309,7 +4334,7 @@ msgid "label_start_identification"
 msgstr "Iniciar la identificació de riscos"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Iniciar"
 
@@ -4354,29 +4379,29 @@ msgid "label_surveygroup_title"
 msgstr "Títol de l'eina OiRA importada"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Elevada"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Baixa"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Mitjana"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Títol"
 
@@ -4436,12 +4461,12 @@ msgid "label_user_title"
 msgstr "Nom"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 mesures)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(sense mesures)"
 
@@ -4488,7 +4513,7 @@ msgid "limitations"
 msgstr "Limitacions"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Iniciar sessió"
 
@@ -4579,7 +4604,7 @@ msgid "menu_import"
 msgstr "Importar una eina OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4684,32 +4709,32 @@ msgid "nav_usermanagement"
 msgstr "Administració d'usuaris"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Ajuda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Tancar la sessió"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Configuració"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Grau d’emplenament"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Avaluacions desades"
 
@@ -4759,27 +4784,27 @@ msgid "notice_country_manager"
 msgstr "Responsable nacional de: ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Avaluació de riscos"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "interactiva en línia"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4799,7 +4824,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4813,7 +4838,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "El llançament oficial de l'eina està previst per al setembre del 2011, un "
@@ -4843,45 +4868,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Elevada"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Baixa"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Mitjana"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Elevada"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Mitjana"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Baixa"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Complet"
 
@@ -4933,18 +4958,13 @@ msgstr "No disposa de compte? Llavors, cal que abans ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4956,7 +4976,7 @@ msgstr ""
 "descarregar. Registreu-vos en un sol pas i accedireu als avantatges següents:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4969,17 +4989,17 @@ msgstr ""
 "afegir comentaris addicionals a l'informe al camp que trobarà a continuació."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Aquest informe s'ha basat en l'eina OiRA \"${title}\" amb la data de revisió "
@@ -5011,35 +5031,35 @@ msgid "request_an_email_reminder"
 msgstr "sol·liciti un recordatori per correu electrònic"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Aquest és un risc de prioritat ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "elevada"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "baixa"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "mitjana"
 
@@ -5059,7 +5079,7 @@ msgid "risk_solution_header"
 msgstr "Mesura ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Aquest risc encara s'ha d'inventariar."
@@ -5107,46 +5127,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "No gaire greu"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Cal interrompre la feina menys de 3 dies"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Greu"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Cal interrompre la feina més de 3 dies"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Molt greu"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Lesions irreversibles, malaltia incurable, mort"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Baixa"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "No cal interrompre la feina"
 
@@ -5216,7 +5236,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Quant a"
 
@@ -5231,7 +5251,7 @@ msgid "title_account_settings"
 msgstr "Configuració del compte"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Canviar la contrasenya"
@@ -5242,7 +5262,7 @@ msgid "title_client_help"
 msgstr "Text d'ajuda per al client"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Mesura"
 
@@ -5277,7 +5297,7 @@ msgid "title_import_sector_survey"
 msgstr "Importar eina OiRA i de sector"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Riscos afegits (per vostè)"
@@ -5304,8 +5324,8 @@ msgstr "Estat de ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA: avaluació de riscos interactiva en línia"
 
@@ -5330,19 +5350,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Estat d’${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Contingut"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Aquest risc no existeix a la seva organització però, com que l'organització "
@@ -5350,7 +5370,7 @@ msgstr ""
 "informe."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Aquest risc no existeix a la seva organització però, com que l'organització "
@@ -5358,7 +5378,7 @@ msgstr ""
 "informe."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Aquest risc encara no s’ha avaluat, però, com que es considera d’alta "
@@ -5386,7 +5406,7 @@ msgid "use_it_to_full_report"
 msgstr "Feu-lo servir per"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Feu-lo servir per"
 
@@ -5396,12 +5416,12 @@ msgid "use_it_to_measures_report"
 msgstr "Feu-lo servir per"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Feu-lo servir per"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Feu-lo servir per"
 
@@ -5416,7 +5436,7 @@ msgid "warn_fix_errors"
 msgstr "Solucioni els errors indicats."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Ha respost a l'afirmació anterior de forma negativa."
@@ -5440,6 +5460,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sí"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Afegir una altra mesura"
+
+#~ msgid "label_prefill"
+#~ msgstr "Mesures predeterminades"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "No s’han fet canvis en les mesures al vostre pla d’acció."

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -663,7 +663,7 @@ msgid "Montenegro"
 msgstr "Černá Hora"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -707,7 +707,7 @@ msgstr "Ne"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1546,10 +1546,6 @@ msgstr "O"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Vytvořil ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4335,6 +4331,11 @@ msgstr "riziko se střední prioritou"
 msgid "label_title"
 msgstr "Název"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4743,7 +4744,7 @@ msgid "optional"
 msgstr "Volitelný"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} dozorovým orgánům (např. inspektorátu práce)"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Přidat obsah z knihovny"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -265,7 +265,7 @@ msgstr "Dostupné nástroje OiRA"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgstr "Kandidátské země"
 msgid "Candidate country"
 msgstr "Kandidátská země"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Změnit e-mailovou adresu"
 
@@ -329,11 +329,11 @@ msgstr ""
 "Obsahuje: všechny informace, vstupy a data, které jste do dokumentu "
 "zapracovali  během celého postupu hodnocení rizik"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Obsahuje: přehled opatření, která mají být provedena."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Obsahuje: přehled zjištěných rizik"
 
@@ -370,15 +370,15 @@ msgstr "Informace o zemi a skupině pro klienta."
 msgid "Country manager"
 msgstr "Manažer pro danou zemi"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Generická licence Creative Commons Attribution-ShareAlike 2.5"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licence Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -436,15 +436,15 @@ msgstr "Stáhněte si akční plán"
 msgid "Download the full report"
 msgstr "Stáhněte si úplné znění zprávy"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Stáhnout přehled opatření"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Stáhnout přehled rizik"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -518,7 +518,7 @@ msgstr "Složka"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formát: Excel (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Formát: PDF (.pdf)"
 
@@ -526,7 +526,7 @@ msgstr "Formát: PDF (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Německo"
 
@@ -554,7 +554,7 @@ msgstr ""
 "máte k dispozici, a poté se k němu v příhodnou chvíli vrátit a začít tam, "
 "kde jste minule skončili."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Chci se s vámi podělit o následující informace"
 
@@ -570,8 +570,7 @@ msgstr ""
 msgid "Important"
 msgstr "Důležité"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informace"
 
@@ -580,7 +579,7 @@ msgstr "Informace"
 msgid "Information"
 msgstr "Informace"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -614,11 +613,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "uloženo"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Další informace o tomto nástroji…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -630,7 +629,7 @@ msgstr "Přihlašovací jméno"
 msgid "Manage"
 msgstr "řízení"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Opatření"
@@ -649,13 +648,13 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "sledování a hodnocení toho, zda byla zavedena potřebná opatření,"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Kontrola plnění opatření, která budou přijata v následujících 3 měsících."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Sledovat, zda jsou rizika/opatření řádně řešena."
 
@@ -787,12 +786,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online pomoc"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Přehled opatření"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Přehled rizik"
@@ -810,8 +811,8 @@ msgstr ""
 "BOZP, zaměstnavateli, odborníkům na prevenci rizik …)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Předat informace dotčeným osobám."
 
@@ -841,9 +842,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Viz příklady uvedené pod formulářem."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Odloženo"
 
@@ -884,7 +885,7 @@ msgstr "předložení důkazů dozorovým orgánům,"
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Více informací"
 
@@ -918,8 +919,8 @@ msgstr ""
 "započatém hodnocení nebo zahájit hodnocení nové."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Odstranit"
 
@@ -940,11 +941,11 @@ msgstr "Riziko"
 msgid "Risk assessments made with this tool"
 msgstr "Hodnocení rizik provedená tímto nástrojem."
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Pozornost"
 
@@ -1022,7 +1023,7 @@ msgstr "Sdílejte tento nástroj OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Zobrazit knihovnu z ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Přihlaste se"
 
@@ -1038,6 +1039,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1092,7 +1097,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nizozemí"
 
@@ -1109,7 +1114,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Základní struktura on-line interaktivního hodnocení rizik obsahuje:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1215,7 +1220,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Svět by se měl o tomto nástroji dozvědět! Sdílejte jej!"
 
@@ -1223,8 +1228,8 @@ msgstr "Svět by se měl o tomto nástroji dozvědět! Sdílejte jej!"
 msgid "Tip"
 msgstr "Tip"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Přepínejte nápovědu na obrazovce"
 
@@ -1236,9 +1241,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Nezodpovězeno"
 
@@ -1355,34 +1360,34 @@ msgid "Your password was successfully changed."
 msgstr "Vaše heslo bylo úspěšně změněno."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Zdrojový kód pro aplikaci OiRA ${GPL} podléhá licenci.."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "Obsah sektorových nástrojů OiRA podléhá licenci pod a ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "Sektorové nástroje OiRA mohou používat zdarma všichni uživatelé."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Více informací o projektu OiRA (v angličtině)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Strategie Evropského společenství týkající se bezpečnosti a zdraví při práci "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Zkušenosti ukazují, že ${key}. Proto EU-OSHA vyvinul ${easy} (“OiRA” - "
@@ -1392,42 +1397,42 @@ msgstr ""
 "${preventive_actions} a podnikání kroků, k monitorování a ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "snadná a bezplatná internetová aplikace"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "vyhodnocení"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identifikace"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "náležité vyhodnocení rizik je klíčem ke zdravým pracovištím "
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "preventivní kroky"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "podávání zpráv"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "proces vyhodnocení rizik krok za krokem"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Internetová aplikace OiRA poskytuje přístup k sektorovým nástrojům "
@@ -1435,7 +1440,7 @@ msgstr ""
 "národní úrovni."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} volá po rozvoji jednoduchých nástrojů k usnadnění vyhodnocení "
@@ -1447,7 +1452,7 @@ msgstr ""
 "OiRA za cíl překonat."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Projekt OiRA a jeho související internetovou aplikaci vyvinul ${eu-osha} "
@@ -1458,12 +1463,12 @@ msgstr ""
 "a za účasti odborových organizací FNV, CNV a MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "K rozvoji projektu OiRA přispěli následující techničtí partneři:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Správní výbor také poskytl agentuře strategické a expertní rady ohledně "
@@ -1471,12 +1476,12 @@ msgstr ""
 "výboru byli určeni zájmovými skupinami v Radě, Komisí a EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikropodniky a makropodniky mají určité nedostatky"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Ačkoliv některé kroky nestojí žádné peníze, mnoho z nich stojí. Proto by měl "
@@ -1484,20 +1489,26 @@ msgstr ""
 "třeba."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Ustanovte někoho ve své společnosti, kdo bude odpovědný za implementaci "
 "tohoto kroku. Tato osoba bude oprávněná podniknout kroky popsané v plánu a/"
 "nebo bude odpovědná za zajištění, že se tyto kroky provádějí."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Popište: 1) jaký je váš obecný přístup k eliminaci nebo (pokud se riziku "
 "nedá vyhnout) snížení rizika; 2) konkrétní krok/y vyžadované k implementaci "
-"tohoto přístupu (k eliminaci nebo snížení rizika); 3) míru znalostí "
+"tohoto přístupu (k eliminaci nebo snížení rizika)"
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Popište: 3) míru znalostí "
 "potřebných k implementaci kroku, např. \"zdravý rozum (nevyžadují se žádné "
 "znalosti BOZP)\", \"žádné specifické znalosti BOZP, ale vyžadují se "
 "minimální znalosti BOZP nebo znalosti nebo školení a/nebo konzultace "
@@ -1562,7 +1573,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: kladná sdělení obsažená v modulech."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Přidat"
 
@@ -1610,7 +1621,7 @@ msgstr "Zrušit"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1931,7 +1942,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Nástroj provedl hodnocení rizika automaticky. Prioritu tohoto rizika budete "
@@ -1983,7 +1994,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Po technickém rozvoji nástroje v roce 2009 agentura v roce 2010 (až do první "
@@ -2024,17 +2035,17 @@ msgid "effect_high"
 msgstr "Vysoká (velmi vysoká) závažnost"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Malá závažnost"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Významná závažnost"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Vysoká (velmi vysoká) závažnost"
 
@@ -2109,7 +2120,7 @@ msgid "error_existing_login"
 msgstr "Toto přihlašovací jméno již existuje."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Zadejte prosím rozpočet v celých EUR"
 
@@ -2145,17 +2156,17 @@ msgid "error_password_mismatch"
 msgstr "Hesla se neshodují"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Toto datum musí být k počátečnímu datu nebo po něm."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Toto datum musí být před datem ukončení."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Tato hodnota musí být kladné celé číslo."
 
@@ -2264,7 +2275,7 @@ msgstr ""
 "být všechny změny v nástroji OiRA vnořeny do vaší relace."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2273,12 +2284,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Akční plán ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Identifikační zpráva ${title}"
 
@@ -2298,7 +2309,7 @@ msgid "french"
 msgstr "Dvě zjednodušená kritéria"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Téměř nikdy"
 
@@ -2308,57 +2319,57 @@ msgid "frequency_almostnever"
 msgstr "Téměř nikdy"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Neustále"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Nepříliš často"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Jednou měsíčně"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Často"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Jednou týdně"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Zřídkakdy"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Jednou ročně"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Velmi často nebo pravidelně"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Minimálně jednou denně"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Pravidelně"
@@ -2385,12 +2396,12 @@ msgid "header_additional_content"
 msgstr "Další obsah"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Další zdroje pro hodnocení rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Dodatečné zdroje pro tento modul"
 
@@ -2405,12 +2416,12 @@ msgid "header_country_managers"
 msgstr "Manažeři pro danou zemi"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Rozvojová a pilotní fáze 2009 - 2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Partneři rozvoje"
 
@@ -2446,18 +2457,18 @@ msgstr "Identifikace"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informace"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Oficiální spuštění projektu - září 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Odkazy na právní předpisy a postupy"
 
@@ -2467,13 +2478,13 @@ msgid "header_legend"
 msgstr "Vysvětlivky"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licence"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Přihlášení"
@@ -2484,12 +2495,12 @@ msgid "header_main_image"
 msgstr "Hlavní obrázek"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Krok ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Krok"
 
@@ -2515,12 +2526,12 @@ msgid "header_not_complicated"
 msgstr "Vyhodnocení není komplikované"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2555,7 +2566,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2575,7 +2586,7 @@ msgid "header_profile_questions"
 msgstr "Otázky týkající se profilu"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Fáze projektu"
 
@@ -2591,7 +2602,7 @@ msgstr "Zodpovězené otázky na jeden modul"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrovat"
 
@@ -2612,23 +2623,23 @@ msgid "header_risk_aware"
 msgstr "Jste si vědom/a všech rizik?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Jaká je závažnost škody?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Jak často jsou lidé tomuto riziku vystaveni?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Zvolte prioritu pro toto riziko"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Jaká je šance na to, že se toto riziko vyskytne?"
 
@@ -2640,7 +2651,7 @@ msgid "header_risks"
 msgstr "Rizika"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2700,12 +2711,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2720,17 +2731,17 @@ msgid "header_welcome"
 msgstr "Vítejte"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Co je projekt OiRA (Online interaktivní vyhodnocení rizik)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Proč projekt OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Připomínky"
 
@@ -2751,142 +2762,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Riziko střední závažnosti"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Rizika vysoce závažná"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Rizika vysoce závažná"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Rizika vysoce závažná"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Rizika vysoce závažná"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Rizika nízké závažnosti"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Rizika nízké závažnosti"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Rizika nízké závažnosti"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Rizika nízké závažnosti"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Rizika střední závažnosti"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Rizika střední závažnosti"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Rizika střední závažnosti"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Rizika střední závažnosti"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Odložená rizika"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Odložená rizika"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Odložená rizika"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Odložená rizika"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Nevyřešená rizika"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Nevyřešená rizika"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Nevyřešená rizika"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Nevyřešená rizika"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Možná rizika"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Možná rizika"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Možná rizika"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Možná rizika"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Existující rizika"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Existující rizika"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Existující rizika"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Existující rizika"
 
@@ -2906,7 +2917,7 @@ msgid "help_authentication"
 msgstr "Tento text by měl vysvětlit, jak se registrovat a přihlásit."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Odpovězte prosím na tyto otázky. Systém na základě vašich odpovědí vypočítá "
@@ -2932,7 +2943,7 @@ msgstr ""
 "kopií stávajícího nástroje OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Uveďte, jak často se riziko objevuje v běžné situaci."
 
@@ -2944,13 +2955,13 @@ msgstr ""
 "může prioritu změnit."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, jak moc je pravděpodobné, že se toto riziko objeví v běžné situaci."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Uveďte závažnost, pokud se toto riziko vyskytne."
 
@@ -3042,6 +3053,11 @@ msgstr ""
 "Načtěte obrázek. Ujistěte se, že váš obrázek je ve formátu jpg nebo gif a "
 "neobsahuje žádné speciální znaky."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3057,7 +3073,7 @@ msgstr ""
 "vyhnout) ke snížení rizika."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Popište míru znalostí potřebných k implementaci kroku, např. \"zdravý rozum "
@@ -3207,7 +3223,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Pokud nespecifikujete název, bude použit ze vstupu."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3292,7 +3308,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Testovací modul"
 
@@ -3481,13 +3497,13 @@ msgstr "Účet je uzamčen"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Akční plán"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Rozpočet"
 
@@ -3497,27 +3513,22 @@ msgid "label_action_plan_download"
 msgstr "Akční plán"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Konec plánování"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Kdo je odpovědný?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Zahájení plánování"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Afegir una altra mesura"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3560,8 +3571,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Prosíme o případné připomínky k problematice uvedené v otázce výše Tyto "
@@ -3648,7 +3659,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Popis"
@@ -3678,7 +3689,7 @@ msgstr "Zobrazit vlastní upozornění pro tento nástroj OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Vyhodnocení"
 
@@ -3698,10 +3709,19 @@ msgid "label_evaluation_phase"
 msgstr "Fáze vyhodnocení"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Opatření již je zavedeno."
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3776,7 +3796,7 @@ msgstr "Provedení vlastního hodnocení rizik"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identifikace"
 
@@ -3784,6 +3804,11 @@ msgstr "Identifikace"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Obrazový soubor"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3806,7 +3831,7 @@ msgid "label_language"
 msgstr "Jazyk"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Odkazy na právní předpisy a postupy"
@@ -3841,21 +3866,26 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Které logo byste chtěl/a zobrazit v levém horním rohu?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Obecný přístup (k eliminaci nebo snížení rizika)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Specifický/é krok/y požadované k implementaci tohoto přístupu"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Míra potřebných znalostí a/nebo požadavků"
 
@@ -3913,25 +3943,25 @@ msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Žádné riziko"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Žádné riziko"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Žádné riziko"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Žádné riziko"
@@ -3971,15 +4001,10 @@ msgstr "Heslo"
 msgid "label_password_confirm"
 msgstr "Heslo znovu"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Předvyplnit"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Příprava"
 
@@ -3990,7 +4015,7 @@ msgstr "Náhled"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Předchozí"
@@ -4053,15 +4078,15 @@ msgstr "Může si stáhnout celou zprávu a akční plán."
 msgid "label_register_first"
 msgstr "registrujte"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Smazat toto opatření"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Zpráva"
 
@@ -4071,12 +4096,12 @@ msgid "label_report_comment"
 msgstr "Prosíme o případné připomínky k problematice uvedené v otázce výše"
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4096,49 +4121,49 @@ msgid "label_risk_type"
 msgstr "Typ rizika"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Riziko bez opatření"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riziko s opatřením(i)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Riziko bez opatření"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Riziko bez opatření"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riziko bez opatření"
@@ -4151,7 +4176,7 @@ msgstr "Uložte a přidejte další riziko."
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Uložit a pokračovat"
 
@@ -4176,7 +4201,7 @@ msgid "label_sector_title"
 msgstr "Název sektoru."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Zvolte jeden z uvedených známých a běžných kroků."
 
@@ -4205,7 +4230,7 @@ msgid "label_show_less_hellip"
 msgstr "Zobrazit méně"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} o tomto riziku."
 
@@ -4235,7 +4260,7 @@ msgid "label_start_identification"
 msgstr "Zahájit identifikaci rizik"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Start"
 
@@ -4280,29 +4305,29 @@ msgid "label_surveygroup_title"
 msgstr "Název importovaného nástroje OiRA"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Výchozí priorita"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Výchozí priorita"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "riziko se střední prioritou"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Název"
 
@@ -4362,12 +4387,12 @@ msgid "label_user_title"
 msgstr "Jméno"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 opatření)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(bez opatření)"
 
@@ -4414,7 +4439,7 @@ msgid "limitations"
 msgstr "omezeních"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Přihlaste se"
 
@@ -4503,7 +4528,7 @@ msgid "menu_import"
 msgstr "Importovat nástroj OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4609,32 +4634,32 @@ msgid "nav_usermanagement"
 msgstr "Správa uživatelů"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Nápověda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Odhlášení"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Nastavení"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Status"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Moje hodnocení"
 
@@ -4684,27 +4709,27 @@ msgid "notice_country_manager"
 msgstr "Manažer pro ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Online interaktivní"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Vyhodnocení rizik"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4724,7 +4749,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4736,7 +4761,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Oficiální spuštění nástroje je plánován na září 2011, jakmile bude dosaženo "
@@ -4765,45 +4790,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Vysoká"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Nízká"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Vysoká"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Velká"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Střední"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Malá"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Kompletní"
 
@@ -4856,18 +4881,13 @@ msgstr "Nemáte účet? Pak se prosím nejprve ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4879,7 +4899,7 @@ msgstr ""
 "Zaregistrujte se pomocí jednoho kroku a získejte přístup k těmto výhodám:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4893,17 +4913,17 @@ msgstr ""
 "měly být obsaženy v této zprávě v políčku níže."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Tato zpráva je založena na nástroji OiRA '${title}' k datu revize ${date}."
@@ -4934,35 +4954,35 @@ msgid "request_an_email_reminder"
 msgstr "žádejte o e-mail s připomenutím"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Toto je ${priority_value} prioritní riziko."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "vysoká"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "nízká"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "střední"
 
@@ -4982,7 +5002,7 @@ msgid "risk_solution_header"
 msgstr "Krok ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Toto riziko musí být zařazeno do seznamu."
@@ -5030,46 +5050,46 @@ msgid "select_add_existing_measure"
 msgstr "Vyberte nebo přidejte opatření, která jsou již zavedena."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Nepříliš vážné"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Potřeba zastavit práci na méně než 3 dny"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Vážné"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Potřeba zastavit práci na vice než 3 dny"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Velmi závažné"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Nevratné poškození, nevyléčitelná nemoc, smrt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Slabé"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Není potřeba zastavit práci"
 
@@ -5139,7 +5159,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Co je projekt OiRA (Online interaktivní vyhodnocení rizik)"
 
@@ -5154,7 +5174,7 @@ msgid "title_account_settings"
 msgstr "Nastavení účtu"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Změnit heslo"
@@ -5165,7 +5185,7 @@ msgid "title_client_help"
 msgstr "Pomocný text klienta"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Opatření"
 
@@ -5200,7 +5220,7 @@ msgid "title_import_sector_survey"
 msgstr "Importovat sektor nebo nástroj OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "(Vámi) přidaná rizika"
@@ -5227,8 +5247,8 @@ msgstr "Stav ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Online interaktivní vyhodnocení rizik"
 
@@ -5253,33 +5273,33 @@ msgid "title_with_vowel_status_of"
 msgstr "Stav ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Obsah"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Toto riziko ve vaší organizaci nehrozí, ale protože sektorová organizace "
 "toto považuje za jedno z prioritních rizik, musí být zahrnuto v této zprávě."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Toto riziko ve vaší organizaci nehrozí, ale protože sektorová organizace "
 "toto považuje za jedno z prioritních rizik, musí být zahrnuto v této zprávě."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Toto riziko nebylo ještě posouzeno, ale vzhledem tomu, že je nástrojem OiRA "
@@ -5307,7 +5327,7 @@ msgid "use_it_to_full_report"
 msgstr "Zprávu použijte pro"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Zprávu použijte pro"
 
@@ -5317,12 +5337,12 @@ msgid "use_it_to_measures_report"
 msgstr "Zprávu použijte pro"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Zprávu použijte pro"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Zprávu použijte pro"
 
@@ -5337,7 +5357,7 @@ msgid "warn_fix_errors"
 msgstr "Opravte prosím uvedené chyby."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Na výše uvedené prohlášení jste odpověděl/a záporně."
@@ -5360,6 +5380,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ano"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Afegir una altra mesura"
+
+#~ msgid "label_prefill"
+#~ msgstr "Předvyplnit"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Ve vašem akčním plánu nebyly provedeny žádné změny."

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -579,7 +579,7 @@ msgstr "Informace"
 msgid "Information"
 msgstr "Informace"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1114,7 +1114,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Základní struktura on-line interaktivního hodnocení rizik obsahuje:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1508,12 +1508,11 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Popište: 3) míru znalostí "
-"potřebných k implementaci kroku, např. \"zdravý rozum (nevyžadují se žádné "
-"znalosti BOZP)\", \"žádné specifické znalosti BOZP, ale vyžadují se "
-"minimální znalosti BOZP nebo znalosti nebo školení a/nebo konzultace "
-"s vedením společnosti\", nebo \"expert\" na prevencirizik. Můžete zde také "
-"popsat jakýkoliv jiný požadavek (pokud existuje)."
+"Popište: 3) míru znalostí potřebných k implementaci kroku, např. \"zdravý "
+"rozum (nevyžadují se žádné znalosti BOZP)\", \"žádné specifické znalosti "
+"BOZP, ale vyžadují se minimální znalosti BOZP nebo znalosti nebo školení a/"
+"nebo konzultace s vedením společnosti\", nebo \"expert\" na prevencirizik. "
+"Můžete zde také popsat jakýkoliv jiný požadavek (pokud existuje)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2156,17 +2155,17 @@ msgid "error_password_mismatch"
 msgstr "Hesla se neshodují"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Toto datum musí být k počátečnímu datu nebo po něm."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Toto datum musí být před datem ukončení."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Tato hodnota musí být kladné celé číslo."
 
@@ -2943,7 +2942,7 @@ msgstr ""
 "kopií stávajícího nástroje OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Uveďte, jak často se riziko objevuje v běžné situaci."
 
@@ -2955,13 +2954,13 @@ msgstr ""
 "může prioritu změnit."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, jak moc je pravděpodobné, že se toto riziko objeví v běžné situaci."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Uveďte závažnost, pokud se toto riziko vyskytne."
 
@@ -3571,7 +3570,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3719,7 +3718,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4015,7 +4014,7 @@ msgstr "Náhled"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Předchozí"
@@ -4176,7 +4175,7 @@ msgstr "Uložte a přidejte další riziko."
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Uložit a pokračovat"
 
@@ -4217,6 +4216,11 @@ msgstr "Zahajte nový modul zvolením následujících sektorových nástrojů"
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1956,17 +1956,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2722,12 +2722,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3246,7 +3246,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3392,7 +3392,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3847,7 +3847,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3888,6 +3888,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -632,7 +632,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -676,7 +676,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1418,10 +1418,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -4007,6 +4003,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4399,7 +4400,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -63,7 +63,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -244,7 +244,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -272,7 +272,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -306,11 +306,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -347,15 +347,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -413,15 +413,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -542,8 +542,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -552,7 +551,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -584,11 +583,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Lær mere om dette værktøj…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -600,7 +599,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -619,12 +618,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -741,12 +740,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -762,8 +763,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -788,9 +789,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -827,7 +828,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -856,8 +857,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -878,11 +879,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -957,7 +958,7 @@ msgstr "Del dette OiRA-værktøj"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -972,6 +973,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1021,7 +1026,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1038,7 +1043,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1138,7 +1143,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Alle bør have glæde af dette værktøj. Del det med andre."
 
@@ -1146,8 +1151,8 @@ msgstr "Alle bør have glæde af dette værktøj. Del det med andre."
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1159,9 +1164,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1268,113 +1273,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1434,7 +1444,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1482,7 +1492,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1750,7 +1760,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1796,7 +1806,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1830,17 +1840,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1910,7 +1920,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1946,17 +1956,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2046,7 +2056,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2055,12 +2065,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -2080,7 +2090,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2090,57 +2100,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2161,12 +2171,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2181,12 +2191,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2222,18 +2232,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2243,13 +2253,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2291,12 +2301,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2331,7 +2341,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2351,7 +2361,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2367,7 +2377,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2388,23 +2398,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2416,7 +2426,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2476,12 +2486,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2496,17 +2506,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2527,142 +2537,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2682,7 +2692,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2702,7 +2712,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2712,12 +2722,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2807,6 +2817,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2818,7 +2833,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2940,7 +2955,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3005,7 +3020,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3157,13 +3172,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3173,26 +3188,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3236,8 +3246,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3322,7 +3332,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3352,7 +3362,7 @@ msgstr "Show a custom notification for this OiRA tool"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3372,9 +3382,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3450,13 +3469,18 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
 #. Default: "Image file"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3480,7 +3504,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3515,21 +3539,26 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3585,25 +3614,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3643,15 +3672,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3662,7 +3686,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3725,15 +3749,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3743,12 +3767,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3768,49 +3792,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3823,7 +3847,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3848,7 +3872,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3877,7 +3901,7 @@ msgid "label_show_less_hellip"
 msgstr "vis mindre"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3907,7 +3931,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3952,29 +3976,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4034,12 +4058,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4084,7 +4108,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4165,7 +4189,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4265,32 +4289,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4340,27 +4364,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4380,7 +4404,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4392,7 +4416,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4418,45 +4442,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4505,18 +4529,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4526,7 +4545,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4536,17 +4555,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4576,35 +4595,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4624,7 +4643,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4672,46 +4691,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4771,7 +4790,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4786,7 +4805,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4797,7 +4816,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4832,7 +4851,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr ""
@@ -4859,8 +4878,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4885,29 +4904,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4932,7 +4951,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4942,12 +4961,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4962,7 +4981,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} für Aufsichtsbehörden."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Kopieren Sie Inhalte aus der Bibliothek"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr "Eine Kopie von “${title}” wurde zu Ihrem OiRA-Tool hinzugefügt."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr "Weitere Maßnahme"
 
@@ -238,7 +238,7 @@ msgstr ""
 "Sind Sie sicher, dass Sie forfahren wollen? Dieser Vorgang kann nicht "
 "rückgängig gemacht werden."
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -271,7 +271,7 @@ msgstr "Vorhandene OiRA Tools"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -299,7 +299,7 @@ msgstr "Kandidatenländer"
 msgid "Candidate country"
 msgstr "Kandidatenland"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "E-Mail-Adresse ändern"
 
@@ -335,13 +335,13 @@ msgstr ""
 "Enthält: Alle Informationen, die Sie währen der gesamten "
 "Gefährdungsbeurteilung eingegeben haben."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 "Enthält: eine übersichtliche Darstellung der Maßnahmen, die für die nächsten "
 "drei Monate geplant sind."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Enthält: eine übersichtliche Darstellung der ermittelten Gefährdungen."
 
@@ -380,16 +380,16 @@ msgstr "Länderinformationen und Gruppierung des Clients."
 msgid "Country manager"
 msgstr "Verwalter eines Landes"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 "Creative Commons Namensnennung-Weitergabe unter gleichen Bedingungen 2.5"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons-Lizenz"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -449,15 +449,15 @@ msgstr "Aktionsplan herunterladen"
 msgid "Download the full report"
 msgstr "Den kompletten Bericht herunterladen"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Übersicht der Maßnahmen herunterladen"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Übersicht der Gefährdungen herunterladen"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-Mail"
@@ -531,7 +531,7 @@ msgstr "Ordner"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Format: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Format: Portable Document Format (.pdf)"
 
@@ -539,7 +539,7 @@ msgstr "Format: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Deutschland"
 
@@ -565,7 +565,7 @@ msgstr ""
 "Allerdings können Sie eine Gefährdungsbeurteilung jederzeit unterbrechen und "
 "dann fortführen, wenn es Ihre Zeit erlaubt."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Ich würde Ihnen gerne folgendes Tool empfehlen"
 
@@ -581,8 +581,7 @@ msgstr "OiRA-Tool importieren"
 msgid "Important"
 msgstr "Wichtig"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Info"
 
@@ -591,7 +590,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informationen"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Falsches Dateiformat für das Bild. Bitte verwenden Sie PNG oder JPEG."
 
@@ -625,11 +624,11 @@ msgstr ""
 msgid "Last saved"
 msgstr "Zuletzt gespeichert"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Erfahren Sie mehr über diese GBU-Vorlage…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -641,7 +640,7 @@ msgstr "Anmelden"
 msgid "Manage"
 msgstr "Probleme und Risiken bewältigen"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Maßnahme"
@@ -661,14 +660,14 @@ msgstr ""
 "Zur Überwachung und Bewertung, ob notwendige Maßnahmen eingeführt wurden."
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Die Maßnahmen überwachen, die in den nächsten drei Monaten umgesetzt werden "
 "sollen."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 "Überwachen, ob Gefährdungen korrekt behandelt und Maßnahmen umgesetzt werden."
@@ -799,12 +798,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online-Hilfe"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Übersicht der Maßnahmen"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Übersicht der Gefährdungen"
@@ -823,8 +824,8 @@ msgstr ""
 "Gesundheitsschutz am Arbeitsplatz, usw.)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Informationen an betroffene Personen weitergeben."
 
@@ -855,9 +856,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Bitte werfen Sie einen Blick auf die Beispiele unter diesem Formular."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Aufgeschoben"
 
@@ -898,7 +899,7 @@ msgstr "Bereitstellen von Dokumentation für Aufsichtsbehörden."
 msgid "Publish Risk Assessment"
 msgstr "GBU veröffentlichen"
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Lesen Sie mehr"
 
@@ -932,8 +933,8 @@ msgstr ""
 "fortführen."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -954,11 +955,11 @@ msgstr "Gefährdung"
 msgid "Risk assessments made with this tool"
 msgstr "Vorhandene GBUs, die mit dieser Vorlage erstellt wurden"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Gefährdung nicht vorhanden"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Gefährdung vorhanden"
 
@@ -1037,7 +1038,7 @@ msgstr "Dieses OiRA-Tool weitergeben"
 msgid "Show library from ${dropdown}."
 msgstr "Zeige die Bibliothek aus ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Melden Sie sich an"
 
@@ -1053,6 +1054,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1107,7 +1112,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Niederlande"
 
@@ -1124,7 +1129,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Die generelle Struktur eines OiRA-Tools besteht aus:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1243,7 +1248,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Dieses Tool verdient es, überall bekannt zu werden! Geben Sie es weiter!"
@@ -1252,8 +1257,8 @@ msgstr ""
 msgid "Tip"
 msgstr "Tipp"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Hilfstexte ein-/ ausschalten"
 
@@ -1265,9 +1270,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr "Veröffentlichung der GBU zurückziehen"
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Nicht beantwortet"
 
@@ -1388,38 +1393,38 @@ msgid "Your password was successfully changed."
 msgstr "Ihr Passwort wurde erfolgreich geändert."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Der Quellcode der OiRA-Anwendung ist ${GPL}-lizenziert."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "Der Inhalt der branchenspezifischen OiRA-Tools ist unter der ${license} "
 "lizenziert."
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "Die Nutzung der branchenspezifischen OiRA-Tools ist für alle Benutzer "
 "kostenlos."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Weitere Informationen über das OiRA-Projekt (auf Englisch)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Gemeinschaftsstrategie für Gesundheit und Sicherheit am Arbeitsplatz "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Die Erfahrung zeigt, dass eine ${key}. Aus diesem Grund hat die Europäische "
@@ -1431,44 +1436,44 @@ msgstr ""
 "Durchführung dieser Maßnahmen bis zur Überwachung und ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "benutzerfreundliche und kostenlose Webanwendung entwickelt"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "Bewertung"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "Ermittlung"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "sachgemäße Gefährdungsbeurteilung der Schlüssel zu gesunden Arbeitsplätzen "
 "ist"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "vorbeugende Maßnahmen"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "Berichterstellung"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "schrittweisen Gefährdungsbeurteilungsprozess einrichten können"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Die Webanwendung OiRA gewährt Zugriff auf die branchenspezifischen Tools zur "
@@ -1476,7 +1481,7 @@ msgstr ""
 "nationaler Ebene entwickelt und verwaltet werden."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "Die ${agency} fordert die Entwicklung einfacher Werkzeuge, die eine "
@@ -1490,7 +1495,7 @@ msgstr ""
 "Defizite beseitigt werden."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Das OiRA-Projekt sowie die zugehörige Webanwendung wurden auf der Grundlage "
@@ -1503,14 +1508,14 @@ msgstr ""
 "und unter Beteiligung der Gewerkschaften FNV, CNV und MHP durchgeführt."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Die folgenden technischen Partner waren an der Entwicklung des OiRA-"
 "Projektes beteiligt:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Ein Lenkungsausschuss hat die Agentur strategisch und fachlich bei der "
@@ -1520,12 +1525,12 @@ msgstr ""
 "Sicherheit und Gesundheitsschutz am Arbeitsplatz ernannt."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "es in Kleinst- und Kleinunternehmen einige Defizite"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Obwohl einzelne Maßnahmen ohne Kostenaufwand durchzuführen sind, kosten die "
@@ -1534,7 +1539,7 @@ msgstr ""
 "werden."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Bestimmen Sie eine Person in Ihrem Unternehmen zum Verantwortlichen für die "
@@ -1542,14 +1547,20 @@ msgstr ""
 "Durchführung der im Plan beschriebenen Schritte und/oder die Veantwortung "
 "für deren Durchführung."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Beschreiben Sie: 1) Ihre allgemeine Vorgehensweise zur Vermeidung bzw. (wenn "
 "die Gefährdung sich nicht vermeiden lässt) Reduzierung der Gefährdung; 2) "
 "die einzelne(n) Aktion(en), die zur Umsetzung dieser Vorgehensweise "
-"erforderlich ist/sind (zur Vermeidung bzw. Reduzierung der Gefährdung); 3) "
+"erforderlich ist/sind (zur Vermeidung bzw. Reduzierung der Gefährdung)"
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Beschreiben Sie: 3) "
 "die erforderlichen Fachkenntnisse, um die Maßnahme umzusetzen, zum Beispiel "
 "„gesunder Menschenverstand (keine OSH-Kenntnisse erforderlich)“, „keine "
 "spezifischen OSH-Kenntnisse, jedoch ein Mindestmaß an OSH-Kenntnissen bzw. -"
@@ -1616,7 +1627,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: Positive Aussagen, die in Modulen gruppiert sind."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Hinzufügen"
 
@@ -1664,7 +1675,7 @@ msgstr "Abbrechen"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Schließen"
 
@@ -1999,7 +2010,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Die Bewertung der Priorität wurde für diese Gefährdung automatisch "
@@ -2063,7 +2074,7 @@ msgstr ""
 "Möglichkeit zur Wiederholung nicht wünschen, deaktivieren Sie die Checkbox."
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Nach der technischen Entwicklung des Tools 2009 führt die Agentur derzeit "
@@ -2106,17 +2117,17 @@ msgid "effect_high"
 msgstr "Hoher (sehr hoher) Schweregrad"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Niedriger Schweregrad"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Signifikanter Schweregrad"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Hoher (sehr hoher) Schweregrad"
 
@@ -2193,7 +2204,7 @@ msgid "error_existing_login"
 msgstr "Dieser Anmeldename ist bereits vergeben."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Geben Sie das Budget in Euro ohne Centbeträge ein."
 
@@ -2229,17 +2240,17 @@ msgid "error_password_mismatch"
 msgstr "Die Passwörter stimmen nicht überein."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Dieses Datum muss nach dem Startdatum liegen."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Dieses Datum muss vor dem Enddatum liegen."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Dieser Wert muss eine ganze positive Zahl sein."
 
@@ -2341,7 +2352,7 @@ msgstr ""
 "Änderungen im OiRA-Tool in Ihrer Sitzung zusammengeführt werden."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2350,12 +2361,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Aktionsplan ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Ermittlungsbericht ${title}"
 
@@ -2375,7 +2386,7 @@ msgid "french"
 msgstr "Vereinfacht, zwei Kriterien"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Fast nie"
 
@@ -2385,57 +2396,57 @@ msgid "frequency_almostnever"
 msgstr "Fast nie"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Dauerhaft"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Nicht sehr häufig"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Nicht sehr häufig"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Häufig"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Häufig"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Selten"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Selten"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Sehr häufig oder regelmäßig"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Sehr häufig oder regelmäßig"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regelmäßig"
@@ -2460,12 +2471,12 @@ msgid "header_additional_content"
 msgstr "Weitere Inhalte"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Anhänge"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Quellen und Anhänge zu diesem Modul."
 
@@ -2480,12 +2491,12 @@ msgid "header_country_managers"
 msgstr "Verwalter eines Landes"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Entwicklungs- und Pilotphase – 2009–2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Entwicklungspartner"
 
@@ -2523,18 +2534,18 @@ msgstr "Ermittlung"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informationen"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Offizielle Einführung des Projektes – September 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Rechtliche und politische Referenzen"
 
@@ -2544,13 +2555,13 @@ msgid "header_legend"
 msgstr "Legende"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Lizenzen"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Anmelden"
@@ -2561,12 +2572,12 @@ msgid "header_main_image"
 msgstr "Hauptbild"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Maßnahme ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Maßnahme"
 
@@ -2592,12 +2603,12 @@ msgid "header_not_complicated"
 msgstr "Die Beurteilung ist kein komplizierter Vorgang"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2632,7 +2643,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2652,7 +2663,7 @@ msgid "header_profile_questions"
 msgstr "Profilfragen"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projektphasen"
 
@@ -2668,7 +2679,7 @@ msgstr "Beantwortete Fragen pro Modul"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrieren"
 
@@ -2689,23 +2700,23 @@ msgid "header_risk_aware"
 msgstr "Sind Sie sich aller Gefährdungen bewusst?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Welchen Schweregrad hat der Schaden?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Wie häufig sind Personen dieser Gefährdung ausgesetzt?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Priorität für diese Gefährdung wählen"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Wie hoch ist die Wahrscheinlichkeit, dass diese Gefährdung auftritt?"
 
@@ -2717,7 +2728,7 @@ msgid "header_risks"
 msgstr "Gefährdungen"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2777,12 +2788,12 @@ msgid "header_training"
 msgstr "Unterweisungsunterlage"
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2797,18 +2808,18 @@ msgid "header_welcome"
 msgstr "Willkommen"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "Beschreibung des OiRA-Projekts (Interaktive Online-Gefährdungsbeurteilung)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Gründe für das OiRA-Projekt"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Bemerkungen"
 
@@ -2829,142 +2840,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Gefährdungen mit mittlerer Priorität"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Gefährdung mit hoher Priorität"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Gefährdungen mit hoher Priorität"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Gefährdungen mit hoher Priorität"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Gefährdungen mit hoher Priorität"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_high_risks} Gefährdung mit niedriger Priorität"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_high_risks} Gefährdungen mit niedriger Priorität"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_high_risks} Gefährdungen mit niedriger Priorität"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_high_risks} Gefährdungen mit niedriger Priorität"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_high_risks} Gefährdung mit mittlerer Priorität"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_high_risks} Gefährdungen mit mittlerer Priorität"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_high_risks} Gefährdungen mit mittlerer Priorität"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_high_risks} Gefährdungen mit mittlerer Priorität"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_possible_risks} Aufgeschobene Gefährdung"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_possible_risks} Aufgeschobene Gefährdungen"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_possible_risks} Aufgeschobene Gefährdungen"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_possible_risks} Aufgeschobene Gefährdungen"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Nicht beantwortete Gefährdung"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Nicht beantwortete Gefährdungen"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Nicht beantwortete Gefährdungen"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Nicht beantwortete Gefährdungen"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Mögliche Gefährdung"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Mögliche Gefährdungen"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Mögliche Gefährdungen"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Mögliche Gefährdungen"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Vorhandene Gefährdung"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Vorhandene Gefährdungen"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Vorhandene Gefährdungen"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Vorhandene Gefährdungen"
 
@@ -2984,7 +2995,7 @@ msgid "help_authentication"
 msgstr "Dieser Text sollte den Registrierungs- und Anmeldevorgang beschreiben."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Bitte beantworten Sie die folgenden Fragen. Aufgrund Ihrer Antworten wird "
@@ -3014,7 +3025,7 @@ msgstr ""
 "Sie dies basierend auf der Kopie eines bestehenden OiRA-Tools tun möchten ..."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Geben Sie an, wie oft diese Gefährdung unter normalen Bedingungen auftritt."
@@ -3027,14 +3038,14 @@ msgstr ""
 "unterstützen. Er/sie hat die Möglichkeit, die Priorität zu ändern."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geben Sie an, wie wahrscheinlich das Auftreten der Gefährdung unter normalen "
 "Bedingungen ist."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Geben Sie den Schweregrad für das Eintreten dieser Gefährdung an."
 
@@ -3131,6 +3142,11 @@ msgstr ""
 "Laden Sie ein Bild hoch. Die Datei muss im PNG-, JPG- oder GIF-Format sein, "
 "und der Dateiname darf keine Sonderzeichen enthalten."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3148,7 +3164,7 @@ msgstr ""
 "Gefährdung)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Beschreiben Sie die erforderlichen Fachkenntnisse, um die Maßnahme "
@@ -3315,7 +3331,7 @@ msgstr ""
 "Wenn Sie keinen Namen angeben, wird ein Name aus der Eingabedatei übernommen."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3404,7 +3420,7 @@ msgstr ""
 "${start_session}."
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Test-Sitzung"
 
@@ -3605,13 +3621,13 @@ msgstr "Konto gesperrt"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Aktionsplan"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budget"
 
@@ -3621,27 +3637,22 @@ msgid "label_action_plan_download"
 msgstr "Aktionsplan"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Abschluss der Planung"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Wer ist die verantwortliche Person?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Beginn der Planung"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Weitere Schutzmaßnahme hinzufügen"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3684,8 +3695,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Bitte hinterlassen Sie mögliche Kommentare, die Sie zu der genannten "
@@ -3777,7 +3788,7 @@ msgstr ""
 "löschen."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Beschreibung"
@@ -3807,7 +3818,7 @@ msgstr "Eine Nutzerbenachrichtigung für dieses OiRA-Tool anzeigen?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Bewertung"
 
@@ -3827,9 +3838,18 @@ msgid "label_evaluation_phase"
 msgstr "Bewertungsphase"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3905,7 +3925,7 @@ msgstr "Sitzungen"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Ermittlung"
 
@@ -3913,6 +3933,11 @@ msgstr "Ermittlung"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Bilddatei"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3935,7 +3960,7 @@ msgid "label_language"
 msgstr "Sprache"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Rechtliche und politische Referenzen"
@@ -3972,22 +3997,27 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Welches Logo soll in der Ecke oben links angezeigt werden?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 "Allgemeine Vorgehensweise (zur Vermeidung bzw. Reduzierung der Gefährdung)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Einzelne Aktion(en) zur Umsetzung dieser Vorgehensweise"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Erforderliche Fachkenntnisse und/oder Anforderungen"
 
@@ -4043,25 +4073,25 @@ msgid "label_no"
 msgstr "Nein"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Keine Gefährdung"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Keine Gefährdungen"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Keine Gefährdungen"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Keine Gefährdungen"
@@ -4101,15 +4131,10 @@ msgstr "Gewünschtes Passwort"
 msgid "label_password_confirm"
 msgstr "Wiederholung Passwort"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Übernehmen"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Vorbereitung"
 
@@ -4120,7 +4145,7 @@ msgstr "Vorschau"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorhergehende"
@@ -4183,15 +4208,15 @@ msgstr "Sie können einen kompletten Bericht und den Aktionsplan herunterladen."
 msgid "label_register_first"
 msgstr "registrieren"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Diese Maßnahme löschen"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Bericht"
 
@@ -4203,12 +4228,12 @@ msgstr ""
 "aufgenommen werden sollen, in dieses Feld ein."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4228,49 +4253,49 @@ msgid "label_risk_type"
 msgstr "Gefährdungstyp"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Gefährdung mit Maßnahme(n)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Gefährdung ohne Maßnahme(n)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Gefährdungen mit Maßnahme(n)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Gefährdungen mit Maßnahme(n)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Gefährdungen mit Maßnahme(n)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Gefährdungen ohne Maßnahme(n)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Gefährdungen ohne Maßnahme(n)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Gefährdungen ohne Maßnahme(n)"
@@ -4283,7 +4308,7 @@ msgstr "Speichern und neue Gefährdung hinzufügen"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Speichern und weiter"
 
@@ -4308,7 +4333,7 @@ msgid "label_sector_title"
 msgstr "Name der Branche"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 "Wählen Sie eine oder mehrere der angebotenen bekannten, allgemeinen "
@@ -4341,7 +4366,7 @@ msgid "label_show_less_hellip"
 msgstr "Weniger anzeigen"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} über die Gefährdung."
 
@@ -4371,7 +4396,7 @@ msgid "label_start_identification"
 msgstr "Gefährdungsermittlung starten"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Starten"
 
@@ -4416,29 +4441,29 @@ msgid "label_surveygroup_title"
 msgstr "Name des importierten OiRA-Tools"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "hoch"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "niedrig"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "mittel"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titel"
 
@@ -4498,12 +4523,12 @@ msgid "label_user_title"
 msgstr "Name"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 Maßnahmen)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(ohne Maßnahmen)"
 
@@ -4552,7 +4577,7 @@ msgid "limitations"
 msgstr "Einschränkungen"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Anmelden"
 
@@ -4649,7 +4674,7 @@ msgid "menu_import"
 msgstr "OiRA-Tool importieren"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr "Unterweisung"
 
@@ -4760,32 +4785,32 @@ msgid "nav_usermanagement"
 msgstr "Benutzerverwaltung"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Hilfe"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Abmelden"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Einstellungen"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Status"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Meine Beurteilungen"
 
@@ -4835,27 +4860,27 @@ msgid "notice_country_manager"
 msgstr "Verwalter für ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Interaktive Online-"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Gefährdungsbeurteilung"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4875,7 +4900,7 @@ msgid "osc_search_placeholder"
 msgstr "Nach Abteilungen suchen"
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4889,7 +4914,7 @@ msgstr ""
 "Großbuchstabe, eine Ziffer und ein Sonderzeichen (z. B. $, # oder @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Die offizielle Einführung des Tools ist für September 2011 geplant, sobald "
@@ -4920,45 +4945,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Hoch"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Niedrig"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Mittel"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Hoch"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Mittelhoch"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Niedrig"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Vollständig"
 
@@ -5010,18 +5035,13 @@ msgstr "Sie haben kein Konto? Dann ${register_link} Sie sich bitte zunächst."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -5034,7 +5054,7 @@ msgstr ""
 "und genießen Sie die folgenden Vorteile:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -5049,17 +5069,17 @@ msgstr ""
 "untenstehende Feld eingeben."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Dieser Bericht basiert auf dem OiRA-Tool '${title}' mit dem Revisionsdatum "
@@ -5091,35 +5111,35 @@ msgid "request_an_email_reminder"
 msgstr "fordern Sie eine Erinnerungs-E-Mail"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Dies ist eine ${priority_value} Prioritätsgefährdung."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "hohe"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "niedrige"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "mittlere"
 
@@ -5139,7 +5159,7 @@ msgid "risk_solution_header"
 msgstr "Maßnahme ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Diese Gefährdung wurde noch nicht inventarisiert."
@@ -5189,46 +5209,46 @@ msgstr ""
 "oder fügen Sie bei Bedarf neue hinzu."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Nicht sehr hoch"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Nicht sehr hoch"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Hoch"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Hoch"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Sehr hoch"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Sehr hoch"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Niedrig"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Niedrig"
 
@@ -5301,7 +5321,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Informationen"
 
@@ -5316,7 +5336,7 @@ msgid "title_account_settings"
 msgstr "Kontoeinstellungen"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Password ändern"
@@ -5327,7 +5347,7 @@ msgid "title_client_help"
 msgstr "Hilfetext für den Client"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Häufig angewendete Lösung"
 
@@ -5362,7 +5382,7 @@ msgid "title_import_sector_survey"
 msgstr "Branche und OiRA-Tool importieren"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Weitere Gefährdungen (durch Sie hinzugefügt)"
@@ -5389,8 +5409,8 @@ msgstr "Status von “${survey_title}”"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 "OiRA – Online interactive Risk Assessment – das interaktive Online-Werkzeug "
@@ -5417,19 +5437,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Status von “${survey_title}”"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Inhalt"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr "Hauptmenü einblenden/ausblenden"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Diese Gefährdung ist in Ihrer Organisation nicht vorhanden. Da jedoch die "
@@ -5437,7 +5457,7 @@ msgstr ""
 "muss sie in den Bericht aufgenommen werden."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Diese Gefährdung ist in Ihrer Organisation nicht vorhanden. Da jedoch die "
@@ -5445,7 +5465,7 @@ msgstr ""
 "muss sie in den Bericht aufgenommen werden."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Diese Gefährdung ist in Ihrer Organisation nicht vorhanden. Da jedoch die "
@@ -5475,7 +5495,7 @@ msgid "use_it_to_full_report"
 msgstr "Damit können Sie"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Damit können Sie"
 
@@ -5485,12 +5505,12 @@ msgid "use_it_to_measures_report"
 msgstr "Damit können Sie"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Damit können Sie"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Damit können Sie"
 
@@ -5505,7 +5525,7 @@ msgid "warn_fix_errors"
 msgstr "Korrigieren Sie die angezeigten Fehler."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Sie haben die obenstehende Aussage verneint."
@@ -5530,6 +5550,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Weitere Schutzmaßnahme hinzufügen"
+
+#~ msgid "label_prefill"
+#~ msgstr "Übernehmen"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -238,7 +238,7 @@ msgstr ""
 "Sind Sie sicher, dass Sie forfahren wollen? Dieser Vorgang kann nicht "
 "rückgängig gemacht werden."
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -590,7 +590,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informationen"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Falsches Dateiformat für das Bild. Bitte verwenden Sie PNG oder JPEG."
 
@@ -1129,7 +1129,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Die generelle Struktur eines OiRA-Tools besteht aus:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1560,13 +1560,12 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Beschreiben Sie: 3) "
-"die erforderlichen Fachkenntnisse, um die Maßnahme umzusetzen, zum Beispiel "
-"„gesunder Menschenverstand (keine OSH-Kenntnisse erforderlich)“, „keine "
-"spezifischen OSH-Kenntnisse, jedoch ein Mindestmaß an OSH-Kenntnissen bzw. -"
-"Schulung und/oder Inanspruchnahme von OSH-Anleitung erforderlich“ oder „OSH-"
-"Fachkraft“. Wenn zutreffend, können Sie hier auch weitere zusätzliche "
-"Anforderungen beschreiben."
+"Beschreiben Sie: 3) die erforderlichen Fachkenntnisse, um die Maßnahme "
+"umzusetzen, zum Beispiel „gesunder Menschenverstand (keine OSH-Kenntnisse "
+"erforderlich)“, „keine spezifischen OSH-Kenntnisse, jedoch ein Mindestmaß an "
+"OSH-Kenntnissen bzw. -Schulung und/oder Inanspruchnahme von OSH-Anleitung "
+"erforderlich“ oder „OSH-Fachkraft“. Wenn zutreffend, können Sie hier auch "
+"weitere zusätzliche Anforderungen beschreiben."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2240,17 +2239,17 @@ msgid "error_password_mismatch"
 msgstr "Die Passwörter stimmen nicht überein."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Dieses Datum muss nach dem Startdatum liegen."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Dieses Datum muss vor dem Enddatum liegen."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Dieser Wert muss eine ganze positive Zahl sein."
 
@@ -3025,7 +3024,7 @@ msgstr ""
 "Sie dies basierend auf der Kopie eines bestehenden OiRA-Tools tun möchten ..."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Geben Sie an, wie oft diese Gefährdung unter normalen Bedingungen auftritt."
@@ -3038,14 +3037,14 @@ msgstr ""
 "unterstützen. Er/sie hat die Möglichkeit, die Priorität zu ändern."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geben Sie an, wie wahrscheinlich das Auftreten der Gefährdung unter normalen "
 "Bedingungen ist."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Geben Sie den Schweregrad für das Eintreten dieser Gefährdung an."
 
@@ -3695,7 +3694,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3848,7 +3847,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4145,7 +4144,7 @@ msgstr "Vorschau"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorhergehende"
@@ -4308,7 +4307,7 @@ msgstr "Speichern und neue Gefährdung hinzufügen"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Speichern und weiter"
 
@@ -4354,6 +4353,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr "GBU-Vorlage auswählen"
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -677,7 +677,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -721,7 +721,7 @@ msgstr "Nein"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr "Für diese Suchanfrage wurden keine GBUs gefunden."
 
@@ -1599,10 +1599,6 @@ msgstr "Informationen"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Produziert von ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "basiert auf"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4471,6 +4467,11 @@ msgstr "mittel"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "basiert auf ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4894,7 +4895,7 @@ msgid "optional"
 msgstr "optional"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr "Zu dieser Suche wurden keine Abteilungen gefunden."
 
@@ -5554,6 +5555,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "based on"
+#~ msgstr "basiert auf"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Weitere Schutzmaßnahme hinzufügen"

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -249,7 +249,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -611,7 +611,7 @@ msgstr "Πληροφορίες"
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Μη αποδεκτός τύπος αρχείου εικόνας. Αποδεκτοί τύποι αρχείων εικόνας PNG, "
@@ -1086,7 +1086,7 @@ msgstr "Πρότυπο"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Προτεινόμενα μέτρα"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1161,7 +1161,7 @@ msgstr ""
 "Η βασική αρχιτεκτονική μιας επιγραμμικής διαδραστικής εκτίμησης κινδύνου "
 "αποτελείται από:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1583,12 +1583,12 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Περιγράψτε: 3) το επίπεδο τεχνογνωσίας που "
-"απαιτείται για να εφαρμοστεί το μέτρο, για παράδειγμα “κοινή λογική (δεν "
-"απαιτούνται γνώσεις AYE)”, “δεν απαιτείται συγκεκριμένη τεχνογνωσία AYE, "
-"ωστόσο χρειάζονται οι ελάχιστες γνώσεις ή κατάρτιση ΑΥΕ ή/και παροχή "
-"συμβουλών για την καθοδήγηση AYE” ή “ειδικός(-ή) σε AYE”. Μπορείτε επίσης να "
-"περιγράψετε εδώ οποιαδήποτε άλλη πρόσθετη απαίτηση (εάν υπάρχει)."
+"Περιγράψτε: 3) το επίπεδο τεχνογνωσίας που απαιτείται για να εφαρμοστεί το "
+"μέτρο, για παράδειγμα “κοινή λογική (δεν απαιτούνται γνώσεις AYE)”, “δεν "
+"απαιτείται συγκεκριμένη τεχνογνωσία AYE, ωστόσο χρειάζονται οι ελάχιστες "
+"γνώσεις ή κατάρτιση ΑΥΕ ή/και παροχή συμβουλών για την καθοδήγηση AYE” ή "
+"“ειδικός(-ή) σε AYE”. Μπορείτε επίσης να περιγράψετε εδώ οποιαδήποτε άλλη "
+"πρόσθετη απαίτηση (εάν υπάρχει)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2255,19 +2255,19 @@ msgid "error_password_mismatch"
 msgstr "Οι κωδικοί πρόσβασης δεν είναι ίδιοι"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας έναρξης."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας λήξης."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Αυτή η τιμή πρέπει να είναι θετικός ακέραιος αριθμός."
 
@@ -3063,7 +3063,7 @@ msgstr ""
 "αρχίσετε με ένα αντίγραφο κάποιου υπάρχοντος Εργαλείου OiRA. "
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο συχνά εκτίθενται οι εργαζόμενοι στον "
@@ -3077,14 +3077,14 @@ msgstr ""
 "προτεραιότητα. Ο χρήστης μπορεί να αλλάξει την προτεραιότητα."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο πιθανό είναι να εκδηλωθεί ο κίνδυνος "
 "αυτός σε φυσιολογικές συνθήκες."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο σοβαρές μπορεί να είναι οι επιπτώσεις "
@@ -3375,7 +3375,7 @@ msgstr "Εάν δεν ορίσετε τίτλο, θα υιοθετηθεί απ�
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Πίνακας μελετών ΕΚ"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3740,7 +3740,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3888,9 +3888,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Προσθήκη επιπρόσθετου μέτρου"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4186,7 +4186,7 @@ msgstr "Προεπισκόπηση"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Προηγούμενο"
@@ -4351,7 +4351,7 @@ msgstr "Αποθήκευση και προσθήκη άλλου κινδύνου
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Αποθήκευση"
 
@@ -4397,6 +4397,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Επιλογή από τα προτεινόμενα μέτρα"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5483,7 +5488,7 @@ msgstr "Περιεχόμενα"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Εμφάνιση/απόκρυψη μενού"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -700,7 +700,7 @@ msgid "Montenegro"
 msgstr "Μαυροβούνιο"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -744,7 +744,7 @@ msgstr "Όχι"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1622,10 +1622,6 @@ msgstr "Σχετικά"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Δημιουργία ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "με βάση το"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4515,6 +4511,11 @@ msgstr "Μέτρια"
 msgid "label_title"
 msgstr "Τίτλος"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "με βάση το ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4935,7 +4936,7 @@ msgid "optional"
 msgstr "Προαιρετικό"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5595,6 +5596,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ναι"
+
+#~ msgid "based on"
+#~ msgstr "με βάση το"
 
 #~ msgid "label_add_measure"
 #~ msgstr "προσθέστε άλλο μέτρο"

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -93,7 +93,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} στις ελεγκτικές αρχές (επιθεώρηση εργασίας)"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr "Προσθήκη περιεχομένου από τη βιβλιοθήκ
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -249,7 +249,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -282,7 +282,7 @@ msgstr "Διαθέσιμα εργαλεία OiRA"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr "Υποψήφιες χώρες "
 msgid "Candidate country"
 msgstr "Υποψήφια χώρα "
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Αλλαγή διεύθυνσης email "
 
@@ -350,11 +350,11 @@ msgstr ""
 "Περιλαμβάνει: όλες τις πληροφορίες και τα στοιχεία που δόθηκαν από εσάς καθ’ "
 "όλη τη διαδικασία (εκτίμηση κινδύνου)"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Περιλαμβάνει: κατάλογο επισκόπησης όλων των μέτρων προς εφαρμογή."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 "Περιλαμβάνει: κατάλογο επισκόπησης όλων των κινδύνων που αναγνωρίστηκαν"
@@ -394,15 +394,15 @@ msgstr "Πληροφορίες χώρας και κατάταξη για τον 
 msgid "Country manager"
 msgstr "Εθνικός διευθυντής"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Απόδοση Creative Commons-Γενική άδεια χρήσης ShareAlike 2.5"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Άδεια χρήσης Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -462,15 +462,15 @@ msgstr "Σχέδιο δράσης"
 msgid "Download the full report"
 msgstr "Έκθεση"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Μεταφόρτωση του καταλόγου επισκόπησης όλων των μέτρων"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Μεταφόρτωση του καταλόγου επισκόπησης όλων των κινδύνων"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Ηλεκτρονικό ταχυδρομείο"
@@ -544,7 +544,7 @@ msgstr "Φάκελος"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Τύπος: Excel (.xls)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Μορφή: PDF (.pdf)"
 
@@ -552,7 +552,7 @@ msgstr "Μορφή: PDF (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Γερμανία"
 
@@ -586,7 +586,7 @@ msgstr ""
 "άλλη στιγμή το θελήσετε στο μέλλον, συνεχίζοντας από το σημείο όπου "
 "σταματήσατε. "
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Θέλω να μοιραστώ μαζί σας τα παρακάτω"
 
@@ -602,8 +602,7 @@ msgstr ""
 msgid "Important"
 msgstr "Σημαντικό"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Πληροφορίες"
 
@@ -612,7 +611,7 @@ msgstr "Πληροφορίες"
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Μη αποδεκτός τύπος αρχείου εικόνας. Αποδεκτοί τύποι αρχείων εικόνας PNG, "
@@ -650,11 +649,11 @@ msgstr "Κοσσυφοπέδιο"
 msgid "Last saved"
 msgstr "αποθηκεύτηκε"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Μάθετε περισσότερα σχετικά με αυτό το εργαλείο…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -666,7 +665,7 @@ msgstr "Σύνδεση"
 msgid "Manage"
 msgstr "Για τη διαχείριση"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Μέτρο"
@@ -686,13 +685,13 @@ msgstr ""
 "παρακολουθείτε και να αξιολογείτε κατά πόσον τα αναγκαία μέτρα έχουν ληφθεί,"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Παρακολούθηση της εφαρμογής των μέτρων για το διάστημα των επόμενων 3 μηνών."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Παρακολούθηση της σωστής ή μη διαχείρισης των κινδύνων ή των μέτρων."
 
@@ -826,12 +825,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online βοήθεια"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Κατάλογος επισκόπησης των μέτρων"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Κατάλογος επισκόπησης των κινδύνων"
@@ -850,8 +851,8 @@ msgstr ""
 "επαγγελματικής ασφάλεια και υγείας, ...),"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Διαβίβαση πληροφοριών στους ενδιαφερόμενους."
 
@@ -883,9 +884,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Βλέπε τα παραδείγματα κάτω από το έντυπο"
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Κίνδυνος σε εκκρεμότητα"
 
@@ -927,7 +928,7 @@ msgstr "παρέχετε στοιχεία στις ελεγκτικές αρχέ
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Διαβάστε περισσότερα"
 
@@ -961,8 +962,8 @@ msgstr ""
 "συνεχίσετε προηγούμενες Εκτιμήσεις Κινδύνου ή για να ξεκινήσετε νέες."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Αφαίρεση "
 
@@ -983,11 +984,11 @@ msgstr "Κίνδυνος"
 msgid "Risk assessments made with this tool"
 msgstr "Εκτιμήσεις επικινδυνότητας με το εργαλείο αυτό"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Ασφαλής κατάσταση"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Προσοχή κίνδυνος!"
 
@@ -1066,7 +1067,7 @@ msgstr "Μοιραστείτε αυτό το εργαλείο OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Προβολή βιβλιοθήκης από ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Συνδεθείτε"
 
@@ -1082,6 +1083,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Πρότυπο"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1137,7 +1142,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Ολλανδία"
 
@@ -1156,7 +1161,7 @@ msgstr ""
 "Η βασική αρχιτεκτονική μιας επιγραμμικής διαδραστικής εκτίμησης κινδύνου "
 "αποτελείται από:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1269,7 +1274,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Αυτό το εργαλείο αξίζει να γίνει γνωστό σε όλο τον κόσμο! Μοιραστείτε το!"
@@ -1278,8 +1283,8 @@ msgstr ""
 msgid "Tip"
 msgstr "Συμβουλή"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Εναλλαγή στη βοήθεια οθόνης"
 
@@ -1291,9 +1296,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Υπό εξέταση κίνδυνος"
 
@@ -1415,38 +1420,38 @@ msgid "Your password was successfully changed."
 msgstr "Η αλλαγή του κωδικού πρόσβασής σας ολοκληρώθηκε με επιτυχία."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Ο πηγαίος κώδικας της εφαρμογής OiRA τελεί υπό την άδεια ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "Για το περιεχόμενο των εργαλείων OiRA για τους τομείς παρέχεται άδεια "
 "${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "Τα εργαλεία OiRA για τους τομείς μπορούν να χρησιμοποιηθούν δωράν από όλους "
 "τους χρήστες."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Περισσότερες πληροφορίες για το έργο OiRA (στα Ελληνικά)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Στρατηγική Ευρωπαϊκής Επιτροπής για την Υγεία και Ασφάλεια στην Εργασία "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Η πείρα δείχνει ότι ${key}. Για αυτό η ΕΕ-OSHA ανέπτυξαν ένα ${easy} (το "
@@ -1457,44 +1462,44 @@ msgstr ""
 "δράσης, έως την εποπτεία και ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "εύχρηστη διαδικτυακή εφαρμογή χωρίς κόστος"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "αξιολόγηση"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "αναγνώριση"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "η κατάλληλη αξιολόγηση κινδύνων είναι το κλειδί για υγιή περιβάλλοντα "
 "εργασίας"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "προληπτικές ενέργειες"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "αναφορά"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "διαδικασία αξιολόγησης κινδύνων βήμα προς βήμα"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Η δικαδικτυακή εφαρμογή OiRA παρέχει πρόσβαση στα τομεακά εργαλεία "
@@ -1502,7 +1507,7 @@ msgstr ""
 "τομεακούς οργανισμούς σε εθνικό επίπεδο."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "Η ${agency} ζητά τη δημιουργία απλών εργαλείων για τη διευκόλυνση της "
@@ -1515,7 +1520,7 @@ msgstr ""
 "την οποία το έργο OiRA έχει στόχο να υπερβεί."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Το έργο OiRA και η σχετική διαδικτυακή εφαρμογή σχεδιάστηκαν από την ${eu-"
@@ -1527,12 +1532,12 @@ msgstr ""
 "τη συμμετοχή των επαγγελματικών οργανώσεων FNV, CNV και MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "Οι παρακάτω τεχνικοί εταίροι συνέβαλαν στο σχεδιασμό του έργου OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Η Υπηρεσία έχει επίσης λάβει στρατηγικές και εξειδικευμένες συμβουλές από "
@@ -1542,13 +1547,13 @@ msgstr ""
 "ΕΕ-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 "οι πολύ μικρές και μικρές επιχειρήσεις μπορεί να αντιμετωπίσουν ανεπάρκειες"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Παρότι η εφαρμογή ορισμένων μέτρων δεν έχει κόστος, τα περισσότερα μέτρα "
@@ -1557,7 +1562,7 @@ msgstr ""
 "ετήσιο προϋπολογισμό, εάν αυτό είναι απαραίτητο."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Αναθέστε σε κάποιον στην επιχείρησή σας την ευθύνη για την εφαρμογή αυτού "
@@ -1565,14 +1570,20 @@ msgstr ""
 "ενέργειες/μέτρα που περιγράφονται στο Σχέδιο Δράσης ή/και θα έχει την ευθύνη "
 "να διασφαλίζει την εφαρμογή τους."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Περιγράψτε: 1) ποια η γενική σας προσέγγιση για να εξαλείψετε τον κίνδυνο ή "
 "εάν αυτός είναι αναπόφευκτος, πώς να μειώσετε τον κίνδυνο, 2) την ειδική "
 "ενέργεια(-ες) που απαιτείται για να εφαρμόσετε αυτή την προσέγγιση (για να "
-"εξαλείψετε ή να μειώσετε τον κίνδυνο), 3) το επίπεδο τεχνογνωσίας που "
+"εξαλείψετε ή να μειώσετε τον κίνδυνο)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Περιγράψτε: 3) το επίπεδο τεχνογνωσίας που "
 "απαιτείται για να εφαρμοστεί το μέτρο, για παράδειγμα “κοινή λογική (δεν "
 "απαιτούνται γνώσεις AYE)”, “δεν απαιτείται συγκεκριμένη τεχνογνωσία AYE, "
 "ωστόσο χρειάζονται οι ελάχιστες γνώσεις ή κατάρτιση ΑΥΕ ή/και παροχή "
@@ -1637,7 +1648,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: θετικές δηλώσεις, οι οποίες περιέχονται σε ενότητες."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "επιλογή"
 
@@ -1685,7 +1696,7 @@ msgstr "Άκυρο"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "κλείσιμο"
 
@@ -2023,7 +2034,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Η αξιολόγηση του κινδύνου (εκτίμηση επικινδυνότητας) πραγματοποιήθηκε "
@@ -2079,7 +2090,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Μετά την τεχνική εξέλιξη του εργαλείου το 2009, το 2010 (έως το πρώτο μισό "
@@ -2121,17 +2132,17 @@ msgid "effect_high"
 msgstr "Μεγάλη (πολύ μεγάλη) σφοδρότητα"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Μικρή σοβαρότητα επιπτώσεων"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Μέτρια σοβαρότητα επιπτώσεων"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Μεγάλη σοβαρότητα επιπτώσεων"
 
@@ -2206,7 +2217,7 @@ msgid "error_existing_login"
 msgstr "Αυτό το όνομα σύνδεσης χρησιμοποιείται ήδη."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Παρακαλώ εισάγετε τον προϋπολογισμό σε ακέραια ευρώ."
 
@@ -2244,19 +2255,19 @@ msgid "error_password_mismatch"
 msgstr "Οι κωδικοί πρόσβασης δεν είναι ίδιοι"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας έναρξης."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας λήξης."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Αυτή η τιμή πρέπει να είναι θετικός ακέραιος αριθμός."
 
@@ -2376,7 +2387,7 @@ msgstr ""
 "ενότητά σας. "
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2385,12 +2396,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Έκθεση κινδύνου ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Έκθεση της Εκτίμησης Κινδύνου ${title} "
 
@@ -2410,7 +2421,7 @@ msgid "french"
 msgstr "Απλοποιημένα δύο κριτήρια "
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Σχεδόν ποτέ"
 
@@ -2420,57 +2431,57 @@ msgid "frequency_almostnever"
 msgstr "Σχεδόν ποτέ"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Διαρκώς"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Όχι πολύ συχνά"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Μία φορά το μήνα "
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Συχνά "
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Μία φορά την εβδομάδα "
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Σπάνια "
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Μία φορά το χρόνο"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Πολύ συχνά ή τακτικά "
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Τουλάχιστον μία φορά την ημέρα "
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Τακτικά"
@@ -2497,12 +2508,12 @@ msgid "header_additional_content"
 msgstr "Συμπληρωματικό περιεχόμενο"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Πρόσθετο πληροφοριακό υλικό για την εκτίμηση του κινδύνου"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Πρόσθετη πληροφόρηση γι’ αυτή τη θεματική ενότητα"
 
@@ -2517,12 +2528,12 @@ msgid "header_country_managers"
 msgstr "Εθνικοί διαχειριστές"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Φάση σχεδιασμού και πιλοτική φάση – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Εταίροι σχεδιασμού"
 
@@ -2560,18 +2571,18 @@ msgstr "Αναγνώριση"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Πληροφορίες"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Επίσημη παρουσίαση του έργου – Σεπτέμβριος 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Νομικές αναφορές και αναφορές πολιτικής"
 
@@ -2581,13 +2592,13 @@ msgid "header_legend"
 msgstr "Λεζάντα"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Άδειες χρήσης"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Σύνδεση"
@@ -2598,12 +2609,12 @@ msgid "header_main_image"
 msgstr "Κύρια εικόνα"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Μέτρο ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Μέτρο"
 
@@ -2629,12 +2640,12 @@ msgid "header_not_complicated"
 msgstr "Η αξιολόγηση δεν είναι πολύπλοκη "
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2669,7 +2680,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2690,7 +2701,7 @@ msgid "header_profile_questions"
 msgstr "Ερωτήσεις προφίλ"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Φάσεις έργου"
 
@@ -2706,7 +2717,7 @@ msgstr "Ερωτήσεις που απαντήθηκαν ανά ενότητα"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Εγγραφή"
 
@@ -2727,23 +2738,23 @@ msgid "header_risk_aware"
 msgstr "Γνωρίζετε όλους τους κινδύνους;"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Ποια είναι η σοβαρότητα των επιπτώσεων?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Πόσο συχνά εκτίθενται άνθρωποι σε αυτό τον κίνδυνο;"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Επιλέξτε την επικινδυνότητα για αυτόν τον κίνδυνο"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Ποια η πιθανότητα να προκληθεί αυτός ο κίνδυνος;"
 
@@ -2755,7 +2766,7 @@ msgid "header_risks"
 msgstr "Κίνδυνοι"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2815,12 +2826,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2835,17 +2846,17 @@ msgid "header_welcome"
 msgstr "Καλώς ήλθατε"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Τι είναι το έργο OiRA (Online διαδραστική Αξιολόγηση Κινδύνων)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Γιατί το έργο OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Σχόλια / Υφιστάμενα μέτρα (αν υπάρχουν)"
 
@@ -2866,142 +2877,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Κίνδυνοι μεσαίας επικινδυνότητας"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Κίνδυνοι υψηλής επικινδυνότητας"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Κίνδυνοι υψηλής επικινδυνότητας"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Κίνδυνοι υψηλής επικινδυνότητας"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Κίνδυνοι υψηλής επικινδυνότητας"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Κίνδυνοι χαμηλής επικινδυνότητας"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Κίνδυνοι χαμηλής επικινδυνότητας"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Κίνδυνοι χαμηλής επικινδυνότητας"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Κίνδυνοι χαμηλής επικινδυνότητας"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Κίνδυνοι μεσαίας επικινδυνότητας"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Κίνδυνοι μεσαίας επικινδυνότητας"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Κίνδυνοι μεσαίας επικινδυνότητας"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Κίνδυνοι μεσαίας επικινδυνότητας"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Κίνδυνοι σε εκκρεμότητα"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Κίνδυνοι σε εκκρεμότητα"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Κίνδυνοι σε εκκρεμότητα"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Κίνδυνοι σε εκκρεμότητα"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Κίνδυνοι υπό εξέταση"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Κίνδυνοι υπό εξέταση"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Κίνδυνοι υπό εξέταση"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Κίνδυνοι υπό εξέταση"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Πιθανοί κίνδυνοι"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Πιθανοί κίνδυνοι"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Πιθανοί κίνδυνοι"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Πιθανοί κίνδυνοι"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Αναγνωρισμένοι κίνδυνοι"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Αναγνωρισμένοι κίνδυνοι"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Αναγνωρισμένοι κίνδυνοι"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Αναγνωρισμένοι κίνδυνοι"
 
@@ -3023,7 +3034,7 @@ msgstr ""
 "Αυτό το κείμενο πρέπει να επεξηγεί πώς να εγγραφείτε και να συνδεθείτε."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Παρακαλούμε απαντήστε στις ακόλουθες ερωτήσεις. Με βάση τις απαντήσεις σας "
@@ -3052,7 +3063,7 @@ msgstr ""
 "αρχίσετε με ένα αντίγραφο κάποιου υπάρχοντος Εργαλείου OiRA. "
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο συχνά εκτίθενται οι εργαζόμενοι στον "
@@ -3066,14 +3077,14 @@ msgstr ""
 "προτεραιότητα. Ο χρήστης μπορεί να αλλάξει την προτεραιότητα."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο πιθανό είναι να εκδηλωθεί ο κίνδυνος "
 "αυτός σε φυσιολογικές συνθήκες."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο σοβαρές μπορεί να είναι οι επιπτώσεις "
@@ -3173,6 +3184,11 @@ msgstr ""
 "Ανεβάστε μια εικόνα. Βεβαιωθείτε ότι η εικόνα είναι τύπου png, jpg ή gif και "
 "ότι δεν περιέχει ειδικούς χαρακτήρες."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3188,7 +3204,7 @@ msgstr ""
 "την προσέγγιση (για να εξαλείψετε ή να μειώσετε τον κίνδυνο)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Περιγράψτε το επίπεδο τεχνογνωσίας που απαιτείται για να εφαρμοστούν τα "
@@ -3357,7 +3373,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Εάν δεν ορίσετε τίτλο, θα υιοθετηθεί από τα δεδομένα που θα εισάγετε."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3445,7 +3461,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Αυτή η έκδοση του εργαλείου είναι δοκιμαστική."
 
@@ -3650,13 +3666,13 @@ msgstr "Ο λογαριασμός είναι κλειδωμένος"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Σχέδιο Δράσης"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Προϋπολογισμός"
 
@@ -3666,27 +3682,22 @@ msgid "label_action_plan_download"
 msgstr "Σχέδιο Δράσης"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Τέλος εφαρμογής"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Ποιος είναι υπεύθυνος;"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Έναρξη εφαρμογής"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "προσθέστε άλλο μέτρο"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3729,8 +3740,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Παρακαλώ υποβάλλετε στο πεδίο αυτό τυχόν σχόλια σχετικά με την παραπάνω "
@@ -3817,7 +3828,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Περιγραφή"
@@ -3847,7 +3858,7 @@ msgstr "Εμφάνιση εξατομικευμένης ειδοποίησης �
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Αξιολόγηση"
 
@@ -3867,10 +3878,19 @@ msgid "label_evaluation_phase"
 msgstr "Φάση αξιολόγησης"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Μέτρο που έχει ήδη εφαρμοστεί"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3945,7 +3965,7 @@ msgstr "Εκπόνηση εκτίμησης κινδύνου"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Αναγνώριση"
 
@@ -3953,6 +3973,11 @@ msgstr "Αναγνώριση"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Αρχείο εικόνας"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3975,7 +4000,7 @@ msgid "label_language"
 msgstr "Γλώσσα"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Νομικές αναφορές και αναφορές πολιτικής"
@@ -4012,21 +4037,26 @@ msgstr "Λογότυπο"
 msgid "label_logo_selection"
 msgstr "Ποιο λογότυπο θέλετε να εμφανίζεται στην επάνω αριστερή γωνία;"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Γενική προσέγγιση (για την εξάλειψη ή μείωση του κινδύνου)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Απαιτείται ειδική ενέργεια(-ες) για την εφαρμογή αυτής της προσέγγισης"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Απαιτήσεις"
 
@@ -4084,25 +4114,25 @@ msgid "label_no"
 msgstr "Όχι"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Κανένας κίνδυνος/Ασφαλής κατάσταση"
@@ -4142,15 +4172,10 @@ msgstr "Κωδικός"
 msgid "label_password_confirm"
 msgstr "Κωδικός πρόσβασης ξανά"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Προτεινόμενα μέτρα"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Προετοιμασία"
 
@@ -4161,7 +4186,7 @@ msgstr "Προεπισκόπηση"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Προηγούμενο"
@@ -4226,15 +4251,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr "εγγραφή"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Διαγραφή αυτού του μέτρου"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Έκθεση"
 
@@ -4246,12 +4271,12 @@ msgstr ""
 "ερώτηση"
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4271,49 +4296,49 @@ msgid "label_risk_type"
 msgstr "Τύπος κινδύνου"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Κίνδυνος με αναφορά μέτρου(-ων)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Κίνδυνος χωρίς αναφορά μέτρου(-ων)"
@@ -4326,7 +4351,7 @@ msgstr "Αποθήκευση και προσθήκη άλλου κινδύνου
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Αποθήκευση"
 
@@ -4351,7 +4376,7 @@ msgid "label_sector_title"
 msgstr "Τίτλος του τομέα."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 "Επιλέξτε ένα ή περισσότερα από τα γνωστά και κοινώς αποδεκτά μέτρα που "
@@ -4384,7 +4409,7 @@ msgid "label_show_less_hellip"
 msgstr "Εμφάνιση λιγότερων στοιχείων…"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} για αυτό τον κίνδυνο."
 
@@ -4414,7 +4439,7 @@ msgid "label_start_identification"
 msgstr "Ξεκίνησε την Αναγνώριση των Κινδύνων"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Έναρξη"
 
@@ -4459,29 +4484,29 @@ msgid "label_surveygroup_title"
 msgstr "Τίτλος εισαχθέντος εργαλείου OiRA"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Υψηλή"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Χαμηλή"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Μέτρια"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Τίτλος"
 
@@ -4541,12 +4566,12 @@ msgid "label_user_title"
 msgstr "Όνομα"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 μέτρα)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(χωρίς αναφορά μέτρων)"
 
@@ -4594,7 +4619,7 @@ msgid "limitations"
 msgstr "περιορισμοί"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Σύνδεση"
 
@@ -4693,7 +4718,7 @@ msgid "menu_import"
 msgstr "Εισαγωγή Εργαλείου OiRA "
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4800,32 +4825,32 @@ msgid "nav_usermanagement"
 msgstr "Διαχείριση χρήστη"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Βοήθεια"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Αποσύνδεση"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Ρυθμίσεις"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Παρούσα Κατάσταση"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Αξιολογήσεις"
 
@@ -4875,27 +4900,27 @@ msgid "notice_country_manager"
 msgstr "Εθνικός διευθυντής για την ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Online διαδραστική"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Αξιολόγηση κινδύνων"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4915,7 +4940,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4929,7 +4954,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Η επίσημη παρουσίαση του εργαλείου έχει προγραμματιστεί για το Σεπτέμβριο "
@@ -4960,45 +4985,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Υψηλή"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Χαμηλή"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Μέτρια"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Υψηλή"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Μέτρια"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Χαμηλή"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% πλήρης"
 
@@ -5051,18 +5076,13 @@ msgstr "Δεν έχετε λογαριασμό; Εάν όχι, απαιτείτ�
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -5075,7 +5095,7 @@ msgstr ""
 "ακόλουθα οφέλη:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -5090,17 +5110,17 @@ msgstr ""
 "πρέπει να συμπεριλαμβάνονται σε αυτή την αναφορά, στο παρακάτω πεδίο."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Αυτή η αναφορά βασίστηκε στο εργαλείο OiRA '${title}' με ημερομηνία "
@@ -5132,35 +5152,35 @@ msgid "request_an_email_reminder"
 msgstr "ζητήστε email υπενθύμισης"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Εκτίμηση επικινδυνότητας: ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "Υψηλή"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "Χαμηλή"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "Μέτρια "
 
@@ -5180,7 +5200,7 @@ msgid "risk_solution_header"
 msgstr "Μέτρο αντιμετώπισης ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Πρέπει να γίνει απογραφή αυτού του κινδύνου"
@@ -5228,46 +5248,46 @@ msgid "select_add_existing_measure"
 msgstr "Επιλέξτε ή προσθέστε τυχόν μέτρα που εφαρμόζονται ήδη."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Όχι πολύ σοβαρή "
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Χρειάζεται διακοπή από την εργασία για λιγότερες από 3 ημέρες "
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Σοβαρή "
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Χρειάζεται διακοπή από την εργασία για περισσότερες από 3 ημέρες "
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Πολύ σοβαρή "
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Μη αναστρέψιμος τραυματισμός, ανίατη ασθένεια, θάνατος "
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Μικρή "
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Δεν χρειάζεται διακοπή από την εργασία "
 
@@ -5341,7 +5361,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Σχετικά"
 
@@ -5356,7 +5376,7 @@ msgid "title_account_settings"
 msgstr "Ρυθμίσεις λογαριασμού "
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Αλλαγή κωδικού πρόσβασης"
@@ -5367,7 +5387,7 @@ msgid "title_client_help"
 msgstr "Κείμενο βοήθειας πελάτη"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Μέτρο"
 
@@ -5402,7 +5422,7 @@ msgid "title_import_sector_survey"
 msgstr "Εισαγωγή τομέα και εργαλείου OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Πρόσθετοι κίνδυνοι (από το χρήστη)"
@@ -5429,8 +5449,8 @@ msgstr "Παρούσα κατάσταση της μελέτης Εκτίμηση
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Online διαδραστική Αξιολόγηση Κινδύνων"
 
@@ -5455,19 +5475,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Παρούσα κατάσταση της μελέτης Εκτίμησης Κινδύνου ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Περιεχόμενα"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Αυτός ο κίνδυνος δεν υπάρχει στην επιχείρησή σας, αλλά επειδή η οργάνωση του "
@@ -5475,7 +5495,7 @@ msgstr ""
 "συμπεριληφθεί σε αυτή την έκθεση."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Αυτός ο κίνδυνος δεν υπάρχει στην επιχείρησή σας, αλλά επειδή η οργάνωση του "
@@ -5483,7 +5503,7 @@ msgstr ""
 "συμπεριληφθεί σε αυτή την έκθεση. "
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Αν και δεν έχετε ακόμα εξετάσει τον συγκεκριμένο κίνδυνο ή η εξέτασή του "
@@ -5515,7 +5535,7 @@ msgid "use_it_to_full_report"
 msgstr "Αξιοποιήστε το"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Αξιοποιήστε το"
 
@@ -5525,12 +5545,12 @@ msgid "use_it_to_measures_report"
 msgstr "Αξιοποιήστε το"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Αξιοποιήστε το"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Αξιοποιήστε το"
 
@@ -5545,7 +5565,7 @@ msgid "warn_fix_errors"
 msgstr "Παρακαλώ αποκαταστήστε τα σφάλματα που επισημαίνονται. "
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Απαντήσατε αρνητικά στην παραπάνω φράση."
@@ -5570,6 +5590,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ναι"
+
+#~ msgid "label_add_measure"
+#~ msgstr "προσθέστε άλλο μέτρο"
+
+#~ msgid "label_prefill"
+#~ msgstr "Προτεινόμενα μέτρα"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -171,7 +171,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -238,7 +238,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -300,11 +300,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -341,15 +341,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -407,15 +407,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr ""
@@ -489,7 +489,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -520,7 +520,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -536,8 +536,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -546,7 +545,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -578,11 +577,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -594,7 +593,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -613,12 +612,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -735,12 +734,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -756,8 +757,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -782,9 +783,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -821,7 +822,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -850,8 +851,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -872,11 +873,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -951,7 +952,7 @@ msgstr ""
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -966,6 +967,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1015,7 +1020,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1032,7 +1037,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1132,7 +1137,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 
@@ -1140,8 +1145,8 @@ msgstr ""
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1153,9 +1158,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1262,113 +1267,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1428,7 +1438,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1476,7 +1486,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1744,7 +1754,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1788,7 +1798,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1822,17 +1832,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1902,7 +1912,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1938,17 +1948,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2038,7 +2048,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2047,12 +2057,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -2072,7 +2082,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2082,57 +2092,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2153,12 +2163,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2173,12 +2183,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2214,18 +2224,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2235,13 +2245,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2252,12 +2262,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2283,12 +2293,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2323,7 +2333,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2343,7 +2353,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2359,7 +2369,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2380,23 +2390,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2408,7 +2418,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2468,12 +2478,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2488,17 +2498,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2519,142 +2529,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2674,7 +2684,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2694,7 +2704,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2704,12 +2714,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2799,6 +2809,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2810,7 +2825,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2931,7 +2946,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -2996,7 +3011,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3148,13 +3163,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3164,26 +3179,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3227,8 +3237,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3313,7 +3323,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3343,7 +3353,7 @@ msgstr ""
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3363,9 +3373,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3441,13 +3460,18 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
 #. Default: "Image file"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3471,7 +3495,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3506,21 +3530,26 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3576,25 +3605,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3634,15 +3663,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3653,7 +3677,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3716,15 +3740,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3734,12 +3758,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3759,49 +3783,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3814,7 +3838,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3839,7 +3863,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3868,7 +3892,7 @@ msgid "label_show_less_hellip"
 msgstr ""
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3898,7 +3922,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3943,29 +3967,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4025,12 +4049,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4075,7 +4099,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4156,7 +4180,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4256,32 +4280,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4331,27 +4355,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4371,7 +4395,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4383,7 +4407,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4409,45 +4433,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4500,18 +4524,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4521,7 +4540,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4531,17 +4550,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4571,35 +4590,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4619,7 +4638,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4667,46 +4686,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4766,7 +4785,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4781,7 +4800,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4792,7 +4811,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4827,7 +4846,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr ""
@@ -4854,8 +4873,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4880,29 +4899,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4927,7 +4946,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4937,12 +4956,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4957,7 +4976,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -626,7 +626,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -670,7 +670,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1412,10 +1412,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -3998,6 +3994,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4390,7 +4391,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1948,17 +1948,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2704,7 +2704,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2714,12 +2714,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3237,7 +3237,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3383,7 +3383,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3677,7 +3677,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3838,7 +3838,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3879,6 +3879,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab-fr-evaluation-5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -82,7 +82,7 @@ msgstr ""
 "Como ${provide-evidence} a las autoridades competentes (inspección del "
 "trabajo);"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -197,7 +197,7 @@ msgstr "Añada contenido de la biblioteca"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -268,7 +268,7 @@ msgstr "Herramientas OiRA disponibles"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -298,7 +298,7 @@ msgstr "Países candidatos"
 msgid "Candidate country"
 msgstr "País candidato"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Cambiar dirección de correo electrónico"
 
@@ -334,11 +334,11 @@ msgstr ""
 "Contiene: toda la información y comentarios hechos a través del proceso de "
 "evaluación de riesgos."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Contiene un resumen de las medidas que deben aplicarse."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Contiene un resumen de los riesgos identificados"
 
@@ -377,15 +377,15 @@ msgstr "Información de país y grupo del cliente."
 msgid "Country manager"
 msgstr "Gestor de país"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Licencia genérica Creative Commons Attribution-ShareAlike 2.5"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licencia Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -443,15 +443,15 @@ msgstr "Descargar el plan de acción"
 msgid "Download the full report"
 msgstr "Descargar el informe completo"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Descargar el resumen de las medidas"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Descargar el resumen de riesgos"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Correo electrónico"
@@ -525,7 +525,7 @@ msgstr "Carpeta"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formato: Excel (.xls)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Formato: formato de documento portátil (.pdf)"
 
@@ -533,7 +533,7 @@ msgstr "Formato: formato de documento portátil (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Alemania"
 
@@ -560,7 +560,7 @@ msgstr ""
 "Sin embargo, puede seguir con la evaluación el tiempo de que disponga y "
 "después continuar en el mismo punto en que lo dejó."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Deseo compartir el siguiente enlace"
 
@@ -576,8 +576,7 @@ msgstr ""
 msgid "Important"
 msgstr "Importante"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Información"
 
@@ -586,7 +585,7 @@ msgstr "Información"
 msgid "Information"
 msgstr "Información"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Formato de archivo inválido para imagen. Por favor utilice PNG, JPEG o GIF."
@@ -623,11 +622,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "Guardado"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Aprenda más sobre esta herramienta…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -639,7 +638,7 @@ msgstr "Login"
 msgid "Manage"
 msgstr "gestionar"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Medida"
@@ -660,13 +659,13 @@ msgstr ""
 "medidas necesarias;"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Controlar las medidas que serán implantadas durante los 3 próximos meses"
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 "Supervisar si se están tratando de forma adecuada los riesgos y las medidas."
@@ -796,12 +795,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Ayuda online"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Resumen de medidas"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Resumen de riesgos"
@@ -819,8 +820,8 @@ msgstr ""
 "prevención, empleador, expertos en salud y seguridad en el trabajo)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Transmitir información a las personas interesadas."
 
@@ -850,9 +851,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr " Por favor, consulte los ejemplos debajo del formulario."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Pospuesto"
 
@@ -895,7 +896,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Leer más"
 
@@ -929,8 +930,8 @@ msgstr ""
 "con la evaluación en curso o para comenzar otra nueva."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -951,11 +952,11 @@ msgstr "Riesgo"
 msgid "Risk assessments made with this tool"
 msgstr "Evaluaciones de riesgo realizadas con esta herramienta"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Atención"
 
@@ -1033,7 +1034,7 @@ msgstr "Comparta esta herramienta OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Mostrar biblioteca de ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Identifíquese"
 
@@ -1049,6 +1050,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Estándar"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1103,7 +1108,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Países Bajos"
 
@@ -1122,7 +1127,7 @@ msgstr ""
 "La arquitectura básica de una herramienta interactiva de  evaluación de "
 "riesgos en línea, consiste en:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1230,7 +1235,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Esta herramienta merece llegar al conocimiento de una audiencia mundial. "
@@ -1240,8 +1245,8 @@ msgstr ""
 msgid "Tip"
 msgstr "Consejo"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Activar la pantalla de ayuda"
 
@@ -1253,9 +1258,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Sin respuesta"
 
@@ -1373,38 +1378,38 @@ msgid "Your password was successfully changed."
 msgstr "Su contraseña se ha cambiado correctamente."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "El código fuente de la aplicación OiRA tiene una licencia ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "El contenido de las herramientas de sector OiRA tiene una licencia bajo "
 "${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "Las herramientas de sector OiRA las pueden utilizar de forma gratuita todos "
 "los usuarios."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Más información sobre el proyecto OiRA (en inglés)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Estrategia de la comunidad europea sobre seguridad e higiene laborales "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "La experiencia demuestra que ${key}. Por este motivo EU-OSHA desarrolló "
@@ -1415,42 +1420,42 @@ msgstr ""
 "acciones de control y ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "aplicación web rentable y fácil de usar"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "evaluación"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identificación"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "la evaluación de riesgos adecuada es la clave de la salud laboral"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "acciones preventivas"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "realización de informes"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "proceso de evaluación de riesgos paso a paso"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "La aplicación web OiRA otorga acceso a las herramientas de evaluación de "
@@ -1458,7 +1463,7 @@ msgstr ""
 "nivel nacional."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "La ${agency} solicita el desarrollo de herramientas sencillas para facilitar "
@@ -1471,7 +1476,7 @@ msgstr ""
 "general que el proyecto OiRA pretende superar."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "El proyecto OiRA y la aplicación web relacionada ha sido desarrollada por "
@@ -1482,14 +1487,14 @@ msgstr ""
 "desarrollando con la participación y ayuda de los sindicatos FNV, CNV y MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Los siguientes socios técnicos han contribuido al desarrollo del proyecto "
 "OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "La Agencia ha recibido asesoramiento experto y estratégico por parte del "
@@ -1498,12 +1503,12 @@ msgstr ""
 "interés de la Junta directiva, por la comisión y por EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "las medianas y pequeñas empresas  tienen defectos"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Aunque algunas medidas no cuestan dinero, la mayoría sí. Por tanto, se debe "
@@ -1511,7 +1516,7 @@ msgstr ""
 "si es necesario."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Designe a alguien de su empresa para que sea el responsable de la "
@@ -1519,13 +1524,19 @@ msgstr ""
 "cabo los pasos descritos en el plan y/o responsabilidad para garantizar que "
 "se realicen."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Describa: 1) ¿cuál es su enfoque general para eliminar o (si el riesgo es "
 "inevitable) reducir el riesgo?; 2) las acciones necesarias para implantar "
-"este enfoque (para eliminar o reducir el riesgo); 3) el nivel de experiencia "
+"este enfoque (para eliminar o reducir el riesgo)"
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Describa: 3) el nivel de experiencia "
 "necesario para implantar la medida, por ejemplo “sentido común (no se "
 "necesitan conocimientos de OSH)”, “no se requiere experiencia específica con "
 "OSH, pero se requiere un conocimiento sobre OSH mínimo o formación y/o "
@@ -1591,7 +1602,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: Afirmaciones positivas, que están contenidas en módulos."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Añadir"
 
@@ -1639,7 +1650,7 @@ msgstr "Cancelar"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Cerrar"
 
@@ -1970,7 +1981,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "La herramienta ha evaluado de forma automática el riesgo. Podrá modificar la "
@@ -2027,7 +2038,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Tras el desarrollo técnico de la herramienta en 2009, en 2010 (hasta la "
@@ -2069,17 +2080,17 @@ msgid "effect_high"
 msgstr "Gravedad alta (muy alta)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Gravedad débil"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Gravedad importante"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Gravedad alta (muy alta)"
 
@@ -2155,7 +2166,7 @@ msgid "error_existing_login"
 msgstr "El nombre de login ya existe."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Introduzca un presupuesto en euros."
 
@@ -2191,17 +2202,17 @@ msgid "error_password_mismatch"
 msgstr "Las contraseñas no coinciden"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Esta fecha debe ser igual o posterior a la fecha de inicio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Esta fecha debe ser igual o anterior a la fecha de finalización."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "El valor debe ser un número entero positivo."
 
@@ -2310,7 +2321,7 @@ msgstr ""
 "fusionar los cambios realizados en la herramienta OiRA en su sesión."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 "Este riesgo se ha establecido como existente por defecto. No se puede "
@@ -2321,12 +2332,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Plan de acción ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Informe de identificación ${title}"
 
@@ -2346,7 +2357,7 @@ msgid "french"
 msgstr "Dos criterios simplificados"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Casi nunca"
 
@@ -2356,57 +2367,57 @@ msgid "frequency_almostnever"
 msgstr "Casi nunca"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Constante"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "No muy frecuente"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Una vez al mes"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Frecuente"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Una vez a la semana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Raro"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Una vez al año"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Muy frecuente o habitual"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Mínimo una vez al día"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regular"
@@ -2433,12 +2444,12 @@ msgid "header_additional_content"
 msgstr "Contenido adicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Recursos adicionales para evaluar el riesgo"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Recursos adicionales para este módulo"
 
@@ -2453,12 +2464,12 @@ msgid "header_country_managers"
 msgstr "Gestores de país"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Fase de desarrollo y piloto – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Socios de desarrollo"
 
@@ -2494,18 +2505,18 @@ msgstr "Identificación"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Información"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Lanzamiento oficial del proyecto – Septiembre de 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Referencias legales y de políticas"
 
@@ -2515,13 +2526,13 @@ msgid "header_legend"
 msgstr "Leyenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licencias"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Entrar"
@@ -2532,12 +2543,12 @@ msgid "header_main_image"
 msgstr "Imagen principal"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Medida ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Medida"
 
@@ -2563,12 +2574,12 @@ msgid "header_not_complicated"
 msgstr "La evaluación no es complicada"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2603,7 +2614,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2623,7 +2634,7 @@ msgid "header_profile_questions"
 msgstr "Pregunta perfil"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Fases del proyecto"
 
@@ -2639,7 +2650,7 @@ msgstr "Preguntas respondidas por módulo"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrarse"
 
@@ -2660,23 +2671,23 @@ msgid "header_risk_aware"
 msgstr "¿Es consciente de todos los riesgos?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "¿Cuál es la gravedad del daño?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "¿Con qué frecuencia está expuesta la gente a este riesgo?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Seleccione la prioridad de este riesgo"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "¿Cuál es la probabilidad de que se produzca el riesgo?"
 
@@ -2688,7 +2699,7 @@ msgid "header_risks"
 msgstr "Riesgos"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2748,12 +2759,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2768,17 +2779,17 @@ msgid "header_welcome"
 msgstr "Bienvenido"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Qué es el proyecto OiRA (evaluación de riesgos interactiva online)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "El motivo del proyecto OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Comentarios"
 
@@ -2799,142 +2810,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Riesgos de prioridad media"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Riesgo de prioridad alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Riesgos de prioridad alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Riesgos de prioridad alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Riesgos de prioridad alta"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Riesgo de prioridad baja"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Riesgos de prioridad baja"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Riesgos de prioridad baja"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Riesgos de prioridad baja"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Riesgo de prioridad media"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Riesgos de prioridad media"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Riesgos de prioridad media"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Riesgos de prioridad media"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Riesgo pospuesto"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Riesgos pospuestos"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Riesgos pospuestos"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Riesgos pospuestos"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Riesgo no respondido"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Riesgos no respondidos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Riesgos no respondidos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Riesgos no respondidos"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Posible riesgo"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Posibles riesgos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Posibles riesgos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Posibles riesgos"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Riesgo existente"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Riesgos existentes"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Riesgos existentes"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Riesgos existentes"
 
@@ -2954,7 +2965,7 @@ msgid "help_authentication"
 msgstr "Este texto debe explicar cómo registrarse e iniciar sesión."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Responda a las siguientes preguntas. Como resultado de sus respuestas, el "
@@ -2985,7 +2996,7 @@ msgstr ""
 "empezar con una copia de una herramienta OiRA existente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indicar con qué frecuencia se produce el riesgo en una situación normal."
@@ -2998,13 +3009,13 @@ msgstr ""
 "usuario podrá seguir cambiando la prioridad."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indicar la probabilidad de que ocurra este riesgo en una situación normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indique la gravedad si este riesgo se produce."
 
@@ -3096,6 +3107,11 @@ msgstr ""
 "Cargar una imagen. Asegúrese de que su imagen tiene el formato png, jpg o "
 "gif y que no contiene caracteres especiales."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3111,7 +3127,7 @@ msgstr ""
 "(para eliminar o reducir el riesgo)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Describa el nivel de experiencia necesario para implantar la medida, por "
@@ -3271,7 +3287,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Si no especifica un título se tomará del texto introducido."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3358,7 +3374,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Sesión de prueba"
 
@@ -3560,13 +3576,13 @@ msgstr "La cuenta está bloqueada"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Plan de acción"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Presupuesto"
 
@@ -3576,27 +3592,22 @@ msgid "label_action_plan_download"
 msgstr "Plan de acción"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Final del plan"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "¿Quién es responsable?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Inicio del plan"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Añadir otra medida"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3639,8 +3650,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Por favor, deje cualquier comentario que tenga sobre la pregunta anterior en "
@@ -3727,7 +3738,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Descripción"
@@ -3757,7 +3768,7 @@ msgstr "¿Mostrar una notificación personalizada para esta herramienta OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Evaluación"
 
@@ -3777,10 +3788,19 @@ msgid "label_evaluation_phase"
 msgstr "Fase de evaluación"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Medida ya aplicada"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3855,7 +3875,7 @@ msgstr "Sesiones"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identificación"
 
@@ -3863,6 +3883,11 @@ msgstr "Identificación"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Archivo de imagen"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3885,7 +3910,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referencias legales y de política"
@@ -3920,21 +3945,26 @@ msgstr "Logotipo"
 msgid "label_logo_selection"
 msgstr "¿Qué logotipo desea mostrar en la esquina superior izquierda?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Enfoque general (para eliminar o reducir el riesgo)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Acciones específicas necesarias para implantar este enfoque"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Nivel de experiencia y/o requisitos necesarios"
 
@@ -3992,25 +4022,25 @@ msgid "label_no"
 msgstr "No"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Sin riesgo"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Sin riesgo"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Sin riesgo"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Sin riesgo"
@@ -4050,15 +4080,10 @@ msgstr "Contraseña"
 msgid "label_password_confirm"
 msgstr "Repetir contraseña"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Medidas predeterminadas"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Preparación"
 
@@ -4069,7 +4094,7 @@ msgstr "Vista previa"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
@@ -4132,15 +4157,15 @@ msgstr "Puede descargar un informe completo y un plan de acción."
 msgid "label_register_first"
 msgstr "Registrarse"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Borrar esta medida"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Informe"
 
@@ -4152,12 +4177,12 @@ msgstr ""
 "este campo"
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4177,49 +4202,49 @@ msgid "label_risk_type"
 msgstr "Tipo de riesgo"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Riesgo con medida(s)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Riesgo sin medidas"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Riesgos con medida(s)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Riesgos con medida(s)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riesgos con medida(s)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Riesgos sin medidas"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Riesgos sin medidas"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riesgos sin medidas"
@@ -4232,7 +4257,7 @@ msgstr "Guardar y añadir otro riesgo"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Guardar y continuar"
 
@@ -4257,7 +4282,7 @@ msgid "label_sector_title"
 msgstr "Título del sector"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Seleccione una o varias de las medidas habituales indicadas."
 
@@ -4288,7 +4313,7 @@ msgid "label_show_less_hellip"
 msgstr "Mostrar menos"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} sobre este riesgo."
 
@@ -4318,7 +4343,7 @@ msgid "label_start_identification"
 msgstr "Iniciar la identificación de Riesgos"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Iniciar"
 
@@ -4363,29 +4388,29 @@ msgid "label_surveygroup_title"
 msgstr "Título de la herramienta OiRA importada"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "alto"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "bajo"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "medio"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Título"
 
@@ -4445,12 +4470,12 @@ msgid "label_user_title"
 msgstr "Nombre"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 medidas)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(sin medidas)"
 
@@ -4497,7 +4522,7 @@ msgid "limitations"
 msgstr "limitaciones"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Identifíquese"
 
@@ -4587,7 +4612,7 @@ msgid "menu_import"
 msgstr "Importar herramienta OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4693,32 +4718,32 @@ msgid "nav_usermanagement"
 msgstr "Gestión de usuarios"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Ayuda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Cerrar sessión"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Ajustes"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Grado de cumplimentación"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Mis Evaluaciones"
 
@@ -4768,27 +4793,27 @@ msgid "notice_country_manager"
 msgstr "Gestor de país para ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Evaluación de riesgos"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "interactiva en línea"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4808,7 +4833,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4820,7 +4845,7 @@ msgid "password_policy_conditions"
 msgstr "Contraseña de confirmación"
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "El lanzamiento oficial de la herramienta está programado para septiembre de "
@@ -4851,45 +4876,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Alto"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Bajo"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Medio"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Grande"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Media"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Pequeña"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% completa"
 
@@ -4941,18 +4966,13 @@ msgstr "¿No tiene una cuenta? ${register_link} primero."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4964,7 +4984,7 @@ msgstr ""
 "de descarga. Regístrese en un solo paso y acceda a las siguientes ventajas:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4978,17 +4998,17 @@ msgstr ""
 "incluirse en este informe en el campo de abajo."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Este informe se ha basado en la herramienta OiRA '${title}' de la fecha de "
@@ -5020,35 +5040,35 @@ msgid "request_an_email_reminder"
 msgstr "solicitar un mensaje recordatorio"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Este es un riesgo prioritario ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "alto"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "bajo"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "medio"
 
@@ -5068,7 +5088,7 @@ msgid "risk_solution_header"
 msgstr "Medida ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Se debe seguir registrando el riesgo."
@@ -5117,46 +5137,46 @@ msgstr ""
 "Seleccione o añada cualquier medida <strong>que ya esté vigente</strong>."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "No muy grave"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Necesidad de parar de trabajar menos de 3 días"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Grave"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Necesidad de parar de trabajar mas de 3 días"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Muy grave"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Lesión irreversible, enfermedad incurable, muerte"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Débil"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "No hay necesidad de parar de trabajar"
 
@@ -5228,7 +5248,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Información sobre"
 
@@ -5243,7 +5263,7 @@ msgid "title_account_settings"
 msgstr "Ajustes de cuenta"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Cambiar contraseña"
@@ -5254,7 +5274,7 @@ msgid "title_client_help"
 msgstr "Texto de ayuda de cliente"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Medida"
 
@@ -5289,7 +5309,7 @@ msgid "title_import_sector_survey"
 msgstr "Importar sector y herramienta OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Riesgos añadidos (por Ud)"
@@ -5316,8 +5336,8 @@ msgstr "Estado de ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Evaluación de riesgos interactiva en línea"
 
@@ -5342,19 +5362,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Estado de ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Contenido"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Este riesgo no afecta a su organización, pero, como el sector de su "
@@ -5362,7 +5382,7 @@ msgstr ""
 "incluirse en este informe."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Este riesgo no afecta a su organización, pero, como el sector de su "
@@ -5370,7 +5390,7 @@ msgstr ""
 "incluirse en este informe."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Este riesgo aún no se ha evaluado, pero, como se considera de alta "
@@ -5399,7 +5419,7 @@ msgid "use_it_to_full_report"
 msgstr "Úselo para"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Úselo para"
 
@@ -5409,12 +5429,12 @@ msgid "use_it_to_measures_report"
 msgstr "Úselo para"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Úselo para"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Úselo para"
 
@@ -5429,7 +5449,7 @@ msgid "warn_fix_errors"
 msgstr "Soluciones los errores indicados."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Ha respondido negativamente a la afirmación anterior."
@@ -5453,6 +5473,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sí"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Añadir otra medida"
+
+#~ msgid "label_prefill"
+#~ msgstr "Medidas predeterminadas"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab-fr-evaluation-5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -675,7 +675,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -719,7 +719,7 @@ msgstr "No"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1574,10 +1574,6 @@ msgstr "Información"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Producido por ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "basada en"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4418,6 +4414,11 @@ msgstr "medio"
 msgid "label_title"
 msgstr "Título"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "basada en ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4827,7 +4828,7 @@ msgid "optional"
 msgstr "Opcional"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5477,6 +5478,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sí"
+
+#~ msgid "based on"
+#~ msgstr "basada en"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Añadir otra medida"

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab-fr-evaluation-5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -585,7 +585,7 @@ msgstr "Información"
 msgid "Information"
 msgstr "Información"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Formato de archivo inválido para imagen. Por favor utilice PNG, JPEG o GIF."
@@ -1053,7 +1053,7 @@ msgstr "Estándar"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Medidas pre-establecidas"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1127,7 +1127,7 @@ msgstr ""
 "La arquitectura básica de una herramienta interactiva de  evaluación de "
 "riesgos en línea, consiste en:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1536,12 +1536,11 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Describa: 3) el nivel de experiencia "
-"necesario para implantar la medida, por ejemplo “sentido común (no se "
-"necesitan conocimientos de OSH)”, “no se requiere experiencia específica con "
-"OSH, pero se requiere un conocimiento sobre OSH mínimo o formación y/o "
-"consultoría sobre OSH”. Puede describir también aquí cualquier requisito "
-"adicional (si lo hay)."
+"Describa: 3) el nivel de experiencia necesario para implantar la medida, por "
+"ejemplo “sentido común (no se necesitan conocimientos de OSH)”, “no se "
+"requiere experiencia específica con OSH, pero se requiere un conocimiento "
+"sobre OSH mínimo o formación y/o consultoría sobre OSH”. Puede describir "
+"también aquí cualquier requisito adicional (si lo hay)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2202,17 +2201,17 @@ msgid "error_password_mismatch"
 msgstr "Las contraseñas no coinciden"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Esta fecha debe ser igual o posterior a la fecha de inicio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Esta fecha debe ser igual o anterior a la fecha de finalización."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "El valor debe ser un número entero positivo."
 
@@ -2996,7 +2995,7 @@ msgstr ""
 "empezar con una copia de una herramienta OiRA existente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indicar con qué frecuencia se produce el riesgo en una situación normal."
@@ -3009,13 +3008,13 @@ msgstr ""
 "usuario podrá seguir cambiando la prioridad."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indicar la probabilidad de que ocurra este riesgo en una situación normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indique la gravedad si este riesgo se produce."
 
@@ -3289,7 +3288,7 @@ msgstr "Si no especifica un título se tomará del texto introducido."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Inicio"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3650,7 +3649,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3798,9 +3797,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Añadir otra medida"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4094,7 +4093,7 @@ msgstr "Vista previa"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
@@ -4257,7 +4256,7 @@ msgstr "Guardar y añadir otro riesgo"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Guardar y continuar"
 
@@ -4301,6 +4300,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Seleccionar medidas pre-establecidas"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5370,7 +5374,7 @@ msgstr "Contenido"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Mostrar/ocultar menú"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -632,7 +632,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -676,7 +676,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1418,10 +1418,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -4006,6 +4002,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4398,7 +4399,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -63,7 +63,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -244,7 +244,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -272,7 +272,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -306,11 +306,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -347,15 +347,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -413,15 +413,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-post"
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -542,8 +542,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -552,7 +551,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -584,11 +583,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Lisateave selle tööriista kohta…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -600,7 +599,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -619,12 +618,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -741,12 +740,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -762,8 +763,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -788,9 +789,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -827,7 +828,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -856,8 +857,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -878,11 +879,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -957,7 +958,7 @@ msgstr "Jagage seda OiRA vahendit"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -972,6 +973,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1021,7 +1026,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1038,7 +1043,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1138,7 +1143,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "See vahend väärib tutvustamist maailmale! Jagage seda!"
 
@@ -1146,8 +1151,8 @@ msgstr "See vahend väärib tutvustamist maailmale! Jagage seda!"
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1159,9 +1164,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1268,113 +1273,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1434,7 +1444,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1482,7 +1492,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1750,7 +1760,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1796,7 +1806,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1830,17 +1840,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1910,7 +1920,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1946,17 +1956,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2046,7 +2056,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2055,12 +2065,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -2080,7 +2090,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2090,57 +2100,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2161,12 +2171,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2181,12 +2191,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2222,18 +2232,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2243,13 +2253,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2291,12 +2301,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2331,7 +2341,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2351,7 +2361,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2367,7 +2377,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2388,23 +2398,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2416,7 +2426,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2476,12 +2486,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2496,17 +2506,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2527,142 +2537,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2682,7 +2692,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2702,7 +2712,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2712,12 +2722,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2807,6 +2817,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2818,7 +2833,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2939,7 +2954,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3004,7 +3019,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3156,13 +3171,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3172,26 +3187,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3235,8 +3245,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3321,7 +3331,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3351,7 +3361,7 @@ msgstr "Kas soovid selle OiRA-vahendi jaoks kohandatud teadet?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3371,9 +3381,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3449,13 +3468,18 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
 #. Default: "Image file"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3479,7 +3503,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3514,21 +3538,26 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3584,25 +3613,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3642,15 +3671,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3661,7 +3685,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3724,15 +3748,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3742,12 +3766,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3767,49 +3791,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3822,7 +3846,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3847,7 +3871,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3876,7 +3900,7 @@ msgid "label_show_less_hellip"
 msgstr "Näita vähem"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3906,7 +3930,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3951,29 +3975,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4033,12 +4057,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4083,7 +4107,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4164,7 +4188,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4264,32 +4288,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4339,27 +4363,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4379,7 +4403,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4391,7 +4415,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4417,45 +4441,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4504,18 +4528,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4525,7 +4544,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4535,17 +4554,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4575,35 +4594,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4623,7 +4642,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4671,46 +4690,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4770,7 +4789,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4785,7 +4804,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4796,7 +4815,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4831,7 +4850,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr ""
@@ -4858,8 +4877,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4884,29 +4903,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4931,7 +4950,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4941,12 +4960,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4961,7 +4980,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1956,17 +1956,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2722,12 +2722,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3245,7 +3245,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3391,7 +3391,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3846,7 +3846,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3887,6 +3887,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2020-04-28 07:57+0000\n"
+"POT-Creation-Date: 2020-05-12 10:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid "Are you sure you want to delete this measure? This action can not be reverted."
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid "The current text in the fields 'Action plan', 'Prevention plan' and 'Requirements' of this measure will be overwritten. This action cannot be reverted. Are you sure you want to continue?"
 msgstr ""
 
@@ -1873,17 +1873,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2631,7 +2631,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334
+#: euphorie/client/browser/risk.py:336
 #: euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
@@ -2642,13 +2642,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329
+#: euphorie/client/browser/risk.py:331
 #: euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338
+#: euphorie/client/browser/risk.py:340
 #: euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
@@ -3178,7 +3178,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3332,7 +3332,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3649,7 +3649,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3813,7 +3813,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3854,6 +3854,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2020-05-12 10:42+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -600,7 +600,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -644,7 +644,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1329,10 +1329,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -3974,6 +3970,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4369,7 +4370,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid "Are you sure you want to delete this measure? This action can not be reverted."
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -279,11 +279,11 @@ msgstr ""
 msgid "Contains: all the information and input provided by you throughout the risk assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -319,15 +319,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -385,15 +385,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr ""
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "However, you can spend whatever time you have available on an assessment and then return to it when convenient to pick up from the same point you left off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -511,8 +511,8 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181
+#: euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -586,12 +586,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -698,12 +698,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -717,8 +719,8 @@ msgid "Pass information on to the people concerned (workers, safety representati
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -738,9 +740,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -773,7 +775,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -798,8 +800,8 @@ msgid "Registering allows you to simply log in at any time to continue previous 
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -820,11 +822,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -898,7 +900,7 @@ msgstr ""
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -913,6 +915,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -957,7 +963,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -973,7 +979,7 @@ msgstr ""
 msgid "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid "The current text in the fields 'Action plan', 'Prevention plan' and 'Requirements' of this measure will be overwritten. This action cannot be reverted. Are you sure you want to continue?"
 msgstr ""
 
@@ -1061,7 +1067,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 
@@ -1069,8 +1075,8 @@ msgstr ""
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1082,9 +1088,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1178,113 +1184,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1344,7 +1355,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1392,7 +1403,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1663,7 +1674,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1708,7 +1719,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1742,17 +1753,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1826,7 +1837,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1862,17 +1873,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -1962,7 +1973,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -1971,12 +1982,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -1996,7 +2007,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2006,57 +2017,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2078,12 +2089,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2098,12 +2109,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2139,18 +2150,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2160,13 +2171,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2177,12 +2188,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2208,12 +2219,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2248,7 +2259,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2268,7 +2279,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2284,7 +2295,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2305,23 +2316,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2333,7 +2344,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2393,12 +2404,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2413,17 +2424,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2444,142 +2455,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2599,7 +2610,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2620,7 +2631,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321
+#: euphorie/client/browser/risk.py:334
 #: euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
@@ -2631,13 +2642,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316
+#: euphorie/client/browser/risk.py:329
 #: euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325
+#: euphorie/client/browser/risk.py:338
 #: euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
@@ -2729,6 +2740,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2740,7 +2756,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2864,7 +2880,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -2929,7 +2945,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3082,13 +3098,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386
 #: euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3099,29 +3115,24 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434
-#: euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390
+#: euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383
 #: euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432
-#: euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388
+#: euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3167,8 +3178,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3259,7 +3270,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3290,7 +3301,7 @@ msgstr ""
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3311,9 +3322,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3400,7 +3420,7 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
@@ -3408,6 +3428,11 @@ msgstr ""
 #: euphorie/content/module.py:78
 #: euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3433,7 +3458,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120
 #: euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
@@ -3471,23 +3496,27 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413
-#: euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373
+#: euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420
-#: euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380
 #: euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
@@ -3547,25 +3576,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3606,15 +3635,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3625,7 +3649,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3690,15 +3714,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3708,12 +3732,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3734,49 +3758,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3789,7 +3813,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3814,7 +3838,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3843,7 +3867,7 @@ msgid "label_show_less_hellip"
 msgstr ""
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3873,7 +3897,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3919,29 +3943,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4002,12 +4026,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4054,7 +4078,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4135,7 +4159,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4235,32 +4259,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4310,27 +4334,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4350,7 +4374,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4362,7 +4386,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4388,45 +4412,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4482,18 +4506,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4503,7 +4522,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4513,17 +4532,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4554,35 +4573,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4602,7 +4621,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4650,46 +4669,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4749,7 +4768,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4764,7 +4783,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4775,7 +4794,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4810,7 +4829,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98
+#: euphorie/client/docx/compiler.py:95
 #: euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
@@ -4838,8 +4857,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4864,29 +4883,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4911,7 +4930,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4921,12 +4940,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4941,7 +4960,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.1.1dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -249,7 +249,7 @@ msgstr "Haluatko varmasti poistaa tämän istunnon? Poistoa ei voi peruuttaa."
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:26
 msgid "Are you sure you want to proceed?"
-msgstr ""
+msgstr "Haluatko varmasti jatkaa?"
 
 #: euphorie/content/behaviour/configure.zcml:33
 msgid "Automatically generate unique ids for content"
@@ -278,6 +278,7 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
+"Voit luoda uuden riskinarviointipohjan myös kopioimalla tämän riskinarvioinnin. Tällöin uuden riskiarvioinnin työstäminen jatkuu tämän nykyisen pohjalta."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -350,7 +351,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/module_identification_custom.pt:39
 msgid "Continue to action plan"
-msgstr ""
+msgstr "Jatka toimintasuunnitelmaan"
 
 #: euphorie/content/profiles/default/types/euphorie.country.xml
 msgid "Country"
@@ -576,9 +577,9 @@ msgstr "Tiedot"
 msgid "Information"
 msgstr "Tiedot"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr ""
+msgstr "Tarkista kuvan tiedostomuoto. Tallennettavan kuvan tulee olla PNG-, JPEG- tai GIF-muodossa."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -1043,7 +1044,7 @@ msgstr "Vakio"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Ehdotetut toimenpiteet"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1051,7 +1052,7 @@ msgstr "Vakioratkaisu"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:83
 msgid "Started"
-msgstr ""
+msgstr "Aloitettu"
 
 #: euphorie/client/browser/login.py:232
 #: euphorie/client/browser/templates/new-session-test.pt:89
@@ -1117,7 +1118,7 @@ msgstr ""
 "Online-muotoisen vuorovaikutteisen riskinarvioinnin perusarkkitehtuuri "
 "koostuu seuraavista tekijöistä :"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1258,11 +1259,11 @@ msgstr "Lähetys"
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:198
 msgid "Upload an image that illustrates this risk."
-msgstr ""
+msgstr "Lataa tätä riskiä havainnollistava kuva."
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:217
 msgid "Upload image"
-msgstr ""
+msgstr "Lataa kuva"
 
 #: euphorie/content/behaviour/configure.zcml:19
 msgid "Use a rich text description for content types."
@@ -1311,7 +1312,7 @@ msgstr "Kyllä"
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:34
 msgid "Yes, clone risk assessment"
-msgstr ""
+msgstr "Kyllä, luo kopio riskinarvioinnista"
 
 #: euphorie/content/templates/library.pt:17
 msgid ""
@@ -1514,11 +1515,10 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Kuvaa: yrityksessä "
-"toimenpiteiden toteuttamiseksi tarvittava asiantuntemus ja/tai ulkopuolisen "
-"tuen tarve (esim. työsuojelulainsäädännön osaaminen, suojainten käytön ja "
-"huollon tuntemus, laitteen maahantuojan antama perehdytys, työterveyshuollon "
-"tuki)."
+"Kuvaa: yrityksessä toimenpiteiden toteuttamiseksi tarvittava asiantuntemus "
+"ja/tai ulkopuolisen tuen tarve (esim. työsuojelulainsäädännön osaaminen, "
+"suojainten käytön ja huollon tuntemus, laitteen maahantuojan antama "
+"perehdytys, työterveyshuollon tuki)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2166,17 +2166,17 @@ msgid "error_password_mismatch"
 msgstr "Salasanat eivät täsmää"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Päivämäärän on oltava sama kuin alkamispäivä tai sitä myöhempi."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Päivämäärän on oltava sama kuin päättymispäivä tai sitä aiempi."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Kohtaan on merkittävä positiivinen kokonaisluku."
 
@@ -2959,7 +2959,7 @@ msgstr ""
 "olemassa olevan OiRA-työkalun kopiolla."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Ilmoita, kuinka usein riski esiintyy normaalissa tilanteessa."
 
@@ -2971,14 +2971,14 @@ msgstr ""
 "vaihtaa prioriteetin."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Ilmoita, kuinka todennäköistä tämän riskin esiintyminen on normaalissa "
 "tilanteessa."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Ilmoita vakavuusaste tämän riskin ilmentyessä."
 
@@ -3249,7 +3249,7 @@ msgstr "Jos et anna nimitystä, se otetaan syötteestä."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Ohjausnäkymä"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3598,7 +3598,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3746,9 +3746,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Lisää muita toimenpiteitä"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3773,7 +3773,7 @@ msgstr "Formaatti"
 #. Default: "General information"
 #: euphorie/client/browser/templates/status_info.pt:31
 msgid "label_general_information"
-msgstr "Yleistä tietoa"
+msgstr "Yhteenveto"
 
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
@@ -4042,7 +4042,7 @@ msgstr "Esikatselu"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Edellinen"
@@ -4204,14 +4204,14 @@ msgstr "Tallenna ja lisää toinen riski"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Tallenna ja jatka"
 
 #. Default: "Save and finish"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:256
 msgid "label_save_and_finish"
-msgstr ""
+msgstr "Tallenna ja lopeta"
 
 #. Default: "Section"
 #: euphorie/client/report.py:151
@@ -4246,6 +4246,11 @@ msgstr "Valitse yksi seuraavista toimialatyökaluista"
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Valitse toimenpiteet"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4295,7 +4300,7 @@ msgstr "Aloita"
 #. Default: "Started"
 #: euphorie/client/browser/templates/status_info.pt:51
 msgid "label_started"
-msgstr ""
+msgstr "aloitettu"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4407,7 +4412,7 @@ msgstr ""
 #. Default: "Used tool"
 #: euphorie/client/browser/templates/status_info.pt:36
 msgid "label_used_tool"
-msgstr ""
+msgstr "OiRA-työkalu"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -5314,7 +5319,7 @@ msgstr "Sisältö"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Näytä/piilota valikko"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.1.1dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -80,7 +80,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} työsuojeluviranomaisille (työsuojelutarkastus)."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr "Lisää sisältöä kirjastosta"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -264,7 +264,7 @@ msgstr "Saatavilla olevat OiRA-työkalut"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr "Ehdokasmaat"
 msgid "Candidate country"
 msgstr "Ehdokasvaltio"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Vaihda sähköpostiosoite"
 
@@ -327,11 +327,11 @@ msgid ""
 msgstr ""
 "Sisältää kaikki tiedot, jotka olet antanut riskinarviointiprosessin aikana."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Sisältö: yhteenveto toteutettavista toimenpiteistä."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Sisältö: yhteenveto tunnistetuista riskeistä."
 
@@ -368,15 +368,15 @@ msgstr "Maatiedot ja ryhmitys asiakkaalle."
 msgid "Country manager"
 msgstr "Maajohtaja"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons -lisenssi"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -434,15 +434,15 @@ msgstr "Lataa toimintasuunnitelma"
 msgid "Download the full report"
 msgstr "Lataa koko raportti"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Lataa yhteenveto toimenpiteistä."
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Lataa yhteenveto riskeistä"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Sähköposti"
@@ -516,7 +516,7 @@ msgstr "Kansio"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formaatti: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Muoto: Portable Document Format (.pdf)"
 
@@ -524,7 +524,7 @@ msgstr "Muoto: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Saksa"
 
@@ -551,7 +551,7 @@ msgstr ""
 "Voit kulloinkin käyttää arviointiin aikaa sen verran kuin sinulla sitä on, "
 "ja myöhemmin palata siihen kohtaan, johon viimeksi jäit. "
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Haluan jakaa seuraavan kanssasi"
 
@@ -567,8 +567,7 @@ msgstr ""
 msgid "Important"
 msgstr "Tärkeää"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Tiedot"
 
@@ -577,7 +576,7 @@ msgstr "Tiedot"
 msgid "Information"
 msgstr "Tiedot"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -611,11 +610,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "tallennettu"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Lisätietoja tästä työkalusta…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -627,7 +626,7 @@ msgstr "Sisäänkirjautuminen"
 msgid "Manage"
 msgstr "Toteuttaessasi"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Toimenpide"
@@ -648,14 +647,14 @@ msgstr ""
 "ovatko ne vaikuttaneet halutulla tavalla sekä"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Seuraa suunniteltujen toimenpiteiden toteutumista tulevan kolmen kuukauden "
 "aikana."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Seuraa, huolehditaanko riskeistä/toimenpiteistä asianmukaisesti."
 
@@ -782,12 +781,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online-apu"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Yhteenveto toteutettavista toimenpiteistä"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Yhteenveto tunnistetuista riskeistä"
@@ -806,8 +807,8 @@ msgstr ""
 "ja ylläpitävistä toimista,"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Välitä tiedot asianomaisille henkilöille."
 
@@ -838,9 +839,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Ota huomioon kaavakkeen alla olevat esimerkit."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "arvioimatta"
 
@@ -883,7 +884,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Lue lisää"
 
@@ -918,8 +919,8 @@ msgstr ""
 "jatkaa kesken olevia arviointeja tai aloittaa uusia. "
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Poista"
 
@@ -940,11 +941,11 @@ msgstr "Riski"
 msgid "Risk assessments made with this tool"
 msgstr "Tämän välineen avulla tehdyt riskinarvioinnit"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "kehitettävää"
 
@@ -1023,7 +1024,7 @@ msgstr "Jaa tämä OiRA-työkalu"
 msgid "Show library from ${dropdown}."
 msgstr "Näytä kirjasto ${dropdown}-valikosta."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Kirjaudu sisään"
 
@@ -1039,6 +1040,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Vakio"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1093,7 +1098,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Alankomaat"
 
@@ -1112,7 +1117,7 @@ msgstr ""
 "Online-muotoisen vuorovaikutteisen riskinarvioinnin perusarkkitehtuuri "
 "koostuu seuraavista tekijöistä :"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1220,7 +1225,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Kaikkien kannattaa tutustua tähän työkaluun! Jaa se!"
 
@@ -1228,8 +1233,8 @@ msgstr "Kaikkien kannattaa tutustua tähän työkaluun! Jaa se!"
 msgid "Tip"
 msgstr "Vihje"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Ohjeen näyttöpainike"
 
@@ -1241,9 +1246,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "vastaus puuttuu"
 
@@ -1360,32 +1365,32 @@ msgid "Your password was successfully changed."
 msgstr "Salasanasi on muutettu."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "OiRA-sovelluksen lähdekoodi on ${GPL}-lisensoitu."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "OiRA-toimialatyökalujen sisällön lisenssi on ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "Kaikki käyttäjät voivat käyttää OiRA-toimialatyökaluja maksutta."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Enemmän tietoa OiRA-projektista (englanniksi)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr "Yhteisön työterveys- ja työturvallisuusstrategia vuosiksi 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Kokemus osoittaa, että ${key}. Sen vuoksi on luotu EU-OSHAn kehittämä "
@@ -1395,50 +1400,50 @@ msgstr ""
 "${preventive_actions} sekä toimenpiteet, tarkkailu ja ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "helppokäyttöinen ja maksuton verkkosovellus"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "arviointi"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "tunnistus"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "riskien kunnollinen arviointi on tärkeää terveellisten työpaikkojen kannalta"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "ennaltaehkäisevät toimenpiteet"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "raportointi"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "vaihe vaiheelta etenevä riskien arviointi"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "OiRA-verkkosovelluksessa on toimialojen riskinarviointityökaluja, jotka ovat "
 "luoneet ja joita ylläpitää toimialaorganisaatiot kansallisella tasolla."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} pyytää kehittämään yksinkertaisia työkaluja helpottamaan "
@@ -1450,7 +1455,7 @@ msgstr ""
 "yleensä. OiRA-projektin tarkoituksena on auttaa tässä."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "OiRA-projektin ja sen verkkosovelluksen on kehittänyt ${eu-osha} perustuen "
@@ -1461,14 +1466,14 @@ msgstr ""
 "edelleen yhdessä ammattijärjestöjen FNV, CNV ja MHP kanssa."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Seuraavat tekniset yhteistyökumppanit ovat osallistuneet OiRA-projektin "
 "kehitykseen:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Virasto on saanut myös strategista neuvontaa ja asiatuntija-apua "
@@ -1477,33 +1482,39 @@ msgstr ""
 "eturyhmiä."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikro- ja pienyrityksillä on joitakin puutteita"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Jotkut toimenpiteet eivät maksa mitään, jotkut maksavat. Toimenpiteillä "
 "täytyy sen vuoksi olla budjetti. Lisää ne tarvittaessa vuosibudjettiin."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Nimitä yrityksessäsi tästä toimenpiteessä vastuussa oleva henkilö. Tämä "
 "henkilö on valtuutettu suunnitelmassa kuvattujen vaiheiden toteuttamiseen ja/"
 "tai varmistamaan, että ne suoritetaan."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Kuvaa: Henkilöstöön, tiloihin, laitteisiin tms. kohdentuva yleinen "
 "toimenpide riskin poistamiseksi tai sen pienentämiseksi (jos riski ei ole "
 "poistettavissa), muut toimenpiteet riskin poistamiseksi tai pienentämiseksi "
-"(esim. yrityksen prosessien kehittäminen, hankinnat) sekä yrityksessä "
+"(esim. yrityksen prosessien kehittäminen, hankinnat)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Kuvaa: yrityksessä "
 "toimenpiteiden toteuttamiseksi tarvittava asiantuntemus ja/tai ulkopuolisen "
 "tuen tarve (esim. työsuojelulainsäädännön osaaminen, suojainten käytön ja "
 "huollon tuntemus, laitteen maahantuojan antama perehdytys, työterveyshuollon "
@@ -1568,7 +1579,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: myönteiset lausumat, jotka sisältyvät moduuleihin."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Lisää"
 
@@ -1616,7 +1627,7 @@ msgstr "Peruuta"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Sulje"
 
@@ -1940,7 +1951,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Työkalu tekee riskinarvioinnin automaattisesti. Voit tarvittaessa muuttaa "
@@ -1992,7 +2003,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Työkalu kehitettiin vuonna 2009. Sen jälkeen vuonna 2010 (vuoden 2011 "
@@ -2034,17 +2045,17 @@ msgid "effect_high"
 msgstr "Suuri (erittäin suuri) vakavuus"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Pieni"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Merkittävä"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Suuri (erittäin suuri)"
 
@@ -2119,7 +2130,7 @@ msgid "error_existing_login"
 msgstr "Tämä kirjautumisnimi on jo käytössä."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Anna budjetti kokonaisina summina euroina."
 
@@ -2155,17 +2166,17 @@ msgid "error_password_mismatch"
 msgstr "Salasanat eivät täsmää"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Päivämäärän on oltava sama kuin alkamispäivä tai sitä myöhempi."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Päivämäärän on oltava sama kuin päättymispäivä tai sitä aiempi."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Kohtaan on merkittävä positiivinen kokonaisluku."
 
@@ -2277,7 +2288,7 @@ msgstr ""
 "päivittää nämä muutokset, ennen kuin voit jatkaa."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2286,12 +2297,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Toimintasuunnitelma ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Tunnistusraportti ${title}"
 
@@ -2311,7 +2322,7 @@ msgid "french"
 msgstr "Kaksi yksinkertaistettua kriteeriä"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Ei juuri koskaan"
 
@@ -2321,57 +2332,57 @@ msgid "frequency_almostnever"
 msgstr "Ei juuri koskaan"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Jatkuvasti"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Ei kovin usein"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Kerran kuukaudessa"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Usein"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Kerran viikossa"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Harvoin"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Kerran vuodessa"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Erittäin usein tai säännöllisesti"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Vähintään kerran päivässä"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Säännöllisesti"
@@ -2397,12 +2408,12 @@ msgid "header_additional_content"
 msgstr "Ylimääräinen sisältö"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Lisämateriaalia riskinarviointia varten."
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Lisämateriaalia tähán osioon"
 
@@ -2417,12 +2428,12 @@ msgid "header_country_managers"
 msgstr "Maajohtajat"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Kehitys- ja pilottivaihe – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Kehityskumppanit"
 
@@ -2459,18 +2470,18 @@ msgstr "Tunnistus"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Tiedot"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Projektin virallinen julkistaminen – syyskuussa 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Oikeudelliset ja toimintaperiaatteita koskevat viitteet"
 
@@ -2480,13 +2491,13 @@ msgid "header_legend"
 msgstr "Selite"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Lisenssit"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Kirjaudu sisään"
@@ -2497,12 +2508,12 @@ msgid "header_main_image"
 msgstr "Pääkuva"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Toimenpide ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Toimenpide"
 
@@ -2528,12 +2539,12 @@ msgid "header_not_complicated"
 msgstr "Arviointi ei ole monimutkainen"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2568,7 +2579,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2588,7 +2599,7 @@ msgid "header_profile_questions"
 msgstr "Profiilikysymykset"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projektin vaiheet"
 
@@ -2604,7 +2615,7 @@ msgstr "Vastatut väittämät ryhmiteltynä osioittain."
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Rekisteröidy käyttäjäksi"
 
@@ -2625,23 +2636,23 @@ msgid "header_risk_aware"
 msgstr "Oletko tietoinen kaikista riskeistä?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Minkälainen on vahingon vakavuus?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Kuinka usein ihmiset altistuvat tälle riskille?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Valitse riskin prioriteetti"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Minkälainen on tämän riskin toteutumismahdollisuus?"
 
@@ -2653,7 +2664,7 @@ msgid "header_risks"
 msgstr "Riskit"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2713,12 +2724,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2733,18 +2744,18 @@ msgid "header_welcome"
 msgstr "Tervetuloa"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "Mikä on OiRA (Vuorovaikutteinen riskinarviointiprojekti verkossa) -projekti"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Miksi OiRA-projekti"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Kommentit"
 
@@ -2765,142 +2776,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Riskit, joiden riskitaso on keskitasoinen."
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Riski, jonka riskitaso on korkea."
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Riskit, joiden riskitaso on korkea."
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Riskit, joiden riskitaso on korkea."
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Riskit, joiden riskitaso on korkea."
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Riski, jonka riskitaso on matala."
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Riskit, joiden riskitaso on matala."
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Riskit, joiden riskitaso on matala."
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Riskit, joiden riskitaso on matala."
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Riski, jonka riskitaso on keskitasoinen."
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Riskit, joiden riskitaso on keskitasoinen."
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Riskit, joiden riskitaso on keskitasoinen."
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Riskit, joiden riskitaso on keskitasoinen."
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Riskiväittämä on arvioimatta."
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Riskiväittämää on arvioimatta."
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Riskiväittämää on arvioimatta."
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Riskiväittämää on arvioimatta."
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Riskiväittämään ei ole vastattu."
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Riskiväittämään ei ole vastattu."
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Riskiväittämään ei ole vastattu."
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Riskiväittämään ei ole vastattu."
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Mahdollinen riski"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Mahdolliset riskit"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Mahdolliset riskit"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Mahdolliset riskit"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Riski (tämänhetkinen)"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Riskit (tämänhetkiset)"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Riskit (tämänhetkiset)"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Riskit (tämänhetkiset)"
 
@@ -2921,7 +2932,7 @@ msgstr ""
 "Tämän teksin tulee kuvailla, kuinka voi rekisteröityä ja kirjautua sisään."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Vastaa seuraaviin kysymyksiin: Järjestelmä laskee vastaustesi perusteella "
@@ -2948,7 +2959,7 @@ msgstr ""
 "olemassa olevan OiRA-työkalun kopiolla."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Ilmoita, kuinka usein riski esiintyy normaalissa tilanteessa."
 
@@ -2960,14 +2971,14 @@ msgstr ""
 "vaihtaa prioriteetin."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Ilmoita, kuinka todennäköistä tämän riskin esiintyminen on normaalissa "
 "tilanteessa."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Ilmoita vakavuusaste tämän riskin ilmentyessä."
 
@@ -3061,6 +3072,11 @@ msgstr ""
 "Lähetä kuva. Varmista, että kuvasi formaatti on png, jpg tai gif ja että "
 "siinä ei ole erikoismerkkejä."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3076,7 +3092,7 @@ msgstr ""
 "pienentämiseksi)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Kerro mitä asiantuntemusta tarvitaan toimenpiteen toteuttamiseen, esim. "
@@ -3231,7 +3247,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Jos et anna nimitystä, se otetaan syötteestä."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3315,7 +3331,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Tämä on kokeiluversio"
 
@@ -3508,13 +3524,13 @@ msgstr "Tili on lukittu"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Toimintasuunnitelma"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budjetti"
 
@@ -3524,27 +3540,22 @@ msgid "label_action_plan_download"
 msgstr "Toimintasuunnitelma"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Toimenpiteet toteutettu/tilanne kunnossa"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Vastuuhenkilö"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Aikataulu: Toimenpiteiden suunnittelu"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Lisää toinen toimenpide"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3587,8 +3598,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Tähän voit lisätä tietoja tai kommentteja yllä olevaan liittyen. Ne näkyvät "
@@ -3675,7 +3686,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Kuvaus"
@@ -3705,7 +3716,7 @@ msgstr "Näytä tälle OiRA-välineelle räätälöity ilmoitus"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Arviointi"
 
@@ -3725,10 +3736,19 @@ msgid "label_evaluation_phase"
 msgstr "Arviointivaihe"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Toimenpide on jo toteutettu"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3803,7 +3823,7 @@ msgstr "Riskinarviointisi toteuttaminen"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Tunnistaminen"
 
@@ -3811,6 +3831,11 @@ msgstr "Tunnistaminen"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Kuvatiedosto"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3833,7 +3858,7 @@ msgid "label_language"
 msgstr "Kieli"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Oikeudelliset ja toimintaperiaatteita koskevat viitteet"
@@ -3868,23 +3893,28 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Minkä logon haluat näkyvän vasemmassa yläkulmassa?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Yleinen toimenpide riskin poistamiseksi tai pienentämiseksi"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 "Muut tarvittavat toimenpiteet riskin poistamiseksi tai pienentämiseksi sekä "
 "yrityksessä"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Tarvittava asiantuntemus ja/tai ulkopuolisen tuen tarve"
 
@@ -3940,25 +3970,25 @@ msgid "label_no"
 msgstr "Ei"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Ei riskiä"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Ei riskejä"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Ei riskejä"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Ei riskejä"
@@ -3998,15 +4028,10 @@ msgstr "Salasana"
 msgid "label_password_confirm"
 msgstr "Salasanan toisto"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Esitäytä"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Suunnittelu"
 
@@ -4017,7 +4042,7 @@ msgstr "Esikatselu"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Edellinen"
@@ -4081,15 +4106,15 @@ msgstr "Voit ladata raportin ja toimintasuunnitelman kokonaisuudessaan."
 msgid "label_register_first"
 msgstr "rekisteröidy"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Poista tämä toimenpide"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Raportti"
 
@@ -4099,12 +4124,12 @@ msgid "label_report_comment"
 msgstr "Lisää tähän tietoja tai kommentteja, jotka haluat näkyviin raportille."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4124,49 +4149,49 @@ msgid "label_risk_type"
 msgstr "Riskityyppi"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Riski, johon on määritetty toimenpiteitä"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Riski, josta puuttuu toimenpiteet"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Riskit, joihin on määritetty toimenpiteitä"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Riskit, joihin on määritetty toimenpiteitä"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riskit, joihin on määritetty toimenpiteitä"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Riskit, joista puuttuvat toimenpiteet"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Riskit, joista puuttuvat toimenpiteet"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riskit, joista puuttuvat toimenpiteet"
@@ -4179,7 +4204,7 @@ msgstr "Tallenna ja lisää toinen riski"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Tallenna ja jatka"
 
@@ -4204,7 +4229,7 @@ msgid "label_sector_title"
 msgstr "Toimialan nimitys"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Valitse yksi tai useampi tunnetuista yleisistä toimenpiteistä."
 
@@ -4233,7 +4258,7 @@ msgid "label_show_less_hellip"
 msgstr "Näytä vähemmän"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} tästä riskistä."
 
@@ -4263,7 +4288,7 @@ msgid "label_start_identification"
 msgstr "Aloita riskien tunnistaminen"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Aloita"
 
@@ -4308,29 +4333,29 @@ msgid "label_surveygroup_title"
 msgstr "Tuodun OiRA-työkalun otsikko"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Korkea"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Matala"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Keskitasoinen"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Otsikko"
 
@@ -4390,12 +4415,12 @@ msgid "label_user_title"
 msgstr "Nimi"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 toimenpidettä)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(ilman toimenpiteitä)"
 
@@ -4442,7 +4467,7 @@ msgid "limitations"
 msgstr "rajoitukset"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Kirjaudu sisään"
 
@@ -4532,7 +4557,7 @@ msgid "menu_import"
 msgstr "Tuo OiRA-työkalu"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4635,32 +4660,32 @@ msgid "nav_usermanagement"
 msgstr "Käyttäjähallinta"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Ohjeet"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Kirjaudu ulos"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Asetukset"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Riskinarvioinnin tila"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Omat arviointini"
 
@@ -4710,27 +4735,27 @@ msgid "notice_country_manager"
 msgstr "Maajohtaja ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Vuorovaikutteisesti verkossa"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Riskinarviointi"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4750,7 +4775,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4764,7 +4789,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Työkalun virallinen julkistaminen on suunniteltu syyskuuksi 2011, sen "
@@ -4795,45 +4820,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Suuri"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Pieni"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Keskitasoinen"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Iso"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Keskitasoinen"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Pieni"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Täydellinen"
 
@@ -4885,18 +4910,13 @@ msgstr "Eikö sinulla ole tiliä? ${register_link} ensin."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4909,7 +4929,7 @@ msgstr ""
 "etuja:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4924,17 +4944,17 @@ msgstr ""
 "kenttään raporttiin lisättäviä kommentteja ja lisätietoja."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Tämä raportti perustui OiRA-työkaluun '${title}', version päivämäärä ${date}."
@@ -4965,35 +4985,35 @@ msgid "request_an_email_reminder"
 msgstr "pyydä sähköpostimuistutusta"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Riskitaso on suuruudeltaan ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "korkea"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "matala"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "keskitasoinen"
 
@@ -5013,7 +5033,7 @@ msgid "risk_solution_header"
 msgstr "Toimenpide ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Tämä riski täytyy vielä inventoida."
@@ -5061,46 +5081,46 @@ msgid "select_add_existing_measure"
 msgstr "Valitse tai lisää jo käytössä olevat toimenpiteet."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Ei erittäin vakava"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Työt täytyy keskeyttää alle 3 päiväksi"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Vakava"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Työt täytyy keskeyttää yli 3 päiväksi"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Erittäin vakava"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Pysyvä vamma, parantumaton sairaus, kuolema"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Pieni"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Työntekoa ei tarvitse keskeyttää"
 
@@ -5172,7 +5192,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Tietoja"
 
@@ -5187,7 +5207,7 @@ msgid "title_account_settings"
 msgstr "Tiliasetukset"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Vaihda salasana"
@@ -5198,7 +5218,7 @@ msgid "title_client_help"
 msgstr "Asiakkaan aputeksti"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Toimenpide"
 
@@ -5233,7 +5253,7 @@ msgid "title_import_sector_survey"
 msgstr "Tuo toimiala ja OiRA-työkalu"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Muut tunnistetut riskitekijät"
@@ -5260,8 +5280,8 @@ msgstr "\"${survey_title}\" riskinarvioinnin eteneminen"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Vuorovaikutteinen riskinarviointiprojekti verkossa"
 
@@ -5286,19 +5306,19 @@ msgid "title_with_vowel_status_of"
 msgstr "\"${survey_title}\" riskinarvioinnin eteneminen"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Sisältö"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Vastauksesi perusteella asia näyttäisi olevan yrityksessäsi kunnossa. Koska "
@@ -5306,7 +5326,7 @@ msgstr ""
 "siksi se tulee aina mukaan toimintasuunnitelmaan."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Vastauksesi perusteella asia näyttäisi olevan yrityksessäsi kunnossa. Koska "
@@ -5314,7 +5334,7 @@ msgstr ""
 "siksi se tulee aina mukaan toimintasuunnitelmaan."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Tämä riskiväittämä on arvioimatta. Koska toimialalla tähän tiedetään "
@@ -5343,7 +5363,7 @@ msgid "use_it_to_full_report"
 msgstr "Käytä sitä"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Käytä sitä"
 
@@ -5353,12 +5373,12 @@ msgid "use_it_to_measures_report"
 msgstr "Käytä sitä"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Käytä sitä"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Käytä sitä"
 
@@ -5373,7 +5393,7 @@ msgid "warn_fix_errors"
 msgstr "Korjaa mainitut virheet."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Vastasit kieltävästi yllä olevaan toteamukseen."
@@ -5397,6 +5417,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Kyllä"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Lisää toinen toimenpide"
+
+#~ msgid "label_prefill"
+#~ msgstr "Esitäytä"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Toimintasuunnitelmassa oleviin toimenpiteisiin ei tehty muutoksia."

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.1.1dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -278,7 +278,9 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
-"Voit luoda uuden riskinarviointipohjan myös kopioimalla tämän riskinarvioinnin. Tällöin uuden riskiarvioinnin työstäminen jatkuu tämän nykyisen pohjalta."
+"Voit luoda uuden riskinarviointipohjan myös kopioimalla tämän "
+"riskinarvioinnin. Tällöin uuden riskiarvioinnin työstäminen jatkuu tämän "
+"nykyisen pohjalta."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -579,7 +581,9 @@ msgstr "Tiedot"
 
 #: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr "Tarkista kuvan tiedostomuoto. Tallennettavan kuvan tulee olla PNG-, JPEG- tai GIF-muodossa."
+msgstr ""
+"Tarkista kuvan tiedostomuoto. Tallennettavan kuvan tulee olla PNG-, JPEG- "
+"tai GIF-muodossa."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -664,7 +668,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -708,7 +712,7 @@ msgstr "Ei"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1552,10 +1556,6 @@ msgstr "Tietoja"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Valmistaja ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4364,6 +4364,11 @@ msgstr "Keskitasoinen"
 msgid "label_title"
 msgstr "Otsikko"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "perustuen ${tool_title} -arviointipohjaan"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4770,7 +4775,7 @@ msgid "optional"
 msgstr "Valinnainen"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -2372,12 +2372,12 @@ msgstr ""
 #. Default: "Action plan ${title}"
 #: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
-msgstr "Plan d'action ${title}.doc"
+msgstr "Rapport Oira ${title}"
 
 #. Default: "Identification report ${title}"
 #: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
-msgstr "Rapport d'identification ${title}"
+msgstr "Oira liste des risques ${title}"
 
 #. Default: "Timeline for ${title}"
 #: euphorie/client/report.py:227

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -683,7 +683,7 @@ msgid "Montenegro"
 msgstr "Monténégro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -727,7 +727,7 @@ msgstr "Non"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1594,10 +1594,6 @@ msgstr "À propos"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Produit par ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "pour l’OiRA"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4492,6 +4488,11 @@ msgstr "moyen"
 msgid "label_title"
 msgstr "Titre"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "pour l’OiRA ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4904,7 +4905,7 @@ msgid "optional"
 msgstr "Optionnel"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5559,6 +5560,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Oui"
+
+#~ msgid "based on"
+#~ msgstr "pour l’OiRA"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Ajouter une autre mesure"

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -87,7 +87,7 @@ msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 "${provide-evidence} auprès des autorités de contrôle (inspection du travail);"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr "Ajouter du contenu à partir de la bibliothèque"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr "Mesure additionnelle"
 
@@ -243,7 +243,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -276,7 +276,7 @@ msgstr "Outils Oira disponibles"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgstr "Pays candidats"
 msgid "Candidate country"
 msgstr "Pays candidat"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Changer mon adresse email"
 
@@ -340,11 +340,11 @@ msgstr ""
 "Contenus: toutes les informations et contributions que vous avez renseignées "
 "durant le processus d´évaluation des risques. "
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Contient: une vue d'ensemble des mesures à mettre en œuvre."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Contient: une vue d'ensemble des risques identifiés."
 
@@ -383,17 +383,17 @@ msgstr "Informations pays et regroupement pour le client. "
 msgid "Country manager"
 msgstr "Gestionnaire de pays"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 "Creative Commons Paternité - Partage des Conditions Initiales à l'Identique "
 "2.5 Générique "
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licence Creative Commons "
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -451,15 +451,15 @@ msgstr "Téléchargez le plan d´action"
 msgid "Download the full report"
 msgstr "Téléchargez le rapport complet"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Télécharger la vue d'ensemble des mesures"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Télécharger la vue d'ensemble des risques "
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Adresse électronique"
@@ -533,7 +533,7 @@ msgstr "Dossier"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Format: Excel (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Format: Portable Document Format (.pdf)"
 
@@ -541,7 +541,7 @@ msgstr "Format: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Allemagne"
 
@@ -569,7 +569,7 @@ msgstr ""
 "limité puis y revenir lorsque vous le désirez pour reprendre là où vous vous "
 "étiez arrêté. "
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 "Je souhaite vous faire découvrir cet outil d'aide à l'évaluation des risques"
@@ -586,8 +586,7 @@ msgstr ""
 msgid "Important"
 msgstr "Important "
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Information"
 
@@ -596,7 +595,7 @@ msgstr "Information"
 msgid "Information"
 msgstr "Information"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -631,11 +630,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "Sauvegardé"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "En savoir plus sur cet outil…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -647,7 +646,7 @@ msgstr "Connexion"
 msgid "Manage"
 msgstr "Pour gérer la mise en œuvre"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Mesure"
@@ -666,12 +665,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "de justificatif auprès des autorités de contrôle;"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Suivi des mesures à mettre en œuvre dans les 3 prochains mois."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 "Contrôler si les risques / les mesures sont traités de manière appropriée."
@@ -800,12 +799,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Aide en ligne"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Vue d’ensemble des mesures"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Aperçu des risques"
@@ -824,8 +825,8 @@ msgstr ""
 "etc.) ;"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Faire circuler l'information aux personnes concernées."
 
@@ -856,9 +857,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Veuillez vous référer aux exemples présentés en dessous du formulaire."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "A faire"
 
@@ -901,7 +902,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Pour en savoir plus"
 
@@ -932,8 +933,8 @@ msgid ""
 msgstr "Il s’agit d’une procédure simple et rapide."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Supprimer"
 
@@ -954,11 +955,11 @@ msgstr "Risque"
 msgid "Risk assessments made with this tool"
 msgstr "Évaluations des risques réalisées avec cet outil"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Attention"
 
@@ -1037,7 +1038,7 @@ msgstr "Partager cet outil OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Afficher la bibliothèque à partir de ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Ouvrir une session"
 
@@ -1053,6 +1054,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1107,7 +1112,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Pays-Bas"
 
@@ -1126,7 +1131,7 @@ msgstr ""
 "L’architecture de base d’une évaluation des risques interactive en ligne est "
 "la suivante:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1234,7 +1239,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Tout le monde doit connaître cet outil! Partagez-le!"
 
@@ -1242,8 +1247,8 @@ msgstr "Tout le monde doit connaître cet outil! Partagez-le!"
 msgid "Tip"
 msgstr "Conseil"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Afficher les options d’aide"
 
@@ -1255,9 +1260,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Sans réponse"
 
@@ -1379,36 +1384,36 @@ msgid "Your password was successfully changed."
 msgstr "Votre mot de passe a été changé avec succès."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Le code source de l’application OiRA est sous licence ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "Le contenu des outils sectoriels OiRA est sous licence ${license} "
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "Les outils sectoriels OiRA peuvent être utilisés gratuitement par tous les "
 "utilisateurs. "
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Plus d'informations sur le projet Oira (en anglais)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Stratégie de la Communauté Eeuropéenne sur la Santé et la Sécurité au "
 "Travail 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "L'expérience montre qu' ${key}. C'est pourquoi l'EU-OSHA a développé une "
@@ -1422,44 +1427,44 @@ msgstr ""
 "l'${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "application Web facile d'utilisation et gratuite"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "évaluation"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identification"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "une évaluation des risques appropriée est l'élément clé pour assurer la "
 "santé sur le lieu de travail "
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "actions préventives"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "établissement de rapports"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "processus d'évaluation des risques progressif"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "L'application Web OiRA offre un accès aux outils sectoriels d'évaluation des "
@@ -1467,7 +1472,7 @@ msgstr ""
 "créés et gérés par des organisations sectorielles au niveau national."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "La ${agency} souhaite le développement d'outils simples afin de faciliter\n"
@@ -1485,7 +1490,7 @@ msgstr ""
 "difficultés."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Le projet OiRA et son application web relative a été développé par le ${eu-"
@@ -1497,7 +1502,7 @@ msgstr ""
 "participation des syndicats FNV, CNV et MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Les partenaires techniques suivants ont contribué au développement du "
@@ -1505,7 +1510,7 @@ msgstr ""
 "OiRA :"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "L’Agence a également reçu des conseils d’expert et stratégiques de la part "
@@ -1516,12 +1521,12 @@ msgstr ""
 "Conseil, par la Commission et par l’EU-OSHA. "
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "les micro et petites entreprises rencontrent certaines difficultés"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Bien que la plupart des mesures ne coûtent pas d'argent, certaines peuvent "
@@ -1529,21 +1534,27 @@ msgstr ""
 "incluses dans les négociations du budget annuel si nécessaire."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Nommez quelqu'un dans votre société, responsable de la mise en place de "
 "cette mesure. Cette personne aura l'autorité de prendre les mesures décrites "
 "dans le plan et/ou la responsabilité de garantir qu'elles sont effectuées."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Décrire : 1) quelle est votre approche générale pour éliminer ou (si le "
 "risque ne peut être évité) pour réduire le risque ; 2) l'action / les "
 "actions spécifique(s) requise(s) pour mettre en place cette approche (pour "
-"éliminer ou réduire le risque) ; 3) le niveau d'expérience nécessaire pour "
+"éliminer ou réduire le risque)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Décrire : 3) le niveau d'expérience nécessaire pour "
 "mettre en place la mesure, par exemple « compétence interne » ou "
 "« compétence externe. Vous pouvez également décrire ici toute autre exigence "
 "supplémentaire (le cas échéant)."
@@ -1607,7 +1618,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: déclarations positives contenues dans les modules."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Ajouter"
 
@@ -1655,7 +1666,7 @@ msgstr "Annuler "
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Fermer"
 
@@ -1991,7 +2002,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "L'évaluation du risque a été effectuée automatiquement par l'outil.   Vous "
@@ -2047,7 +2058,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Suite au développement technique de l'outil en 2009, en 2010 (jusqu'à la\n"
@@ -2092,17 +2103,17 @@ msgid "effect_high"
 msgstr "Grave (très grave)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Faible"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Important"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Grave (très grave)"
 
@@ -2177,7 +2188,7 @@ msgid "error_existing_login"
 msgstr "Ce nom d’utilisateur existe déjà."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Veuillez saisir un nombre entier pour le budget en Euros."
 
@@ -2215,17 +2226,17 @@ msgid "error_password_mismatch"
 msgstr "Les mots de passe ne correspondent pas "
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Cette date doit se situer après la date de début."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Cette date doit se situer avant la date de fin."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Cette valeur doit être un nombre entier positif."
 
@@ -2351,7 +2362,7 @@ msgstr ""
 "session."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2360,12 +2371,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Plan d'action ${title}.doc"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Rapport d'identification ${title}"
 
@@ -2385,7 +2396,7 @@ msgid "french"
 msgstr "Cotation calculée simple (2 critères)"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Presque jamais"
 
@@ -2395,57 +2406,57 @@ msgid "frequency_almostnever"
 msgstr "Presque jamais"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Constamment"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Moyenne"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Exposition de l'ordre de une fois par mois"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Fréquente"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Exposition de l'ordre de une fois par semaine"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Faible"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Exposition de l'ordre de une fois par an"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Très fréquente"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Exposition quotidienne ou permanente"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Régulièrement"
@@ -2471,12 +2482,12 @@ msgid "header_additional_content"
 msgstr "Contenu supplémentaire"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Ressources supplémentaires pour évaluer le risque"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Ressources supplémentaires pour ce module"
 
@@ -2491,12 +2502,12 @@ msgid "header_country_managers"
 msgstr "Gestionnaires pays"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Développement et phase pilote – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Partenaires de développement"
 
@@ -2532,18 +2543,18 @@ msgstr "Identification"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Information"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Lancement officiel du projet – septembre 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Références juridiques et techniques"
 
@@ -2553,13 +2564,13 @@ msgid "header_legend"
 msgstr "Légende "
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licences"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Connexion"
@@ -2570,12 +2581,12 @@ msgid "header_main_image"
 msgstr "Image principale"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Mesure ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Mesure"
 
@@ -2601,12 +2612,12 @@ msgid "header_not_complicated"
 msgstr "L'évaluation n'est pas compliquée."
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2641,7 +2652,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2661,7 +2672,7 @@ msgid "header_profile_questions"
 msgstr "Questions sur le profil"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Phases du projet"
 
@@ -2677,7 +2688,7 @@ msgstr "Questions ayant reçu une réponse par module"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Inscription"
 
@@ -2698,23 +2709,23 @@ msgid "header_risk_aware"
 msgstr "Êtes-vous conscient de tous les risques?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Quel est le niveau de gravité des dommages ?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "À quelle fréquence les gens sont-ils exposés à ce risque ?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Sélectionnez la priorité de ce risque"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Quelle est la probablilité d'apparition de ce risque ?"
 
@@ -2726,7 +2737,7 @@ msgid "header_risks"
 msgstr "Risques"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2786,12 +2797,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2806,19 +2817,19 @@ msgid "header_welcome"
 msgstr "Accueil"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "Qu'est-ce que le projet OiRA (Online Interactive Risk Assessment, évaluation "
 "des risques interactive en ligne) "
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Pourquoi le projet OiRA "
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Commentaires"
 
@@ -2839,142 +2850,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Risques de priorité moyenne"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} risque de priorité élevée"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} risques de priorité élevée"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} risques de priorité élevée"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} risques de priorité élevée"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} risque de priorité faible"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} risques de priorité faible"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} risques de priorité faible"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} risques de priorité faible"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} risque de priorité moyenne"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} risques de priorité moyenne"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} risques de priorité moyenne"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} risques de priorité moyenne"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} risque reporté"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} risques reportés"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} risques reportés"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} risques reportés"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} risque sans réponse"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} risques sans réponse"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} risques sans réponse"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} risques sans réponse"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Risque en attente"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Risques en attente"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Risques en attente"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Risques en attente"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Risque identifié"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Risques identifiés"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Risques identifiés"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Risques identifiés"
 
@@ -2994,7 +3005,7 @@ msgid "help_authentication"
 msgstr "Ce texte devrait expliquer comment s'enregistrer et se connecter."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Veuillez répondre aux questions suivantes.  En fonction de vos réponses, le "
@@ -3023,7 +3034,7 @@ msgstr ""
 "souhaitez démarrer avec une copie d'un outil OiRA existant."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indiquez la fréquence de l’apparition de ce risque dans une situation "
@@ -3037,14 +3048,14 @@ msgstr ""
 "défaut. Il / Elle peut toujours changer la priorité."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indiquez le degré de probabilité de l’apparition de ce risque dans une "
 "situation normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indiquer la gravité si ce risque se produit."
 
@@ -3139,6 +3150,11 @@ msgstr ""
 "Télécharger une image. Veillez à ce que votre image soit dans le format png, "
 "jpg ou gif et ne contient pas de caractère spécial."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3154,7 +3170,7 @@ msgstr ""
 "cette approche (pour éliminer ou réduire le risque)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Décrire le niveau d'expérience nécessaire pour mettre en place la mesure, "
@@ -3319,7 +3335,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Si vous ne spécifiez pas de titre, il sera pris dans l'entrée."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3405,7 +3421,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Session d'essai"
 
@@ -3633,13 +3649,13 @@ msgstr "Le compte est verrouillé"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Plan d'action"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budget"
 
@@ -3649,27 +3665,22 @@ msgid "label_action_plan_download"
 msgstr "Plan d'action"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Date de fin prévue"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Qui est responsable ?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Date de commencement prévue"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Ajouter une autre mesure"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3712,8 +3723,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Vous pouvez écrire ici tout commentaire se rapportant à cette question. Vous "
@@ -3800,7 +3811,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Description"
@@ -3830,7 +3841,7 @@ msgstr "Afficher une notification personnalisée pour cet outil OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Estimation"
 
@@ -3850,10 +3861,19 @@ msgid "label_evaluation_phase"
 msgstr "Phase d’évaluation "
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Mesure déjà en place"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3928,7 +3948,7 @@ msgstr "Réaliser votre évaluation en ligne"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identification"
 
@@ -3936,6 +3956,11 @@ msgstr "Identification"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Fichier image"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3958,7 +3983,7 @@ msgid "label_language"
 msgstr "Langue"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Références légales et de politique"
@@ -3993,22 +4018,27 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Quel logo souhaitez-vous afficher en haut à gauche ? "
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Décrivez cette mesure"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 "Précisez les actions à mettre en place pour rendre cette mesure effective"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 "Indiquez les compétences spécifiques nécessaires ou précisez quelle(s) "
@@ -4066,25 +4096,25 @@ msgid "label_no"
 msgstr "Non"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Pas de risque"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Pas de risque"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Pas de risque"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Pas de risque"
@@ -4124,15 +4154,10 @@ msgstr "Mot de passe"
 msgid "label_password_confirm"
 msgstr "Confirmer le mot de passe"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Pré-remplir"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Préparation"
 
@@ -4143,7 +4168,7 @@ msgstr "Précédent"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Précédent"
@@ -4206,15 +4231,15 @@ msgstr "Vous pouvez télécharger un rapport complet et un plan d'action."
 msgid "label_register_first"
 msgstr "vous inscrire"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Effacer cette mesure"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Rapport"
 
@@ -4224,12 +4249,12 @@ msgid "label_report_comment"
 msgstr "Vous pouvez écrire ici tout commentaire se rapportant à cette question"
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr "Date d’édition"
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr "Le cas échéant : personnes consultées (nom, fonction…)"
 
@@ -4249,49 +4274,49 @@ msgid "label_risk_type"
 msgstr "Type de risque"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Risque avec mesure(s)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Risque sans mesure"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Risques avec mesure(s)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Risques avec mesure(s)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risques avec mesure(s)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Risques sans mesure"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Risques sans mesure"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risques sans mesure"
@@ -4304,7 +4329,7 @@ msgstr "Sauvegardez et ajoutez un autre risque"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Enregistrer et continuer"
 
@@ -4329,7 +4354,7 @@ msgid "label_sector_title"
 msgstr "Titre du secteur."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Sélectionner une ou plusieurs des mesures communes connues fournies."
 
@@ -4358,7 +4383,7 @@ msgid "label_show_less_hellip"
 msgstr "Réduire"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} sur ce risque."
 
@@ -4388,7 +4413,7 @@ msgid "label_start_identification"
 msgstr "Commencer l'identification des risques"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Commencer"
 
@@ -4433,29 +4458,29 @@ msgid "label_surveygroup_title"
 msgstr "Titre de l'Outil OiRA importé"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "élevé"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "bas"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "moyen"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titre"
 
@@ -4515,12 +4540,12 @@ msgid "label_user_title"
 msgstr "Nom"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(>1 mesure)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(sans mesure)"
 
@@ -4569,7 +4594,7 @@ msgid "limitations"
 msgstr "limites"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Connexion"
 
@@ -4660,7 +4685,7 @@ msgid "menu_import"
 msgstr "Importer outil OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4766,32 +4791,32 @@ msgid "nav_usermanagement"
 msgstr "Gestion utilisateurs"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Aide"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Déconnexion"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Paramètres"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Avancement"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Mes évaluations"
 
@@ -4841,27 +4866,27 @@ msgid "notice_country_manager"
 msgstr "Gestionnaire pays pour ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Outil d'évaluation"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "des risques en ligne"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4881,7 +4906,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4895,7 +4920,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Le lancement officiel de l'outil est prévu pour septembre 2011, une fois que "
@@ -4926,45 +4951,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Élevée"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Faible"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Moyenne"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Élevée"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Moyenne"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Faible"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Complet"
 
@@ -5017,18 +5042,13 @@ msgstr "Pas encore de compte ? Veuillez tout d'abord ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr "Actions :"
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr "Compétences requises :"
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr "Date de fin : ${date}"
 
@@ -5041,7 +5061,7 @@ msgstr ""
 "bénéficier des avantages suivants :"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -5058,17 +5078,17 @@ msgstr ""
 "le compléter et le modifier comme vous le souhaitez."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr "Mesures déjà en place :"
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr "Responsable : ${responsible_name}"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Ce rapport est basé sur l'outil OiRA '${title}' dans sa version du ${date}."
@@ -5099,35 +5119,35 @@ msgid "request_an_email_reminder"
 msgstr "demandez un rappel"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Ceci est un risque prioritaire ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "élevé"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "bas"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "moyen"
 
@@ -5147,7 +5167,7 @@ msgid "risk_solution_header"
 msgstr "Mesure ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Ce risque a toujours besoin d'être inventorié."
@@ -5195,46 +5215,46 @@ msgid "select_add_existing_measure"
 msgstr "Sélectionner ou ajouter les mesures <strong>déjà en place</strong>."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Moyenne"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Accident ou maladie ave arrêt de travail"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Grave"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Accident ou maladie avec incapacité permanente partielle"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Très grave"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Accident ou maladie mortel"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Faible"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Accident ou maladie sans arrêt de travail"
 
@@ -5305,7 +5325,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "À propos"
 
@@ -5320,7 +5340,7 @@ msgid "title_account_settings"
 msgstr "Configuration du compte"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Modifier le mot de passe"
@@ -5331,7 +5351,7 @@ msgid "title_client_help"
 msgstr "Texte d'aide client"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Mesure"
 
@@ -5366,7 +5386,7 @@ msgid "title_import_sector_survey"
 msgstr "Importer secteur et Outil OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Risques ajoutés (par vous)"
@@ -5393,8 +5413,8 @@ msgstr "Statut de ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Évaluation interactive des risques en ligne"
 
@@ -5419,19 +5439,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Statut d'${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Contenu"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Ce risque n'est pas présent dans votre organisation, mais puisque "
@@ -5439,7 +5459,7 @@ msgstr ""
 "il doit être inclus dans ce rapport."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Ce risque n'est pas présent dans votre organisation, mais puisque "
@@ -5447,7 +5467,7 @@ msgstr ""
 "il doit être inclus dans ce rapport."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Ce risque n’a pas encore été évalué, mais puisque il est considéré comme une "
@@ -5476,7 +5496,7 @@ msgid "use_it_to_full_report"
 msgstr "Utilisez-le"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Utilisez-le"
 
@@ -5486,12 +5506,12 @@ msgid "use_it_to_measures_report"
 msgstr "Utilisez-le"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Utilisez-le"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Utilisez-le"
 
@@ -5506,7 +5526,7 @@ msgid "warn_fix_errors"
 msgstr "Veuillez corriger les erreurs indiquées."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Vous avez répondu de façon négative à la déclaration ci-dessus."
@@ -5531,6 +5551,15 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Oui"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Ajouter une autre mesure"
+
+#~ msgid "label_prefill"
+#~ msgstr "Pré-remplir"
+
+#~ msgid "report_actions"
+#~ msgstr "Actions :"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Les mesures de votre plan d’action n’ont pas été modifiées"

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -243,7 +243,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -261,7 +261,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:26
 msgid "Are you sure you want to proceed?"
-msgstr ""
+msgstr "Êtes-vous certain de vouloir confirmer ?"
 
 #: euphorie/content/behaviour/configure.zcml:33
 msgid "Automatically generate unique ids for content"
@@ -290,6 +290,8 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
+"En duplicant une évaluation des risques, vous pouvez créer une nouvelle "
+"évaluation reprenant les contenus existants comme base de départ."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -595,9 +597,10 @@ msgstr "Information"
 msgid "Information"
 msgstr "Information"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
+"Le format de l’image est non valide. Veuillez utiliser : PNG, JPEG, GIF."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -1057,7 +1060,7 @@ msgstr "Standard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Mesures standards"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1131,7 +1134,7 @@ msgstr ""
 "L’architecture de base d’une évaluation des risques interactive en ligne est "
 "la suivante:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1272,7 +1275,7 @@ msgstr "Télécharger"
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:198
 msgid "Upload an image that illustrates this risk."
-msgstr ""
+msgstr "Télécharger une image pour illustrer ce risque."
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:217
 msgid "Upload image"
@@ -1325,7 +1328,7 @@ msgstr "Oui"
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:34
 msgid "Yes, clone risk assessment"
-msgstr ""
+msgstr "Oui, dupliquer cette évaluation"
 
 #: euphorie/content/templates/library.pt:17
 msgid ""
@@ -1554,10 +1557,10 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Décrire : 3) le niveau d'expérience nécessaire pour "
-"mettre en place la mesure, par exemple « compétence interne » ou "
-"« compétence externe. Vous pouvez également décrire ici toute autre exigence "
-"supplémentaire (le cas échéant)."
+"Décrire : 3) le niveau d'expérience nécessaire pour mettre en place la "
+"mesure, par exemple « compétence interne » ou « compétence externe. Vous "
+"pouvez également décrire ici toute autre exigence supplémentaire (le cas "
+"échéant)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1594,7 +1597,7 @@ msgstr "Produit par ${EU-OSHA}."
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:143
 msgid "based on"
-msgstr ""
+msgstr "pour l’OiRA"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -2226,17 +2229,17 @@ msgid "error_password_mismatch"
 msgstr "Les mots de passe ne correspondent pas "
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Cette date doit se situer après la date de début."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Cette date doit se situer avant la date de fin."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Cette valeur doit être un nombre entier positif."
 
@@ -3034,7 +3037,7 @@ msgstr ""
 "souhaitez démarrer avec une copie d'un outil OiRA existant."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indiquez la fréquence de l’apparition de ce risque dans une situation "
@@ -3048,14 +3051,14 @@ msgstr ""
 "défaut. Il / Elle peut toujours changer la priorité."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indiquez le degré de probabilité de l’apparition de ce risque dans une "
 "situation normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indiquer la gravité si ce risque se produit."
 
@@ -3337,7 +3340,7 @@ msgstr "Si vous ne spécifiez pas de titre, il sera pris dans l'entrée."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Tableau de bord"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3723,7 +3726,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3871,9 +3874,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Ajouter une mesure supplémentaire"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4168,7 +4171,7 @@ msgstr "Précédent"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Précédent"
@@ -4329,7 +4332,7 @@ msgstr "Sauvegardez et ajoutez un autre risque"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Enregistrer et continuer"
 
@@ -4371,6 +4374,11 @@ msgstr "Choisissez votre secteur dans le menu déroulant ci-dessous"
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Sélectionner des mesures standards"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4420,7 +4428,7 @@ msgstr "Commencer"
 #. Default: "Started"
 #: euphorie/client/browser/templates/status_info.pt:51
 msgid "label_started"
-msgstr ""
+msgstr "Commencé le"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4532,7 +4540,7 @@ msgstr ""
 #. Default: "Used tool"
 #: euphorie/client/browser/templates/status_info.pt:36
 msgid "label_used_tool"
-msgstr ""
+msgstr "Outil utilisé"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -5447,7 +5455,7 @@ msgstr "Contenu"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Afficher/masquer le menu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -667,7 +667,7 @@ msgid "Montenegro"
 msgstr "Crna Gora"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr "Ne"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1550,10 +1550,6 @@ msgstr "O"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Izdanje objavljuje ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "na temelju"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4359,6 +4355,11 @@ msgstr "Srednji"
 msgid "label_title"
 msgstr "Naziv"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "na temelju ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4772,7 +4773,7 @@ msgid "optional"
 msgstr "Opcionalno"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5417,6 +5418,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Da"
+
+#~ msgid "based on"
+#~ msgstr "na temelju"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Dodaj drugu mjeru"

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} za nadzorna tijela (Inspekciju rada)."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgstr "Dodajte sadržaj iz biblioteke"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr "Dodana preslika \"${title}\" vašem OiRA alatu."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -266,7 +266,7 @@ msgstr "Dostupni OiRA alati"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr "Države kandidati"
 msgid "Candidate country"
 msgstr "Država kandidat"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Promijeni adresu e-pošte"
 
@@ -332,11 +332,11 @@ msgstr ""
 "Sadrži: sve informacije i unose koje ste unijeli tijekom postupka procjene "
 "rizika."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Sadrži: pregled mjera koje treba implementirati."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Sadrži: pregled identificiranih rizika"
 
@@ -375,15 +375,15 @@ msgstr "Informacije o državi i grupiranju za klijenta."
 msgid "Country manager"
 msgstr "Državni voditelj"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons licenca"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -442,15 +442,15 @@ msgstr "Preuzimanje plana mjera"
 msgid "Download the full report"
 msgstr "Preuzimanje potpunog izvješća"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Preuzimanje pregleda mjera"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Preuzimanje pregleda rizika"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-pošta"
@@ -524,7 +524,7 @@ msgstr "Mapa"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Oblik: Office Open XML radna knjiga (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Oblik: Portable Document Format (.pdf)"
 
@@ -532,7 +532,7 @@ msgstr "Oblik: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Njemačka"
 
@@ -559,7 +559,7 @@ msgstr ""
 "procjeni, a zatim se vratiti i nastaviti gdje ste stali kada vam to bude "
 "prikladno."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Želim s vama podijeliti sljedeće"
 
@@ -575,8 +575,7 @@ msgstr "Uvoz verzije OiRA alata"
 msgid "Important"
 msgstr "Važno"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informacije"
 
@@ -585,7 +584,7 @@ msgstr "Informacije"
 msgid "Information"
 msgstr "Informacije"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nevažeći format slike. Molimo koristite PNG, JPEG ili GIF."
 
@@ -619,11 +618,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "spremljeno"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Saznajte više o ovom alatu…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -635,7 +634,7 @@ msgstr "Prijava"
 msgid "Manage"
 msgstr "Upravljanje"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Mjera"
@@ -654,12 +653,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "Praćenje i procjenu jesu li uvedene neophodne mjere."
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Nadgledanje mjera za implementaciju u naredna 3 mjeseca."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Praćenje jesu li rizici/mjere pravilno riješeni."
 
@@ -786,12 +785,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Pomoć na internetu"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Pregled mjera"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Pregled rizika"
@@ -809,8 +810,8 @@ msgstr ""
 "povjerenicima, stručnjacima zaštite na radu itd.)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Prosljeđivanje informacija osobama kojih se to tiče."
 
@@ -839,9 +840,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Pogledajte primjere ispod obrasca."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Odgođen"
 
@@ -882,7 +883,7 @@ msgstr "Osiguravanje dokaza nadzornim tijelima."
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Saznajte više"
 
@@ -915,8 +916,8 @@ msgstr ""
 "nastavka prethodne procjene ili pokretanja nove."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Ukloni"
 
@@ -937,11 +938,11 @@ msgstr "Rizik"
 msgid "Risk assessments made with this tool"
 msgstr "Procjene rizika izvršene ovim alatom"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Rizik ne postoji"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Postoji rizik"
 
@@ -1019,7 +1020,7 @@ msgstr "Podijeli ovaj alat OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Prikaži oblik biblioteke ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Prijava"
 
@@ -1035,6 +1036,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Uobičajen"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1089,7 +1094,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nizozemska"
 
@@ -1107,7 +1112,7 @@ msgid ""
 msgstr ""
 "Osnovna arhitektura Internetske interaktivne procjene rizika sastoji se od:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1221,7 +1226,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Ovaj alat zaslužuje da se zna za njega! Podijelite ga!"
 
@@ -1229,8 +1234,8 @@ msgstr "Ovaj alat zaslužuje da se zna za njega! Podijelite ga!"
 msgid "Tip"
 msgstr "Savjet"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Uključi pomoć na zaslonu"
 
@@ -1242,9 +1247,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Neodgovoren"
 
@@ -1361,33 +1366,33 @@ msgid "Your password was successfully changed."
 msgstr "Vaša lozinka je uspješno promijenjena."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Izvorni kod OiRA aplikacije ima ${GPL} licencu."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "Sadržaj OiRA sektorskog alata licenciran je pod ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "OiRA sektorske alate svi korisnici mogu besplatno koristiti."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Više informacija o OiRA projektu (na engleskom jeziku)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Strategija Europske zajednice o zdravlju i sigurnosti na radu 2007. – 2012."
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Iskustvo je pokazalo da ${key}. To je ujedno i razlog zašto je EU-OSHA "
@@ -1398,49 +1403,49 @@ msgstr ""
 "nadgledanje i ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "besplatna web-aplikacija, jednostavna za korištenje"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "procjena"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identifikacija"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "točna procjena rizika ključni je čimbenik „zdravih” radnih mjesta"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "preventivne akcije"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "izvješćivanje"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "postupak procjene rizika „korak po korak”"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "OiRA web-aplikacija omogućuje pristup sektorskim alatima za procjenu rizika "
 "koje su stvorile i održavaju sektorske organizacije na nacionalnoj razini."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} je uputila pozive za razvoj jednostavnih alata kako bi se "
@@ -1452,7 +1457,7 @@ msgstr ""
 "preventivne politike općenito, koje OiRA projekt nastoji prebroditi."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "OiRA projekt i povezana web-aplikacija razvila je ${eu-osha} na temelju "
@@ -1463,12 +1468,12 @@ msgstr ""
 "pomoć i sudjelovanje sindikata FNV, CNV i MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "Razvoju OiRA projekta doprinijeli su sljedeći tehnički partneri:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Upravni odbor dao je Agenciji strateški i stručni savjet za razvoj i "
@@ -1476,32 +1481,38 @@ msgstr ""
 "su interesne skupine na odboru, Komisija i EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikropoduzeća i mala poduzeća imaju neke nedostatke"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Iako neke mjere ne koštaju ništa, mnoge koštaju. Zbog toga za mjere treba "
 "proračun; ako je potrebno, uključite ih u godišnji proračun."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Odredite osobu u svojoj tvrtki koja će biti odgovorna za implementaciju ove "
 "mjere. Ta osoba bit će ovlaštena provoditi korake opisane u Planu i/ili "
 "dužnosti koje će osigurati njihovo izvršenje."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Opiši: 1) kako općenito pristupaš uklanjanju ili (ako se rizik ne može "
 "izbjeći) smanjenju rizika; 2) konkretnu(e) aktivnost(i) potrebnu(e) za "
-"implementaciju tog pristupa (za uklanjanje ili smanjenje rizika); 3) razinu "
+"implementaciju tog pristupa (za uklanjanje ili smanjenje rizika)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Opiši: 3) razinu "
 "ekspertize potrebnu za implementaciju mjere, npr. \"zdrav razum (nije "
 "potrebno ZNR znanje)”, “nema posebne ZNR ekspertize, ali je potrebno "
 "minimalno ZNR znanje ili obuka i/ili korištenje ZNR smjernica” ili ZNR "
@@ -1567,7 +1578,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: pozitivne izjave, koje su spremljene u modulima."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Dodaj"
 
@@ -1615,7 +1626,7 @@ msgstr "Odustani"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Zatvori"
 
@@ -1942,7 +1953,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Alat je automatski procijenio rizik. U Planu mjera razina rizika može se "
@@ -1998,7 +2009,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Nakon tehničkog razvoja alata u 2009. godini, u 2010. (sve do prve polovice "
@@ -2039,17 +2050,17 @@ msgid "effect_high"
 msgstr "Visoka (vrlo visoka) ozbiljnost"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Slaba"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Značajna"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Visoka (vrlo visoka)"
 
@@ -2125,7 +2136,7 @@ msgid "error_existing_login"
 msgstr "Ovo se ime za prijavu već koristi."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Unesite proračun u cijelim eurima."
 
@@ -2161,17 +2172,17 @@ msgid "error_password_mismatch"
 msgstr "Lozinke se ne podudaraju"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Ovaj datum mora biti isti ili veći od datuma početka."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Ovaj datum mora biti isti ili manji od datuma kraja."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Ova vrijednost mora biti pozitivan cijeli broj."
 
@@ -2279,7 +2290,7 @@ msgstr ""
 "izvršite ažuriranje kako biste preuzeli ove izmjene."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 "Ovaj je rizik automatski bio postavljen kao postojeći. Ovo ne možete "
@@ -2290,12 +2301,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Plan mjera ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Izvješće o identifikaciji ${title}"
 
@@ -2315,7 +2326,7 @@ msgid "french"
 msgstr "Pojednostavljena dva mjerila"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Gotovo nikad"
 
@@ -2325,57 +2336,57 @@ msgid "frequency_almostnever"
 msgstr "Gotovo nikad"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Stalno"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Ne tako često"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Jednom mjesečno"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Često"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Jednom tjedno"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Rijetko"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Jednom godišnje"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Vrlo često ili redovito"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Najmanje jednom dnevno"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Redovito"
@@ -2400,12 +2411,12 @@ msgid "header_additional_content"
 msgstr "Dodatni sadržaj"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Dodatni resursi za procjenu rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Dodatni resursi za ovaj modul"
 
@@ -2420,12 +2431,12 @@ msgid "header_country_managers"
 msgstr "Državni voditelji"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Razvoj i faza probne verzije – 2009. – 2011."
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Razvojni partneri"
 
@@ -2461,18 +2472,18 @@ msgstr "Prepoznavanje"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informacija"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Službeno pokretanje projekta – rujna 2011."
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Propisi i dodatne informacije"
 
@@ -2482,13 +2493,13 @@ msgid "header_legend"
 msgstr "Legenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licence"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prijava"
@@ -2499,12 +2510,12 @@ msgid "header_main_image"
 msgstr "Glavna slika"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Mjera ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Mjera"
 
@@ -2530,12 +2541,12 @@ msgid "header_not_complicated"
 msgstr "Procjena uopće nije komplicirana"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2570,7 +2581,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2590,7 +2601,7 @@ msgid "header_profile_questions"
 msgstr "Pitanja o profilu"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Faze projekta"
 
@@ -2606,7 +2617,7 @@ msgstr "Odgovorena pitanja po modulu"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registracija"
 
@@ -2627,23 +2638,23 @@ msgid "header_risk_aware"
 msgstr "Jeste li svjesni svih rizika?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Kolika je ozbiljnost štete?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Koliko su često osobe izložene ovom riziku?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Odaberite prioritet za ovaj rizik"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Koja je vjerojatnost pojave ovog rizika?"
 
@@ -2655,7 +2666,7 @@ msgid "header_risks"
 msgstr "Rizici"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2715,12 +2726,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2735,17 +2746,17 @@ msgid "header_welcome"
 msgstr "Dobrodošli"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Što je projekt OiRA (internetska interaktivna procjena rizika)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Zašto OiRA projekt"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Komentari"
 
@@ -2766,142 +2777,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Rizici srednjeg prioriteta"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} rizik visokog prioriteta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} rizika visokog prioriteta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} rizika visokog prioriteta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} rizika visokog prioriteta"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} rizik niskog prioriteta"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} rizika niskog prioriteta"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} rizika niskog prioriteta"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} rizika niskog prioriteta"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} rizik srednjeg prioriteta"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} rizika srednjeg prioriteta"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} rizika srednjeg prioriteta"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} rizika srednjeg prioriteta"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} odgođen rizik"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} odgođena rizika"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} odgođena rizika"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} odgođenih rizika"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} rizik nema odgovor"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} rizika nemaju odgovor"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} rizika nemaju odgovor"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} rizika nemaju odgovor"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} mogući rizik"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} moguća rizika"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} moguća rizika"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} mogućih rizika"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} postojeći rizik"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} postojeća rizika"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} postojeća rizika"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} postojećih rizika"
 
@@ -2921,7 +2932,7 @@ msgid "help_authentication"
 msgstr "Ovaj tekst pojašnjava način registracije i prijave."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Odgovorite na sljedeća pitanja. Na temelju vaših odgovora sustav će "
@@ -2950,7 +2961,7 @@ msgstr ""
 "započeti s kopijom postojećeg OiRA alata."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Navodi koliko se često ovaj rizik pojavljuje u normalnoj situaciji."
 
@@ -2962,13 +2973,13 @@ msgstr ""
 "uvijek može promijeniti prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Navodi kolika je vjerojatnost pojave ovog rizika u normalnoj situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Navodi ozbiljnost u slučaju da dođe do ovog rizika."
 
@@ -3061,6 +3072,11 @@ msgstr ""
 "Prenesite sliku. Provjerite je li vaša slika u png, jpg ili gif obliku te "
 "sadrži li nekakav posebni znak."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3076,7 +3092,7 @@ msgstr ""
 "(za uklanjanje ili smanjenje rizika)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Opišite razinu ekspertize potrebnu za implementaciju mjere, npr. „zdrav "
@@ -3229,7 +3245,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Ako ne navedete naziv, on će se uzeti iz ulazne datoteke."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3313,7 +3329,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Ovo je probna sesija"
 
@@ -3506,13 +3522,13 @@ msgstr "Račun je zaključan"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Plan mjera"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Proračun"
 
@@ -3522,27 +3538,22 @@ msgid "label_action_plan_download"
 msgstr "Plan mjera"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Planirani kraj"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Tko je odgovoran?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Planirani početak"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Dodaj drugu mjeru"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3585,8 +3596,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Ovdje možete ostaviti komentar na postavljeno pitanje. Komentar će se "
@@ -3673,7 +3684,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Opis"
@@ -3703,7 +3714,7 @@ msgstr "Prikaz prilagođene obavijesti za ovaj alat OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "procjena"
 
@@ -3723,10 +3734,19 @@ msgid "label_evaluation_phase"
 msgstr "Procijeni fazu"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Već provedena mjera"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3801,7 +3821,7 @@ msgstr "Izvršite svoju procjenu rizika"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Prepoznavanje"
 
@@ -3809,6 +3829,11 @@ msgstr "Prepoznavanje"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Slikovna datoteka"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3831,7 +3856,7 @@ msgid "label_language"
 msgstr "Jezik"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Pravila i pravne reference"
@@ -3866,21 +3891,26 @@ msgstr "Logotip"
 msgid "label_logo_selection"
 msgstr "Koji biste logotip željeli prikazati u gornjem lijevom kutu?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Opći pristup (za eliminaciju ili smanjenje rizika)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Konkretna(e) aktivnost(i) potrebna(e) za implementaciju ovog pristupa"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Razina stručnosti i/ili potrebni zahtjevi"
 
@@ -3936,25 +3966,25 @@ msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Nema rizika"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Nema rizika"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Nema rizika"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Nema rizika"
@@ -3994,15 +4024,10 @@ msgstr "Lozinka"
 msgid "label_password_confirm"
 msgstr "Ponovite lozinku"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Unaprijed ispunjeno"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Priprema"
 
@@ -4013,7 +4038,7 @@ msgstr "Pretpregled"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Prethodni"
@@ -4076,15 +4101,15 @@ msgstr "Možete preuzeti potpuno izvješće i akcijski plan."
 msgid "label_register_first"
 msgstr "registrirajte se"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Izbriši ovu mjeru"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Završni dokumenti"
 
@@ -4095,12 +4120,12 @@ msgstr ""
 "U ovom polju ostavite dodatni komentar koji bi trebalo uključiti u izvješće."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4120,49 +4145,49 @@ msgid "label_risk_type"
 msgstr "Vrsta rizika"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Rizik s mjerom(ama)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Rizik bez mjere"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Rizici s mjerom(ama)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Rizici s mjerom(ama)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Rizici s mjerom(ama)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Rizici bez mjere(a)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Rizici bez mjere(a)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Rizici bez mjere(a)"
@@ -4175,7 +4200,7 @@ msgstr "Pohranite i dodajte drugi rizik"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Spremi i nastavi"
 
@@ -4200,7 +4225,7 @@ msgid "label_sector_title"
 msgstr "Naziv sektora."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Odaberite jednu ili više poznatih uobičajenih mjera koje su ponuđene."
 
@@ -4229,7 +4254,7 @@ msgid "label_show_less_hellip"
 msgstr "Prikaži manje…"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} o ovom riziku."
 
@@ -4259,7 +4284,7 @@ msgid "label_start_identification"
 msgstr "Započnite procjenu rizika"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Pokrenite"
 
@@ -4304,29 +4329,29 @@ msgid "label_surveygroup_title"
 msgstr "Naziv uvezenog OiRA alata"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Visoki"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Niski"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Srednji"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Naziv"
 
@@ -4386,12 +4411,12 @@ msgid "label_user_title"
 msgstr "Ime"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 mjere(a))"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(bez mjera)"
 
@@ -4438,7 +4463,7 @@ msgid "limitations"
 msgstr "ograničenjima"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Prijava"
 
@@ -4529,7 +4554,7 @@ msgid "menu_import"
 msgstr "Uvezi OiRA alat"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4638,32 +4663,32 @@ msgid "nav_usermanagement"
 msgstr "Upravljanje korisnicima"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Pomoć"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Odjava"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Postavke"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Provjerite svoj napredak"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Moje procjene"
 
@@ -4713,27 +4738,27 @@ msgid "notice_country_manager"
 msgstr "Državni voditelj za ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Interaktivno na mreži"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Procjena rizika"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4753,7 +4778,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4767,7 +4792,7 @@ msgstr ""
 "veliko slovo, jedan broj i jedan posebni znak (npr. $, # ili @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Službeno pokretanje projekta planirano je za rujan 2011., čim budu dosegnuti "
@@ -4796,45 +4821,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Veliki"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Mali"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Srednji"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Velika"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Srednja"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Mala"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Dovršeno"
 
@@ -4887,18 +4912,13 @@ msgstr "Nemate račun? Najprije posjetite ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4910,7 +4930,7 @@ msgstr ""
 "Registrirajte se u samo jednom koraku i pristupite sljedećim pogodnostima:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4924,17 +4944,17 @@ msgstr ""
 "uključiti u to izvješće."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Ovo izvješće temelji  se na OiRA  alatu '${title}' s datumom revizije "
@@ -4966,35 +4986,35 @@ msgid "request_an_email_reminder"
 msgstr "zatražite podsjetnik putem e-pošte"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Ovo je ${priority_value} rizik"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "veliki"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "mali"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "srednji"
 
@@ -5014,7 +5034,7 @@ msgid "risk_solution_header"
 msgstr "Mjera ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Ovaj rizik tek treba unijeti u popis."
@@ -5062,46 +5082,46 @@ msgid "select_add_existing_measure"
 msgstr "Odaberite ili dodajte sve mjere koje su već uvedene."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Ne tako ozbiljna"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Potrebno je zastati s radom manje od 3 dana"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Ozbiljna"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Potrebno je zastati s radom više od 3 dana"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Vrlo ozbiljna"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Nepovratno oštećenje, neizlječiva bolest, smrt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Slaba"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Nije potrebno zastati s radom"
 
@@ -5169,7 +5189,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "O"
 
@@ -5184,7 +5204,7 @@ msgid "title_account_settings"
 msgstr "Postavke računa"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Promjena lozinke"
@@ -5195,7 +5215,7 @@ msgid "title_client_help"
 msgstr "Tekst pomoći na klijentu"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Mjera"
 
@@ -5230,7 +5250,7 @@ msgid "title_import_sector_survey"
 msgstr "Uvezite sektor i OiRA alat"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Ostali izvori opasnosti, štetnosti i napora"
@@ -5257,8 +5277,8 @@ msgstr "Status ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA – internetska interaktivna procjena rizika"
 
@@ -5283,19 +5303,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Status ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Sadržaj"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Ovaj rizik ne postoji u vašoj organizaciji, ali budući da ga organizacija "
@@ -5303,7 +5323,7 @@ msgstr ""
 "izvješće."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Ovaj rizik ne postoji u vašoj organizaciji, ali budući da ga organizacija "
@@ -5311,7 +5331,7 @@ msgstr ""
 "izvješće."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Rizik još nije procijenjen, ali budući da se smatra “velikim rizikom” od "
@@ -5339,7 +5359,7 @@ msgid "use_it_to_full_report"
 msgstr "Koristiti za"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Koristiti za"
 
@@ -5349,12 +5369,12 @@ msgid "use_it_to_measures_report"
 msgstr "Koristiti za"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Koristiti za"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Koristiti za"
 
@@ -5369,7 +5389,7 @@ msgid "warn_fix_errors"
 msgstr "Popravite navedene pogreške."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Odgovorili ste negativno na gornju tvrdnju."
@@ -5393,6 +5413,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Da"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Dodaj drugu mjeru"
+
+#~ msgid "label_prefill"
+#~ msgstr "Unaprijed ispunjeno"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "U mjerama vašeg plana mjera nisu unesene promjene."

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -584,7 +584,7 @@ msgstr "Informacije"
 msgid "Information"
 msgstr "Informacije"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nevažeći format slike. Molimo koristite PNG, JPEG ili GIF."
 
@@ -1039,7 +1039,7 @@ msgstr "Uobičajen"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Predložene mjere"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1112,7 +1112,7 @@ msgid ""
 msgstr ""
 "Osnovna arhitektura Internetske interaktivne procjene rizika sastoji se od:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1512,11 +1512,10 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Opiši: 3) razinu "
-"ekspertize potrebnu za implementaciju mjere, npr. \"zdrav razum (nije "
-"potrebno ZNR znanje)”, “nema posebne ZNR ekspertize, ali je potrebno "
-"minimalno ZNR znanje ili obuka i/ili korištenje ZNR smjernica” ili ZNR "
-"stručnjak”. Ovdje također možete opisati bilo koji dodatni zahtjev (ako "
+"Opiši: 3) razinu ekspertize potrebnu za implementaciju mjere, npr. \"zdrav "
+"razum (nije potrebno ZNR znanje)”, “nema posebne ZNR ekspertize, ali je "
+"potrebno minimalno ZNR znanje ili obuka i/ili korištenje ZNR smjernica” ili "
+"ZNR stručnjak”. Ovdje također možete opisati bilo koji dodatni zahtjev (ako "
 "postoji)."
 
 #. Default: "add a new OiRA Tool"
@@ -2172,17 +2171,17 @@ msgid "error_password_mismatch"
 msgstr "Lozinke se ne podudaraju"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Ovaj datum mora biti isti ili veći od datuma početka."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Ovaj datum mora biti isti ili manji od datuma kraja."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Ova vrijednost mora biti pozitivan cijeli broj."
 
@@ -2961,7 +2960,7 @@ msgstr ""
 "započeti s kopijom postojećeg OiRA alata."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Navodi koliko se često ovaj rizik pojavljuje u normalnoj situaciji."
 
@@ -2973,13 +2972,13 @@ msgstr ""
 "uvijek može promijeniti prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Navodi kolika je vjerojatnost pojave ovog rizika u normalnoj situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Navodi ozbiljnost u slučaju da dođe do ovog rizika."
 
@@ -3247,7 +3246,7 @@ msgstr "Ako ne navedete naziv, on će se uzeti iz ulazne datoteke."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Nadzorna ploča"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3596,7 +3595,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3744,9 +3743,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Dodajte dodatnu mjeru"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4038,7 +4037,7 @@ msgstr "Pretpregled"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Prethodni"
@@ -4200,7 +4199,7 @@ msgstr "Pohranite i dodajte drugi rizik"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Spremi i nastavi"
 
@@ -4242,6 +4241,11 @@ msgstr "Pokrenite novu sesiju odabirom nekog od sljedećih sektorskih alata"
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Odaberite predložene mjere"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5311,7 +5315,7 @@ msgstr "Sadržaj"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Prikaži/sakrij izbornik"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -260,7 +260,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr "Jelölt országok"
 msgid "Candidate country"
 msgstr "Jelölt ország"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -322,11 +322,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -363,15 +363,15 @@ msgstr "Országra vonatkozó adatok és csoportosítás az ügyfél részére."
 msgid "Country manager"
 msgstr "Országos igazgató"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic Licenc"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons Licenc"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -429,15 +429,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -511,7 +511,7 @@ msgstr "Mappa"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -519,7 +519,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Németország"
 
@@ -547,7 +547,7 @@ msgstr ""
 "rendelkezésére áll, majd egy későbbi alkalmas időpontban újra megnyithatja, "
 "és ott folytathatja, ahol abbahagyta."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Szeretném megosztani veletek a következőket"
 
@@ -563,8 +563,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -573,7 +572,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -607,11 +606,11 @@ msgstr "Koszovó"
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Tudjon meg többet erről az eszközről…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -623,7 +622,7 @@ msgstr "Bejelentkezés"
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -642,12 +641,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -777,12 +776,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online súgó"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -798,8 +799,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -824,9 +825,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -863,7 +864,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -894,8 +895,8 @@ msgstr ""
 "értékeléseket vagy újat kezdhet."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -916,11 +917,11 @@ msgstr "Kockázat"
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -995,7 +996,7 @@ msgstr "Ossza meg ezt az OiRA-eszközt!"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -1011,6 +1012,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1059,7 +1064,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Hollandia"
 
@@ -1076,7 +1081,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1178,7 +1183,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Ez az eszköz megérdemli, hogy megismerje a világ! Ossza meg!"
 
@@ -1186,8 +1191,8 @@ msgstr "Ez az eszköz megérdemli, hogy megismerje a világ! Ossza meg!"
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1199,9 +1204,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1313,34 +1318,34 @@ msgid "Your password was successfully changed."
 msgstr "A jelszó megváltoztatása megtörtént."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Az OiRA alkalmazás forráskódja ${GPL} engedéllyel rendelkezik."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "Az OiRA ágazati eszközök tartalmára ${license} licenc vonatkozik"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "Az OiRA ágazati eszközt minden felhasználó ingyen használhatja."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "További információk az OiRA projektről (angolul)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Az Európai Közösség munkahelyi egészségvédelemmel és biztonsággal "
 "kapcsolatos stratégiája 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "A tapasztalat azt mutatja, hogy ${key}. Az EU-OSHA ezért fejlesztett ki egy "
@@ -1351,43 +1356,43 @@ msgstr ""
 "meghozatalán keresztül, az ellenőrzésig és ${reporting}-ig."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "könnyen használható és ingyenes internetes alkalmazás"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "értékelés"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "azonosítás"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "az egészséges munkehelyekhez kulcsfontosságú a megfelelő kockázatértékelés"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "megelőző lépések"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "jelentés"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "lépésenként végigvezetett kockázatértékelési folyamat"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Az OiRA internetes alkalmazás segítségével az ágazati szervezetek által "
@@ -1395,7 +1400,7 @@ msgstr ""
 "eszközt lehet elérni."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "A(z) ${agency} a kockázatértékelés megkönnyítése érdekében egyszerű eszközök "
@@ -1407,7 +1412,7 @@ msgstr ""
 "politika elfogadása általában, amit az OiRA projekt igyekszik legyőzni."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Az OiRA projektet és a kapcsolódó web alkalmazásokat az ${eu-osha} tervezte "
@@ -1419,13 +1424,13 @@ msgstr ""
 "részvételével hajtották végre."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Az OiRA projekt fejlesztéséhez az alábbi technikai partnerek járultak hozzá:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Az Ügynökség emellett stratégiai és szaktanácsadói támogatást kapott egy "
@@ -1434,23 +1439,28 @@ msgstr ""
 "érdekcsoportjai, a Bizottság és az EU-OSHA nevezték ki."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "a mikró- és kisvállalkozások rendelkeznek gyenge pontokkal"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1510,7 +1520,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1558,7 +1568,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1890,7 +1900,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1937,7 +1947,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Az eszköz 2009-es technikai kifejlesztése után, 2010-ben (2011. első "
@@ -1977,17 +1987,17 @@ msgid "effect_high"
 msgstr "Magas (nagyon magas) súlyosság"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2063,7 +2073,7 @@ msgid "error_existing_login"
 msgstr "Ez a bejelentkezési név már foglalt."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -2099,17 +2109,17 @@ msgid "error_password_mismatch"
 msgstr "A jelszavak nem egyeznek"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2199,7 +2209,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2208,12 +2218,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Azonosítási jelentés ${title}"
 
@@ -2233,7 +2243,7 @@ msgid "french"
 msgstr "Két egyszerűsített kritérium"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2243,57 +2253,57 @@ msgid "frequency_almostnever"
 msgstr "Szinte soha"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2314,12 +2324,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2334,12 +2344,12 @@ msgid "header_country_managers"
 msgstr "Országos igazgatók"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Kifejlesztés és tesztelés szakasza – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Fejlesztő partnerek"
 
@@ -2375,18 +2385,18 @@ msgstr "Azonosítás"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "A projekt hivatalos indítása – 2011. szeptember"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2396,13 +2406,13 @@ msgid "header_legend"
 msgstr "Jelmagyarázat"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Engedélyek"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2413,12 +2423,12 @@ msgid "header_main_image"
 msgstr "Fő kép"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2444,12 +2454,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2484,7 +2494,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2504,7 +2514,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projekt fázisai"
 
@@ -2520,7 +2530,7 @@ msgstr "Modulonként megválaszolt kérdések"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2541,23 +2551,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2569,7 +2579,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2629,12 +2639,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2649,19 +2659,19 @@ msgid "header_welcome"
 msgstr "Üdvözöljük!"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "Mi az OiRA (Online Interactive Risk Assessment, vagyis online interaktív "
 "kockázatértékelés) projekt"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Miért az OiRA projekt"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2682,142 +2692,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2837,7 +2847,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2860,7 +2870,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Jelölje, hogy ez a kockázat milyen gyakran fordul elő normál esetben."
 
@@ -2870,13 +2880,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Jelölje, hogy mennyire valószínű a kockázat előfordulása normál helyzetben."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2970,6 +2980,11 @@ msgstr ""
 "Töltsön fel egy képet. A kép formátuma legyen png, jpg vagy gif, és ne "
 "tartalmazzon különleges karaktereket."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2981,7 +2996,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -3113,7 +3128,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Ha nem ad meg címet, akkor azt a bemeneti adatokból vesszük át."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3181,7 +3196,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3335,13 +3350,13 @@ msgstr "A felhasználói fiókot zárolták"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3351,26 +3366,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3414,8 +3424,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3500,7 +3510,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3530,7 +3540,7 @@ msgstr "Személyre szabott értesítés megjelenítése ehhez az OiRA eszközhö
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3550,9 +3560,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3628,7 +3647,7 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
@@ -3636,6 +3655,11 @@ msgstr ""
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Képfájl"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3658,7 +3682,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Hivatkozások jogszabályokra és szabályzatokra"
@@ -3693,21 +3717,26 @@ msgstr "Logó"
 msgid "label_logo_selection"
 msgstr "Melyik logót szeretné megjeleníteni a bal felső sarokban?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3763,25 +3792,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3821,15 +3850,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3840,7 +3864,7 @@ msgstr "Előnézet"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3903,15 +3927,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3921,12 +3945,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3946,49 +3970,49 @@ msgid "label_risk_type"
 msgstr "Kockázat típusa"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -4001,7 +4025,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -4026,7 +4050,7 @@ msgid "label_sector_title"
 msgstr "Ágazat címe."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -4055,7 +4079,7 @@ msgid "label_show_less_hellip"
 msgstr "Kevesebb megjelenítése"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -4085,7 +4109,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -4130,29 +4154,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Magas"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Alacsony"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Közepes"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Cím"
 
@@ -4212,12 +4236,12 @@ msgid "label_user_title"
 msgstr "Név"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4265,7 +4289,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4349,7 +4373,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4450,32 +4474,32 @@ msgid "nav_usermanagement"
 msgstr "Felhasználók kezelése"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4525,27 +4549,27 @@ msgid "notice_country_manager"
 msgstr "${country} országos igazgatója."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4565,7 +4589,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4577,7 +4601,7 @@ msgid "password_policy_conditions"
 msgstr "Jelszó megerősítése"
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Az eszköz bevezetésének tervezett időpontja 2011. szeptember, amint sikerült "
@@ -4606,45 +4630,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4693,18 +4717,13 @@ msgstr "Nincs felhasználói fiókja? Kérjük, előbb ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4714,7 +4733,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4724,17 +4743,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4764,35 +4783,35 @@ msgid "request_an_email_reminder"
 msgstr "kérjen e-mail emlékeztetőt"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4812,7 +4831,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Ezt a kockázatot fel kell venni."
@@ -4860,46 +4879,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4961,7 +4980,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Névjegy"
 
@@ -4976,7 +4995,7 @@ msgid "title_account_settings"
 msgstr "Felhasználói fiók beállításai"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4987,7 +5006,7 @@ msgid "title_client_help"
 msgstr "Ügyfél súgójának szövege"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -5022,7 +5041,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Hiba"
@@ -5049,8 +5068,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -5075,29 +5094,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -5122,7 +5141,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -5132,12 +5151,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -5152,7 +5171,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -572,7 +572,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1081,7 +1081,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -2109,17 +2109,17 @@ msgid "error_password_mismatch"
 msgstr "A jelszavak nem egyeznek"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Jelölje, hogy ez a kockázat milyen gyakran fordul elő normál esetben."
 
@@ -2880,13 +2880,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Jelölje, hogy mennyire valószínű a kockázat előfordulása normál helyzetben."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3424,7 +3424,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3570,7 +3570,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3864,7 +3864,7 @@ msgstr "Előnézet"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -4025,7 +4025,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -4066,6 +4066,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -655,7 +655,7 @@ msgid "Montenegro"
 msgstr "Montenegró"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -699,7 +699,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1494,10 +1494,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -4185,6 +4181,11 @@ msgstr "Közepes"
 msgid "label_title"
 msgstr "Cím"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4584,7 +4585,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -583,7 +583,7 @@ msgstr "Upplýsingar"
 msgid "Information"
 msgstr "Upplýsingar"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Get ekki lesið myndskrá. Vinsamlegast notið PNG, JPEG eða GIF skrár."
 
@@ -1041,7 +1041,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Tillögur að aðgerðum"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1112,7 +1112,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Grunnuppbygging gagnvirks áhættumats á netinu samanstendur af: "
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1486,10 +1486,10 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Gefðu lýsingu á: 3) hvaða sérfræðiþekking er nauðsynleg til að "
-"framkvæma aðgerðina, til dæmis „heilbrigð skynsemi ,þ.e. ekki þörf á "
-"sérstakri sérfræðiþekkingu á öryggis- og heilbrigðismálum (ÖH)“, „engin þörf "
-"á sérfræðiþekkingu á ÖH en lágmarks þekking eða þjálfun varðandi ÖH og/eða "
+"Gefðu lýsingu á: 3) hvaða sérfræðiþekking er nauðsynleg til að framkvæma "
+"aðgerðina, til dæmis „heilbrigð skynsemi ,þ.e. ekki þörf á sérstakri "
+"sérfræðiþekkingu á öryggis- og heilbrigðismálum (ÖH)“, „engin þörf á "
+"sérfræðiþekkingu á ÖH en lágmarks þekking eða þjálfun varðandi ÖH og/eða "
 "samráð við viðurkenndan ÖH þjónustuaðila“ eða „ÖH sérfræðiþekking "
 "nauðsynleg“. ;Þú getur einnig lýst hér viðbótarkröfum, eftir því sem við á."
 
@@ -2134,17 +2134,17 @@ msgid "error_password_mismatch"
 msgstr "Lykilorðin eru ekki eins"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir upphafsdagsetningu."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir lokadagsetningu."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Þetta þarf að vera heiltala stærri en núll."
 
@@ -2937,7 +2937,7 @@ msgstr ""
 "viljir byrja með afrit af OiRA verkfæri sem er þegar til staðar."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Tilgreindu hversu oft þessi áhætta kemur upp við venjulegar aðstæður."
 
@@ -2949,12 +2949,12 @@ msgstr ""
 "(forgangsröð). Hann eða hún getur breytt forgangsröðinni að vild."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Hversu líklegt er að þessi áhætta komi upp við venjulegar aðstæður?"
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Hversu alvarlegt verður atvikið ef það gerist?"
 
@@ -3217,7 +3217,7 @@ msgstr ""
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr "Mælaborð"
+msgstr "Stjórnborð"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3557,7 +3557,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3707,9 +3707,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Bætið við aðgerð"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4003,7 +4003,7 @@ msgstr "Prufuútgáfa"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Fyrra"
@@ -4164,7 +4164,7 @@ msgstr "Vistaðu og bættu við annarri áhættu"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Vista og halda áfram"
 
@@ -4206,6 +4206,11 @@ msgstr "Veljið áhættumatsverkfæri"
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Veljið tillögur að aðgerðum"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5274,7 +5279,7 @@ msgstr "Innihald"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Sýna/fela valmynd"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -76,7 +76,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence}"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -192,7 +192,7 @@ msgstr "Bæta við efni úr verkfærasafni"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -266,7 +266,7 @@ msgstr "OiRA verkfæri í boði"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Breyta tölvupóstfangi"
 
@@ -332,11 +332,11 @@ msgstr ""
 "Innihald: Allar upplýsingar og gögn sem þú hefur skráð inn meðan á "
 "áhættumatinu stóð."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Inniheldur: Yfirlit yfir úrbætur sem þarf að framkvæma."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Inniheldur: Yfirlit um áhættur"
 
@@ -374,15 +374,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -441,15 +441,15 @@ msgstr "Hlaða niður aðgerðaáætlun "
 msgid "Download the full report"
 msgstr "Hlaða niður skýrslunni í heild"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Sækja yfirlit yfir úrbætur"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Sækja fullyrðingar verkfærisins"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr "Mappa"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Snið: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Snið: Portable Document Format (.pdf)"
 
@@ -531,7 +531,7 @@ msgstr "Snið: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 "Þú getur byrjað og hætt hvenær sem er. Hægt að halda áfram með fyrra mat og "
 "breyta að vild."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -574,8 +574,7 @@ msgstr ""
 msgid "Important"
 msgstr "Mikilvægt"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Upplýsingar"
 
@@ -584,7 +583,7 @@ msgstr "Upplýsingar"
 msgid "Information"
 msgstr "Upplýsingar"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Get ekki lesið myndskrá. Vinsamlegast notið PNG, JPEG eða GIF skrár."
 
@@ -619,11 +618,11 @@ msgstr ""
 msgid "Last saved"
 msgstr "Síðast vistað"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Lærðu meira um þetta verkfæri…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -635,7 +634,7 @@ msgstr "Innskráning"
 msgid "Manage"
 msgstr "Vinna að úrbótum"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Ráðstöfun til úrbóta"
@@ -655,12 +654,12 @@ msgstr ""
 "Fylgjast með og meta hvort nauðsynlegar úrbætur hafi verið framkvæmdar."
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Fylgjast með þeim úrbótum sem eru fyrirhugaðar næstu þrjá mánuðina."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 "Að fylgjast með hvort greindar áhættur, og tilheyrandi úrbætur, séu "
@@ -789,12 +788,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Hjálp á netinu"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Yfirlit yfir aðgerðir til úrbóta"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Yfirlit um áhættur"
@@ -812,8 +813,8 @@ msgstr ""
 "sérfræðinga á sviði vinnuverndar og heilsuverndar."
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Að koma upplýsingum til þeirra sem málið varðar."
 
@@ -844,9 +845,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Vinsamlegast athugaðu dæmin hér að aftan"
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Frestað"
 
@@ -886,7 +887,7 @@ msgstr "Leggja fram gögn til opinberra eftirlitsstofnana"
 msgid "Publish Risk Assessment"
 msgstr "Birta áhættumat"
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Lesa meira"
 
@@ -917,8 +918,8 @@ msgstr ""
 "halda áfram með fyrra mat eða byrjað á nýju."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Fjarlægja"
 
@@ -939,11 +940,11 @@ msgstr "Áhætta "
 msgid "Risk assessments made with this tool"
 msgstr "Áhættumat sem gerð eru með þessu verkfæri"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Áhættan er ekki til staðar"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Áhættan er til staðar"
 
@@ -1021,7 +1022,7 @@ msgstr ""
 msgid "Show library from ${dropdown}."
 msgstr "Sýna verkfærasafn frá ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "stofna aðgang"
 
@@ -1036,6 +1037,10 @@ msgstr "Lausn"
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1090,7 +1095,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1107,7 +1112,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Grunnuppbygging gagnvirks áhættumats á netinu samanstendur af: "
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1217,7 +1222,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 
@@ -1225,8 +1230,8 @@ msgstr ""
 msgid "Tip"
 msgstr "Ábending"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Virkja aðstoð á skjá"
 
@@ -1238,9 +1243,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Ekki opnað"
 
@@ -1358,102 +1363,102 @@ msgid "Your password was successfully changed."
 msgstr "Lykilorðinu hefur verið breytt."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Enda þótt sumar úrbótaaðgerðir kosti ekki fjármuni þá á það samt við um þær "
@@ -1461,7 +1466,7 @@ msgstr ""
 "inn í undirbúning á fjárveitingu ársins ef þörf er á."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Þú þarft að tilnefna einhvern aðila í fyrirtæki þínu sem ber ábyrgð á "
@@ -1469,13 +1474,19 @@ msgstr ""
 "ráðstafanir sem lýst er í áætluninni og/eða starfs skyldu til að tryggja að "
 "þær séu framkvæmdar."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Gefðu lýsingu á: 1) almennri aðferð við að fjarlægja hættuna eða draga úr "
 "henni; 2) sérstökum aðgerðum sem nauðsynlegar eru til að framkvæma "
-"nauðsynlegar aðgerðir; 3) hvaða sérfræðiþekking er nauðsynleg til að "
+"nauðsynlegar aðgerði."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Gefðu lýsingu á: 3) hvaða sérfræðiþekking er nauðsynleg til að "
 "framkvæma aðgerðina, til dæmis „heilbrigð skynsemi ,þ.e. ekki þörf á "
 "sérstakri sérfræðiþekkingu á öryggis- og heilbrigðismálum (ÖH)“, „engin þörf "
 "á sérfræðiþekkingu á ÖH en lágmarks þekking eða þjálfun varðandi ÖH og/eða "
@@ -1539,7 +1550,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: jákvæðum yfirlýsingum sem eru settar fram í flokkum."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Bæta við"
 
@@ -1587,7 +1598,7 @@ msgstr "Hætta við"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Loka"
 
@@ -1913,7 +1924,7 @@ msgstr ""
 "úrbótum sem notandinn sér við greiningu á áhættu)"
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Verkfærið metur áhættuna sjálkrafa. Hægt er að breyta forgangi áhættunar í "
@@ -1964,7 +1975,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -2000,17 +2011,17 @@ msgid "effect_high"
 msgstr "Alvarlegar eða mjög alvarlegar afleiðingar"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Minni háttar"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Alvarlegt"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Mjög alvarlegt"
 
@@ -2087,7 +2098,7 @@ msgid "error_existing_login"
 msgstr "Þetta notendanafn er upptekið"
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Notið eingöngu tölustafi (ekki nota kommu og punkt)"
 
@@ -2123,17 +2134,17 @@ msgid "error_password_mismatch"
 msgstr "Lykilorðin eru ekki eins"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir upphafsdagsetningu."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir lokadagsetningu."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Þetta þarf að vera heiltala stærri en núll."
 
@@ -2250,7 +2261,7 @@ msgstr ""
 "þarft að uppfæra þessar breytingar áður en þú heldur áfram."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 "Þessi áhætta hefur verið skilgreind sem stöðug áhætta (þ.e. alltaf fyrir "
@@ -2261,12 +2272,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Aðgerðaáætlun ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Áhættumatsskýrsla ${title}"
 
@@ -2286,7 +2297,7 @@ msgid "french"
 msgstr "Eimnfaldara tveggja þrepa mat á áhættu"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Næstum aldrei"
 
@@ -2296,57 +2307,57 @@ msgid "frequency_almostnever"
 msgstr "Næstum aldrei"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Stöðugt"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Ekki mjög oft"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Einu sinni í mánuði"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Oft"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Einu sinni í viku"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Sjaldan"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Einu sinni á ári"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Mjög oft eða reglulega"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Minnst einu sinni á dag"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Reglulega"
@@ -2372,12 +2383,12 @@ msgid "header_additional_content"
 msgstr "Annað efni"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Viðbótar upplýsingar til að meta áhættuna"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Viðbótar upplýsingar fyrir þennan flokk"
 
@@ -2392,12 +2403,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2433,18 +2444,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Upplýsingar"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Tilvísanir í önnur gögn s.s. lög, reglur og önnur opinber gögn"
 
@@ -2454,13 +2465,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Innskráning"
@@ -2471,12 +2482,12 @@ msgid "header_main_image"
 msgstr "Aðalmynd"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Ráðstöfun til úrbóta ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Ráðstöfun til úrbóta"
 
@@ -2502,12 +2513,12 @@ msgid "header_not_complicated"
 msgstr "Matið er ekki flókið"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr "Samráð við starfsmenn "
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr "OiRA skýrsla: \"${title}"
 
@@ -2542,7 +2553,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr "Áhættur sem hafa verið greindar og aðgerðaáætlun útbúin fyrir þær"
 
@@ -2562,7 +2573,7 @@ msgid "header_profile_questions"
 msgstr "Spurningar um starfsemi"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2578,7 +2589,7 @@ msgstr "Hve mörgum spurningum var svarað í hverjum flokki"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Stofna aðgang"
 
@@ -2599,23 +2610,23 @@ msgid "header_risk_aware"
 msgstr "Þekkir þú allar áhætturnar?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Hversu alvarlegt er vandamálið?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Hversu oft er fólk í hættu?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Veldu stig þessarar áhættu"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Hverjar eru líkurnar á að þessi hætta komi upp?"
 
@@ -2627,7 +2638,7 @@ msgid "header_risks"
 msgstr "Áhættur"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 "Hættur/vandamál sem er stýrt innan ásættanlegra marka eða eru ekki fyrir "
@@ -2689,14 +2700,14 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 "Hættur/vandamál sem eru í biðstöðu og á eftir að meta og vinna úr "
 "niðurstöðunum"
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 "Áhættur sem hafa verið greindar en aðgerðaáætlun er ekki tilbúin fyrir þær."
@@ -2712,17 +2723,17 @@ msgid "header_welcome"
 msgstr "Velkomin/n"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Athugasemdir"
 
@@ -2743,142 +2754,142 @@ msgid "heading_medium_prio_risks"
 msgstr "meðal áhættuflokkur (minnka eins og hægt er)"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Mikil áhætta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Mikil áhætta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Mikil áhætta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Mikil áhætta"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Lítil áhætta"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Lítil áhætta"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Lítil áhætta"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Lítil áhætta"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Meðal áhætta"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Meðal áhætta"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Meðal áhætta"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Meðal áhætta"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} áhættum frestað"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} áhættum frestað"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} áhættum frestað"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} áhættum frestað"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} áhættum ekki svarað"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} áhættum ekki svarað"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} áhættum ekki svarað"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} áhættum ekki svarað"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} mögulegar áhættur"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} mögulegar áhættur"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} mögulegar áhættur"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} mögulegar áhættur"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} áhættur"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} áhættur"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} áhættur"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} áhættur"
 
@@ -2898,7 +2909,7 @@ msgid "help_authentication"
 msgstr "Þessi texti á að útskýra hvernig á að skrá sig inn á notendaaðgang"
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Vinsamlegast svaraðu eftirfarandi spurningum. Verkfærið metur áhættuna, "
@@ -2926,7 +2937,7 @@ msgstr ""
 "viljir byrja með afrit af OiRA verkfæri sem er þegar til staðar."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Tilgreindu hversu oft þessi áhætta kemur upp við venjulegar aðstæður."
 
@@ -2938,12 +2949,12 @@ msgstr ""
 "(forgangsröð). Hann eða hún getur breytt forgangsröðinni að vild."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Hversu líklegt er að þessi áhætta komi upp við venjulegar aðstæður?"
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Hversu alvarlegt verður atvikið ef það gerist?"
 
@@ -3042,6 +3053,11 @@ msgstr ""
 "Mynd sett inn. Myndin þarf að vera á forminu png, jpg eða gif og má ekki "
 "innihalda neina sértæka stafi."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3054,7 +3070,7 @@ msgstr ""
 "Lýsið sérstökum aðgerðum sem þarf til að fjarlægja eða minnka áhættuna."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Lýsið hvaða þekking er nauðsynleg? Stundum dugar heilbrigð skynsemi.  "
@@ -3199,7 +3215,7 @@ msgstr ""
 "Ef þú tiltekur ekki nafn hér, verður það tekið úr því sem hlaðið er niður"
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr "Mælaborð"
 
@@ -3275,7 +3291,7 @@ msgid "info_select_session"
 msgstr "Veldu áhættumat til að ljúka eða endurskoða eða ${start_session}."
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 "Hér er hægt að prófa verkfærið. Það verður að ${link_sign_in} til að gera "
@@ -3467,13 +3483,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Aðgerðaáætlun"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Áætlaður kostnaður"
 
@@ -3483,27 +3499,22 @@ msgid "label_action_plan_download"
 msgstr "Aðgerðaáætlun"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Áætluð verklok"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Hver ber ábyrgð?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Framkvæmdir/úrbætur hefjast"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Bættu við annarri ráðstöfun"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3546,8 +3557,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Settu athugasemdir um spurninguna í þennan reit. Þessar athugasemdir verða "
@@ -3636,7 +3647,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Lýsing"
@@ -3666,7 +3677,7 @@ msgstr "Birta sérstaka tilkynningu fyrir þetta verkfæri"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Mat"
 
@@ -3686,10 +3697,19 @@ msgid "label_evaluation_phase"
 msgstr "Matsfasi"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Núverandi ráðstöfun til úrbóta."
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3764,7 +3784,7 @@ msgstr "Framkvæmd áhættumatsins"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Greining"
 
@@ -3772,6 +3792,11 @@ msgstr "Greining"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Skrá með myndefni"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3794,7 +3819,7 @@ msgid "label_language"
 msgstr "Tungumál"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Tilvísanir í önnur gögn s.s. lög, reglur og önnur opinber gögn"
@@ -3829,23 +3854,28 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 "Almenn nálgun. (Fjarlægja skal hættur eða draga úr þeim þannig að þær verði "
 "innan ásættanlegra marka.)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Sérstakar aðgerðir til að innleiða úrbæturnar."
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Þekking og reynsla sem er nauðsynleg"
 
@@ -3901,25 +3931,25 @@ msgid "label_no"
 msgstr "Nei"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Áhættan er ekki til staðar"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Áhættan er ekki til staðar"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Áhættan er ekki til staðar"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Áhættan er ekki til staðar"
@@ -3959,15 +3989,10 @@ msgstr "Lykilorð"
 msgid "label_password_confirm"
 msgstr "Staðfesta lykilorð"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Tillögur að úrbótum"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Undirbúningur"
 
@@ -3978,7 +4003,7 @@ msgstr "Prufuútgáfa"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Fyrra"
@@ -4041,15 +4066,15 @@ msgstr "Hægt er að búa til skýrslu og aðgerðaáætlun."
 msgid "label_register_first"
 msgstr "Skrá aðgang"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Eyða þessari tillögu að úrbótum"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Skýrsla"
 
@@ -4059,12 +4084,12 @@ msgid "label_report_comment"
 msgstr "Bætið við athugasemdum í skýrsluna hér."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4084,49 +4109,49 @@ msgid "label_risk_type"
 msgstr "Flokkur áhættu"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Áhætta og tilheyrandi úrbótaaðgerð(ir)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Áhætta án tilgreindrar úrbótaaðgerðar"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Áhætta með úrbótaaðgerð(um)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Áhætta með úrbótaaðgerð(um)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Áhætta með úrbótaaðgerð(um)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Áhættur án tilheyrandi úrbótaðgerða"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Áhættur án tilheyrandi úrbótaðgerða"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Áhættur án tilheyrandi úrbótaðgerða"
@@ -4139,7 +4164,7 @@ msgstr "Vistaðu og bættu við annarri áhættu"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Vista og halda áfram"
 
@@ -4164,7 +4189,7 @@ msgid "label_sector_title"
 msgstr "Heiti atvinnugreinar"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Veldu lausn eða lausnir sem eru tilgreindar."
 
@@ -4193,7 +4218,7 @@ msgid "label_show_less_hellip"
 msgstr "Sýna minna...."
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} um áhætturnar."
 
@@ -4223,7 +4248,7 @@ msgid "label_start_identification"
 msgstr "Byrja áhættugreiningu"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Byrja"
 
@@ -4268,29 +4293,29 @@ msgid "label_surveygroup_title"
 msgstr "Nýtt heiti afritaðs OiRA verkfæris"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Há"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Lág"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Meðal"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Heiti"
 
@@ -4350,12 +4375,12 @@ msgid "label_user_title"
 msgstr "Nafn"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 lausn)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(án úrbótaaðgerða)"
 
@@ -4402,7 +4427,7 @@ msgid "limitations"
 msgstr "galla"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "stofna aðgang"
 
@@ -4487,7 +4512,7 @@ msgid "menu_import"
 msgstr "Flytja inn OiRA verkfæri"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4594,32 +4619,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Aðstoð"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Útskráning"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Stillingar"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Staða"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Mín áhættumöt"
 
@@ -4670,27 +4695,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr "f.h. atvinnuveitanda:"
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr "f.h. starfsmanna:"
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Gagnvirkt áhættumatsverkfæri"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr " á netinu"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr "Dagsetning:"
 
@@ -4710,7 +4735,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 "Undirrituð/-aðir lýsa hér með yfir því að haft hefur verið samráð við "
@@ -4726,7 +4751,7 @@ msgstr ""
 "minnsta kosti einn hástaf, einn tölustaf og eitt tákn (s.s. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4754,45 +4779,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Há"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Lág"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Miðlungs"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Miklar"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Miðlungs"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Litlar"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Lokið"
 
@@ -4845,18 +4870,13 @@ msgstr "Ertu með aðgang? Skráðu þig ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4868,7 +4888,7 @@ msgstr ""
 "gögn. Stofnaðu aðgang til að nota verkfærið:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr "Þetta skjal var byggt á '${title}' ,útgáfu dagsettri ${date}."
 
@@ -4881,17 +4901,17 @@ msgstr ""
 "neðan."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Þessi skýrsla var byggð á OiRA áhaldinu '${title}' sem endurskoðað var "
@@ -4923,35 +4943,35 @@ msgid "request_an_email_reminder"
 msgstr "fáðu áminningu í tölvupósti"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Áhættustig ${priority_value}"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "Hátt"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "Lágt"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "Meðal"
 
@@ -4971,7 +4991,7 @@ msgid "risk_solution_header"
 msgstr "Ráðstöfun til úrbóta ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -5019,46 +5039,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Ekki alvarlegt"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Nauðsynlegt að stöðva vinnu í 3 daga eða minna"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Alvarlegt"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Nauðsynlegt að stöðva vinnu í 3 daga eða meira"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Mjög alvarlegt"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Alvarleg slys og sjúkdómar, dauðsföll"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Lítið"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Engin ástæða til að stöðva vinnu"
 
@@ -5129,7 +5149,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "um"
 
@@ -5144,7 +5164,7 @@ msgid "title_account_settings"
 msgstr "Stillingar fyrir aðgang"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Skipta um lykilorð"
@@ -5155,7 +5175,7 @@ msgid "title_client_help"
 msgstr "Hjálpartexti fyrir notandann"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Ráðstöfun til úrbóta"
 
@@ -5192,7 +5212,7 @@ msgid "title_import_sector_survey"
 msgstr "Flytja inn atvinnusvið og OiRA verkfæri"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Aðrar áhættur á vinnustaðnum (ef við á)"
@@ -5219,8 +5239,8 @@ msgstr "Staða: ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 "OiRA - Online interactive Risk Assessment (gagnvirkt áhættumat á netinu)"
@@ -5246,19 +5266,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Staða: ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Innihald"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Þessi áhætta er ekki til staðar á þínum vinnustað, en þar sem samtökin í "
@@ -5266,7 +5286,7 @@ msgstr ""
 "að taka hana með í þessa skýrslu."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Þessi áhætta er ekki til staðar í stofnun þinni en þar sem samtökin í "
@@ -5274,7 +5294,7 @@ msgstr ""
 "að taka hana með í þessa skýrslu."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Þessi áhætta er ekki til staðar á þínum vinnustað, en þar sem samtökin í "
@@ -5302,7 +5322,7 @@ msgid "use_it_to_full_report"
 msgstr "Þessi skýrsla nýtist til "
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Þetta yfirlit yfir úrbætur nýtist við "
 
@@ -5312,12 +5332,12 @@ msgid "use_it_to_measures_report"
 msgstr "Þessi skýrsla um úrbætur nýtist til  "
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Þetta yfirlit yfir áhættur nýtist til "
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Þessi skýrsla um áhættur nýtist til "
 
@@ -5332,7 +5352,7 @@ msgid "warn_fix_errors"
 msgstr "Það þarf að lagfæra villurnar sem bent er á."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Þú svaraðir ofangreindri fullyrðingu neitandi."
@@ -5356,6 +5376,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "já "
+
+#~ msgid "label_add_measure"
+#~ msgstr "Bættu við annarri ráðstöfun"
+
+#~ msgid "label_prefill"
+#~ msgstr "Tillögur að úrbótum"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Engar breytingar voru gerðar á úrbótaaðgerðum í aðgerðaáætluninni."

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -670,7 +670,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr "Meira"
@@ -714,7 +714,7 @@ msgstr "Nei"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1525,10 +1525,6 @@ msgstr "Um"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Framleitt af ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "byggð á"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4324,6 +4320,11 @@ msgstr "Meðal"
 msgid "label_title"
 msgstr "Heiti"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "byggð á ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4730,7 +4731,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5381,6 +5382,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "já "
+
+#~ msgid "based on"
+#~ msgstr "byggð á"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Bættu við annarri ráðstöfun"

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 "${provide-evidence} rispetto a tutti i pericoli e rischi indicati dalla "
 "strumento e le misure inserite."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr "Aggiungi contenuti dalla biblioteca"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr "Ulteriore misura"
 
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -272,7 +272,7 @@ msgstr "Strumenti OIRA disponibili"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -300,7 +300,7 @@ msgstr "Paesi candidati"
 msgid "Candidate country"
 msgstr "Paese candidato"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Modificare indirizzo e-mail"
 
@@ -337,11 +337,11 @@ msgstr ""
 "Contiene tutte le informazioni e i dettagli che hai fornito tramite il "
 "processo di valutazione dei rischi"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Contiene: panoramica delle misure da implementare."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Contiene: panoramica dei rischi identificati"
 
@@ -380,15 +380,15 @@ msgstr "Informazioni sul Paese e raggruppamento per il cliente."
 msgid "Country manager"
 msgstr "Country manager"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licenza Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -446,15 +446,15 @@ msgstr "Scarica il programma di miglioramento"
 msgid "Download the full report"
 msgstr "Scarica l’intero Report"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Scarica la panoramica delle misure"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Scarica la panoramica dei rischi"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -528,7 +528,7 @@ msgstr "Cartella"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formato: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Formato: Portable Document Format (.pdf)"
 
@@ -536,7 +536,7 @@ msgstr "Formato: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Germania"
 
@@ -562,7 +562,7 @@ msgstr ""
 "interrompere la compilazione del tool per poi riprenderla in una fase "
 "successiva."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Vorrei condividere con voi ció che segue"
 
@@ -578,8 +578,7 @@ msgstr ""
 msgid "Important"
 msgstr "Importante"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Info"
 
@@ -588,7 +587,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informazione"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato dell'immagine non valido, per favore usa PNG, JPEG o GIF."
 
@@ -623,11 +622,11 @@ msgstr "Cossovo"
 msgid "Last saved"
 msgstr "Salvato"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Ulteriori informazioni su questo strumento…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -639,7 +638,7 @@ msgstr "Login"
 msgid "Manage"
 msgstr "Gestire"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Misura"
@@ -660,12 +659,12 @@ msgstr ""
 "che organizzativo (nuove macchine, nuovi lavoratori"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Monitorare le misure da implementare nei prossimi tre mesi"
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Monitorare se rischi e misure sono trattati in modo corretto."
 
@@ -794,12 +793,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Aiuto online"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Panoramica delle misure"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "panoramica dei rischi"
@@ -817,8 +818,8 @@ msgstr ""
 "prevenzione e protezione adottate"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Trasferire le informazioni alle persone interessate."
 
@@ -849,9 +850,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Riferirsi agli esempi in basso al modulo….."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Adempimenti e rischi da completare"
 
@@ -894,7 +895,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Ulteriori informazioni"
 
@@ -925,8 +926,8 @@ msgstr ""
 "momento, per continuare le valutazioni iniziate o per avviarne delle nuove."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Rimuovi"
 
@@ -947,13 +948,13 @@ msgstr "Rischio"
 msgid "Risk assessments made with this tool"
 msgstr "Valutazioni del rischio effettuate con questo strumento"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 "Adempimenti e rischi non applicabili o per i quali non sono previste "
 "ulteriori misure di miglioramento"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -1033,7 +1034,7 @@ msgstr "Condividi questo strumento OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Mostra biblioteca da ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Registrazione"
 
@@ -1049,6 +1050,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1104,7 +1109,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Paesi Bassi"
 
@@ -1123,7 +1128,7 @@ msgstr ""
 "L'architettura di base di una valutazione interattiva online dei rischi "
 "consiste in:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1232,7 +1237,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Questo strumento merita di essere conosciuto in tutto il mondo: condividilo!"
@@ -1241,8 +1246,8 @@ msgstr ""
 msgid "Tip"
 msgstr "Suggerimento"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Attiva la schermata di aiuto"
 
@@ -1254,9 +1259,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Non esaminato"
 
@@ -1371,37 +1376,37 @@ msgid "Your password was successfully changed."
 msgstr "La password è stata modificata con successo."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Il codice di origine dell'applicazione OiRA è patentato ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "Il contenuto del tool OiRA settoriale è pubblicato con la licenza ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "I tool settoriali OiRA possono essere utilizzati gratuitamente da tutti gli "
 "utenti."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Ulteriori informazioni sul progetto OiRA (in inglese)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Strategia della comunità europea per la salute e la sicurezza sul lavoro "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "L'esperienza dimostra che ${key}. Questo è il motivo per cui EU-OSHA ha "
@@ -1412,44 +1417,44 @@ msgstr ""
 "monitorare e ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "facile da utilizzare e applicazione web esente da costi"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "valutazione"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "Identificazione"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "la corretta valutazione dei rischi è la chiave di successo per ambienti di "
 "lavoro sani"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "Misure preventive"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "rapportare"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "procedimento di valutazione del rischio step-by-step"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "L'applicazione web OiRA permette l'accesso agli strumenti settoriali per la "
@@ -1457,7 +1462,7 @@ msgstr ""
 "settoriali a livello nazionale."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "La ${agency} richiede lo sviluppo di strumenti semplici per facilitare la "
@@ -1470,7 +1475,7 @@ msgstr ""
 "che il progetto OiRA mira a superarle."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Il progetto OiRA e la relativa applicazione web sono stati sviluppati da "
@@ -1482,13 +1487,13 @@ msgstr ""
 "sindacati FNV, CNV e MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "I seguenti partner tecnici hanno contribuito allo sviluppo del progetto OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "All'agenzia è stata affidata, da un comitato direttivo, una nota strategica "
@@ -1497,31 +1502,37 @@ msgstr ""
 "interesse del Consiglio, dalla commissione e da EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "le imprese micro e piccole hanno alcune imperfezioni"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Inserire il budget di riferimento che si prevede di utilizzare per "
 "l’attuazione di questa determinata misura."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Indicare la persona che nella tua azienda deve provvedere all’ attuazione "
 "della misura obbligatoria adottata e dell’eventuale misura di miglioramento."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descrivere qual è l’approccio generale utilizzato per eliminare o ridurre i "
-"rischi: le misure obbligatorie adottate, le eventuali misure di "
-"miglioramento, competenze/requisiti necessari per l’attuazione delle misure."
+"rischi: le misure obbligatorie adottate e le eventuali misure di "
+"miglioramento."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Descrivere quali sono le competenze / i requisiti necessari per l'attuazione delle misure."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1583,7 +1594,7 @@ msgstr ""
 "${Risks}: affermazioni positive riguardanti i pericoli indicati nei moduli."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Aggiungere"
 
@@ -1631,7 +1642,7 @@ msgstr "Annullare"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Chiudi"
 
@@ -1967,7 +1978,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Il livello di rischio per la sicurezza e la salute correlato ai pericoli "
@@ -2022,7 +2033,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Dopo lo sviluppo tecnico dello strumento nel 2009, nel 2010 (fino a metà "
@@ -2064,17 +2075,17 @@ msgid "effect_high"
 msgstr "Gravità alta (molto alta)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Gravità leggera"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Gravità significante"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Gravità alta (molto alta)"
 
@@ -2152,7 +2163,7 @@ msgid "error_existing_login"
 msgstr "Questo nome d'accesso è giá occupato."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Inserire il budget in euro interi"
 
@@ -2189,17 +2200,17 @@ msgid "error_password_mismatch"
 msgstr "Le password non coincidono"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Questa data deve essere uguale o successiva alla data di inizio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Questa data deve essere uguale o precedente alla data di fine."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Questo valore deve essere un numero intero positivo."
 
@@ -2302,7 +2313,7 @@ msgstr ""
 "continuare è necessario aggiornare le modifiche."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2311,12 +2322,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Misure obbligatorie adottate e Programma di miglioramento ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Elenco dei rischi e degli adempimenti ${title}"
 
@@ -2336,7 +2347,7 @@ msgid "french"
 msgstr "Due criteri semplificati"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Quasi mai"
 
@@ -2346,57 +2357,57 @@ msgid "frequency_almostnever"
 msgstr "Quasi mai"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Costantemente"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Non frequente"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Uno per mese"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Spesso"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Uno per settimana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Raro"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Uno per anno"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Spesso o regolarmente"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Minimo una volta al giorno"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regolarmente"
@@ -2423,12 +2434,12 @@ msgid "header_additional_content"
 msgstr "Contenuti aggiuntivi"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Risorse aggiuntive per la valutazione del rischio"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Risorse aggiuntive per questo modulo"
 
@@ -2443,12 +2454,12 @@ msgid "header_country_managers"
 msgstr "Country manager"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Fase di sviluppo e fase pilota – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Partner di sviluppo"
 
@@ -2488,18 +2499,18 @@ msgstr "Identificazione"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informazioni"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Lancio ufficiale del progetto – Settembre 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Riferimenti normativi"
 
@@ -2509,13 +2520,13 @@ msgid "header_legend"
 msgstr "Leggenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licenze"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
@@ -2526,12 +2537,12 @@ msgid "header_main_image"
 msgstr "Immagine principale"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Misura ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Misura"
 
@@ -2557,12 +2568,12 @@ msgid "header_not_complicated"
 msgstr "La valutazione dei rischi con questo strumento non è complicata"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2597,7 +2608,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2617,7 +2628,7 @@ msgid "header_profile_questions"
 msgstr "Domande sul profilo"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Fasi del progetto"
 
@@ -2633,7 +2644,7 @@ msgstr "Domande e risposte tramite il modulo"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrazione"
 
@@ -2654,23 +2665,23 @@ msgid "header_risk_aware"
 msgstr "Sei consapevole dei rischi presenti nella tua azienda?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Cosa è la gravità del danno?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Quante volte la gente è esposta al rischio?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Il livello di rischio è"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Quali sono le eventualità che procura questo rischio?"
 
@@ -2682,7 +2693,7 @@ msgid "header_risks"
 msgstr "Rischi"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2742,12 +2753,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2762,17 +2773,17 @@ msgid "header_welcome"
 msgstr "Benvenuto"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Cosa è il progetto OiRA (Online Interactive Risk Assessment)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Perché il progetto OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Commenti"
 
@@ -2793,142 +2804,142 @@ msgid "heading_medium_prio_risks"
 msgstr "rischio prioritario di livello medio"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} di rischi prioritari di livello alto"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} di rischi prioritari di livello alto"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} di rischi prioritari di livello alto"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} di rischi prioritari di livello alto"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} di rischi prioritari di livello basso"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} di rischi prioritari di livello basso"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} di rischi prioritari di livello basso"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} di rischi prioritari di livello basso"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} di rischi prioritari di livello medio"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} di rischi prioritari di livello medio"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} di rischi prioritari di livello medio"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} di rischi prioritari di livello medio"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} rischi non ancora compilati"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} rischi non ancora compilati"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} rischi non ancora compilati"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} rischi non ancora compilati"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Risks not answered"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Risks not answered"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Risks not answered"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Risks not answered"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} rischi possibili"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} rischi possibili"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} rischi possibili"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} rischi possibili"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} dei rischi presenti"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} dei rischi presenti"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} dei rischi presenti"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} dei rischi presenti"
 
@@ -2949,7 +2960,7 @@ msgstr ""
 "Questo testo dovrebbe spiegare come registrarsi e accedere allo strumento."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Rispondere alle seguenti domande. Sulla base delle risposte date, il sistema "
@@ -2977,7 +2988,7 @@ msgstr ""
 "con una copia di un tool OiRA esistente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indicare la frequenza che questo rischio si verifica in una situazione "
@@ -2991,14 +3002,14 @@ msgstr ""
 "L'utente finale ha poi la possibilità di modificare il grado di priorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indicare quanto sia possibile che questo rischio si verifichi in una "
 "situazione normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indicare la gravità che questo rischio potrebbe comportare."
 
@@ -3091,6 +3102,11 @@ msgstr ""
 "Caricare un'immagine. Assicurarsi che l'immagine sia in formato png, jpg o "
 "gif e che non contenga caratteri speciali"
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3104,7 +3120,7 @@ msgid "help_measure_prevention_plan"
 msgstr "Descrivere la misura specifica."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Descrivere il livello di competenze necessarie per attuare la misura, per "
@@ -3265,7 +3281,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Se non si specifica il titolo, sarà preso dall'input."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3352,7 +3368,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Sessione di prova"
 
@@ -3547,13 +3563,13 @@ msgstr "L'account è bloccato"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Misure di miglioramento"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budget (campo facoltativo)"
 
@@ -3563,28 +3579,23 @@ msgid "label_action_plan_download"
 msgstr "Programma di miglioramento"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 "Stima termine previsto per la attuazione (solo per misure di miglioramento)"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Chi è il responsabile?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Stima inizio attuazione (solo per misure di miglioramento)"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Aggiungere un'altra misura"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3627,8 +3638,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Inserire eventuali commenti e informazioni aggiuntive (ad esempio gli "
@@ -3716,7 +3727,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Descrizione"
@@ -3746,7 +3757,7 @@ msgstr "Mostrare una notifica al cliente relativa a questo strumento OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Valutazione"
 
@@ -3766,10 +3777,19 @@ msgid "label_evaluation_phase"
 msgstr "Fase di valutazione"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Misura già attuata"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3844,7 +3864,7 @@ msgstr "Valutazione dei rischi"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identificazione"
 
@@ -3852,6 +3872,11 @@ msgstr "Identificazione"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "File immagine"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3874,7 +3899,7 @@ msgid "label_language"
 msgstr "Lingua"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Riferimenti normativi"
@@ -3909,21 +3934,26 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Quale logo le piacerebbe avere all'angolo sinistro in alto?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Tipologia di misura (per eliminare e ridurre i rischi)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Misura specifica"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Livello di esperienza o requisiti necessari"
 
@@ -3979,7 +4009,7 @@ msgid "label_no"
 msgstr "No"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
@@ -3987,7 +4017,7 @@ msgstr ""
 "ulteriori misure di miglioramento"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
@@ -3995,7 +4025,7 @@ msgstr ""
 "ulteriori misure di miglioramento"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
@@ -4003,7 +4033,7 @@ msgstr ""
 "ulteriori misure di miglioramento"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -4047,15 +4077,10 @@ msgstr "Password"
 msgid "label_password_confirm"
 msgstr "Ripetere password"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Pre-compilazione"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Presentazione"
 
@@ -4066,7 +4091,7 @@ msgstr "Anteprima"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Indietro"
@@ -4129,15 +4154,15 @@ msgstr "È possibile scaricare il report e il programma di miglioramento."
 msgid "label_register_first"
 msgstr "registrarti"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Eliminare questa misura"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Report"
 
@@ -4149,12 +4174,12 @@ msgstr ""
 "inclusi nel Report."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4174,7 +4199,7 @@ msgid "label_risk_type"
 msgstr "Tipo di rischio"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
@@ -4182,7 +4207,7 @@ msgstr ""
 "miglioramento"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
@@ -4190,7 +4215,7 @@ msgstr ""
 "miglioramento non ancora inserite"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
@@ -4198,7 +4223,7 @@ msgstr ""
 "miglioramento"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
@@ -4206,7 +4231,7 @@ msgstr ""
 "miglioramento"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
@@ -4214,7 +4239,7 @@ msgstr ""
 "miglioramento"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
@@ -4222,7 +4247,7 @@ msgstr ""
 "miglioramento non ancora inserite"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
@@ -4230,7 +4255,7 @@ msgstr ""
 "miglioramento non ancora inserite"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -4245,7 +4270,7 @@ msgstr "Salva e aggiungi un altro rischio"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Salva e continua"
 
@@ -4270,7 +4295,7 @@ msgid "label_sector_title"
 msgstr "Titolo del settore."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 "ATTENZIONE: le misure obbligatorie devono essere state tutte adottate e "
@@ -4303,7 +4328,7 @@ msgid "label_show_less_hellip"
 msgstr "Mostrare meno…"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more}"
 
@@ -4333,7 +4358,7 @@ msgid "label_start_identification"
 msgstr "Inizia l'identificazione dei pericoli"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Inizia"
 
@@ -4378,29 +4403,29 @@ msgid "label_surveygroup_title"
 msgstr "Titolo del tool OiRA importato"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Alto"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Basso"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Medio"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titolo"
 
@@ -4460,12 +4485,12 @@ msgid "label_user_title"
 msgstr "Nome"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 misure)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "senza misure"
 
@@ -4514,7 +4539,7 @@ msgid "limitations"
 msgstr "limiti"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Login"
 
@@ -4604,7 +4629,7 @@ msgid "menu_import"
 msgstr "Importare strumento OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4713,32 +4738,32 @@ msgid "nav_usermanagement"
 msgstr "Amministrazione utente"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Aiuto"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Disconnettere"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Impostazioni"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Stato"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Le mie valutazioni"
 
@@ -4788,27 +4813,27 @@ msgid "notice_country_manager"
 msgstr "Country manager per ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Online interattivo"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Valutazione del rischio"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4828,7 +4853,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4842,7 +4867,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Il lancio ufficiale dello strumento è previsto per settembre 2011, quando "
@@ -4872,45 +4897,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Alto"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Basso"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Medio"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Grande"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Medio"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Piccolo"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "Completo al ${completion_percentage}%"
 
@@ -4969,18 +4994,13 @@ msgstr "Non avete un account? Innanzitutto ${register_link} ."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr "AZIONI:"
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr "COMPETENZE RICHIESTE:"
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr "DATA DI CONCLUSIONE: ${date}"
 
@@ -4993,7 +5013,7 @@ msgstr ""
 "l’accesso usufruendo dei seguenti vantaggi:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -5015,17 +5035,17 @@ msgstr ""
 "Competente, ove nominato.</p>"
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr "RESPONSABILE: ${responsible_name}"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Questo rapporto è stato basato allo strumento OiRA '${title}' con data di "
@@ -5057,35 +5077,35 @@ msgid "request_an_email_reminder"
 msgstr "richiedere un reminder per e-mail"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Questo è un rischio di priorità ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "Alto"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "basso"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "Medio"
 
@@ -5105,7 +5125,7 @@ msgid "risk_solution_header"
 msgstr "Misura ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Questo rischio dovrà essere inventariato."
@@ -5156,46 +5176,46 @@ msgstr ""
 "</strong>"
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Non molto severo"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "È necessario fermare il lavoro per meno di 3 giorni"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Severo"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "È necessario fermare il lavoro per più di 3 giorni"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Molto rigido"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Danno irreversibile, malattia incurabile, morte"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Debole"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Non è necessario fermare il lavoro"
 
@@ -5268,7 +5288,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Riguardo"
 
@@ -5283,7 +5303,7 @@ msgid "title_account_settings"
 msgstr "Impostazioni dell'account"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Cambia password"
@@ -5294,7 +5314,7 @@ msgid "title_client_help"
 msgstr "Testo di aiuto per il cliente"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Misura"
 
@@ -5329,7 +5349,7 @@ msgid "title_import_sector_survey"
 msgstr "Importare settore e strumento OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Rischi aggiuntivi (inseriti dall’utente)"
@@ -5356,8 +5376,8 @@ msgstr "Stato di ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Online interactive Risk Assessment"
 
@@ -5382,26 +5402,26 @@ msgid "title_with_vowel_status_of"
 msgstr "Stato di ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Contenuti"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Per questo rischio non sono state previste misure di miglioramento in fase "
 "di identificazione."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Nonostante il rischio sia gestito correttamente, è comunque necessario "
@@ -5409,7 +5429,7 @@ msgstr ""
 "miglioramento."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "La valutazione di questo rischio è rimasta in sospeso, per favore completa "
@@ -5436,7 +5456,7 @@ msgid "use_it_to_full_report"
 msgstr "Utilizzare per"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Utilizzare per"
 
@@ -5446,12 +5466,12 @@ msgid "use_it_to_measures_report"
 msgstr "Utilizzare per"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Utilizzare per"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Utilizzare per"
 
@@ -5466,7 +5486,7 @@ msgid "warn_fix_errors"
 msgstr "Stabilire gli errori indicati"
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""
@@ -5492,6 +5512,15 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sì"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Aggiungere un'altra misura"
+
+#~ msgid "label_prefill"
+#~ msgstr "Pre-compilazione"
+
+#~ msgid "report_actions"
+#~ msgstr "AZIONI:"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -257,7 +257,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:26
 msgid "Are you sure you want to proceed?"
-msgstr ""
+msgstr "Sei sicuro che vuoi procedere?"
 
 #: euphorie/content/behaviour/configure.zcml:33
 msgid "Automatically generate unique ids for content"
@@ -286,6 +286,7 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
+"Copiando una valutazione del rischio già realizzata, puoi utilizzarla come base di partenza per creare una nuova valutazione dei rischi utilizzando i contenuti già predisposti."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -587,7 +588,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informazione"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato dell'immagine non valido, per favore usa PNG, JPEG o GIF."
 
@@ -1053,7 +1054,7 @@ msgstr "Standard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Misure di prevenzione e protezione"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1128,7 +1129,7 @@ msgstr ""
 "L'architettura di base di una valutazione interattiva online dei rischi "
 "consiste in:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1324,7 +1325,7 @@ msgstr "Sì"
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:34
 msgid "Yes, clone risk assessment"
-msgstr ""
+msgstr "Si, copia la valutazione dei rischi"
 
 #: euphorie/content/templates/library.pt:17
 msgid ""
@@ -1532,7 +1533,8 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Descrivere quali sono le competenze / i requisiti necessari per l'attuazione delle misure."
+"Descrivere quali sono le competenze / i requisiti necessari per l'attuazione "
+"delle misure."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1569,7 +1571,7 @@ msgstr "Prodotto da ${EU-OSHA}."
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:143
 msgid "based on"
-msgstr ""
+msgstr "relative al settore"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -2200,17 +2202,17 @@ msgid "error_password_mismatch"
 msgstr "Le password non coincidono"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Questa data deve essere uguale o successiva alla data di inizio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Questa data deve essere uguale o precedente alla data di fine."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Questo valore deve essere un numero intero positivo."
 
@@ -2988,7 +2990,7 @@ msgstr ""
 "con una copia di un tool OiRA esistente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indicare la frequenza che questo rischio si verifica in una situazione "
@@ -3002,14 +3004,14 @@ msgstr ""
 "L'utente finale ha poi la possibilità di modificare il grado di priorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Indicare quanto sia possibile che questo rischio si verifichi in una "
 "situazione normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indicare la gravità che questo rischio potrebbe comportare."
 
@@ -3283,7 +3285,7 @@ msgstr "Se non si specifica il titolo, sarà preso dall'input."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Pannello di controllo"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3638,7 +3640,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3787,9 +3789,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Aggiungi le misure di miglioramento"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3814,7 +3816,7 @@ msgstr "Formato"
 #. Default: "General information"
 #: euphorie/client/browser/templates/status_info.pt:31
 msgid "label_general_information"
-msgstr "Informazione generale"
+msgstr "Informazioni generali"
 
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
@@ -4091,7 +4093,7 @@ msgstr "Anteprima"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Indietro"
@@ -4270,7 +4272,7 @@ msgstr "Salva e aggiungi un altro rischio"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Salva e continua"
 
@@ -4316,6 +4318,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Seleziona le misure di prevenzione e protezione precompilate"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4365,7 +4372,7 @@ msgstr "Inizia"
 #. Default: "Started"
 #: euphorie/client/browser/templates/status_info.pt:51
 msgid "label_started"
-msgstr ""
+msgstr "data di inizio"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4477,7 +4484,7 @@ msgstr ""
 #. Default: "Used tool"
 #: euphorie/client/browser/templates/status_info.pt:36
 msgid "label_used_tool"
-msgstr ""
+msgstr "Tool in uso"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -5410,7 +5417,7 @@ msgstr "Contenuti"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Mostra/nascondi il menu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -286,7 +286,9 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
-"Copiando una valutazione del rischio già realizzata, puoi utilizzarla come base di partenza per creare una nuova valutazione dei rischi utilizzando i contenuti già predisposti."
+"Copiando una valutazione del rischio già realizzata, puoi utilizzarla come "
+"base di partenza per creare una nuova valutazione dei rischi utilizzando i "
+"contenuti già predisposti."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -674,7 +676,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -718,7 +720,7 @@ msgstr "No"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1568,10 +1570,6 @@ msgstr "Cos’è OiRA"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Prodotto da ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "relative al settore"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4436,6 +4434,11 @@ msgstr "Medio"
 msgid "label_title"
 msgstr "Titolo"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "relative al settore ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4850,7 +4853,7 @@ msgid "optional"
 msgstr "Facoltativo"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5519,6 +5522,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sì"
+
+#~ msgid "based on"
+#~ msgstr "relative al settore"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Aggiungere un'altra misura"

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -79,7 +79,7 @@ msgstr ""
 "${provide-evidence} priežiūros institucijoms (pvz., darbo inspekcijai) "
 "pateikti. "
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Pridėkite medžiagą iš bibliotekos"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -264,7 +264,7 @@ msgstr "Esamos OiRA priemonės"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -294,7 +294,7 @@ msgstr "Šalys kandidatės"
 msgid "Candidate country"
 msgstr "Šalis kandidatė"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Keisti el. pašto adresą"
 
@@ -330,11 +330,11 @@ msgstr ""
 "pateikiama: visa informacija ir duomenys, kuriuos nurodėte atlikdami rizikos "
 "vertinimą"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Turinys: įgyvendintinų priemonių apžvalga."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Turinys: nustatytų rizikų apžvalga"
 
@@ -373,15 +373,15 @@ msgstr "Šalies informacija ir programos grupavimas."
 msgid "Country manager"
 msgstr "Šalies administratorius"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "„Creative Commons Attribution-ShareAlike 2.5 Generic“ licencija"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "„Creative Commons“ licencija"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -440,15 +440,15 @@ msgstr "Atsisiųskite prevencijos veiksmų planą"
 msgid "Download the full report"
 msgstr "Atsisiųskite išsamią ataskaitą"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Atsisiųskite priemonių apžvalgą"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Atsisiųskite rizikų apžvalgą"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E. paštas"
@@ -522,7 +522,7 @@ msgstr "Aplankas"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "formatas: Excel (.xls)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Formatas: dokumento formatas (.pdf)"
 
@@ -530,7 +530,7 @@ msgstr "Formatas: dokumento formatas (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Vokietija"
 
@@ -555,7 +555,7 @@ msgstr ""
 "Tačiau vertinimui skirkite tiek laiko, kiek jo turite – bet kada galėsite "
 "tęsti nuo tos vietos, kur baigėte praeitą kartą."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Noriu pasidalinti šia informacija su jumis"
 
@@ -571,8 +571,7 @@ msgstr ""
 msgid "Important"
 msgstr "Svarbu"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informacija"
 
@@ -581,7 +580,7 @@ msgstr "Informacija"
 msgid "Information"
 msgstr "Informacija"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -615,11 +614,11 @@ msgstr "Kosovas"
 msgid "Last saved"
 msgstr "išsaugota"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Sužinokite daugiau apie šį įrankį…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -631,7 +630,7 @@ msgstr "Prisijungimas"
 msgid "Manage"
 msgstr "savo darbo vietoje"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Priemonė"
@@ -650,14 +649,14 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "stebėdami ir vertindami, ar taikomos būtinos priemonės;"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Priemonių, kurios turi būti įgyvendintos per artimiausius 3 mėnesius "
 "stebėsena)"
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Stebėkite rizikas / priemonių tinkamą įgyvendinimą."
 
@@ -783,12 +782,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Internetinis žinynas"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Priemonių peržiūra"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Rizikų peržiūra"
@@ -806,8 +807,8 @@ msgstr ""
 "atstovams, darbdaviams, DSS specialistams....)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Perduokite informaciją susijusiems asmenims."
 
@@ -837,9 +838,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Žr. formos apačioje pateiktus pavyzdžius."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Atidėta"
 
@@ -880,7 +881,7 @@ msgstr "įrodymams priežiūros institucijoms pateikti;"
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Sužinokite daugiau"
 
@@ -913,8 +914,8 @@ msgstr ""
 "rizikos vertinimus arba pradėti naujus."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Pašalinti"
 
@@ -935,11 +936,11 @@ msgstr "Rizika"
 msgid "Risk assessments made with this tool"
 msgstr "Naudojantis šia priemone atlikti rizikos vertinimai"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "GERAI"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Dėmesio"
 
@@ -1017,7 +1018,7 @@ msgstr "Dalytis šia internetine interaktyviąja rizikos vertinimo priemone"
 msgid "Show library from ${dropdown}."
 msgstr "Rodyti biblioteką iš ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Registruokitės"
 
@@ -1033,6 +1034,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standartinis"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1087,7 +1092,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Olandija"
 
@@ -1106,7 +1111,7 @@ msgstr ""
 "Pagrindinės internetinės interaktyviosios rizikos vertinimo priemonės "
 "sudedamosios dalys yra šios:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1211,7 +1216,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Pasaulis turi žinoti apie šią priemonę! Dalykitės!"
 
@@ -1219,8 +1224,8 @@ msgstr "Pasaulis turi žinoti apie šią priemonę! Dalykitės!"
 msgid "Tip"
 msgstr "Patarimas"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Įjungti/išjungti paaiškinimus ekrane"
 
@@ -1232,9 +1237,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Neatsakyta"
 
@@ -1351,33 +1356,33 @@ msgid "Your password was successfully changed."
 msgstr "Jūsų slaptažodis sėkmingai pakeistas."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "OiRA programos šaltinio kodas turi ${GPL} licenciją."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "OiRA priemonės turiniui yra taikoma ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "OiRA priemones nemokai gali naudoti visi naudotojai."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Daugiau informacijos apie OiRA projektą (anglų kalba)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Europos Bendrijos strategija dėl sveikatos ir saugos darbe, 2007-2012 m."
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Patirtis rodo, kad ${key}. Štai kodėl ES-OSHA sukūrė ${easy} (OiRA - "
@@ -1387,42 +1392,42 @@ msgstr ""
 "${preventive_actions}, imantis veiksmų, stebint ir ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "paprasta naudoti ir lengvai pritaikoma žiniatinkliui programa"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "vertinimas"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "nustatymas"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "tinkamas rizikos vertinimas yra saugios darbo vietos pagrindas"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "prevenciniai veiksmai"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "ataskaitų rengimas"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "nuoseklus rizikos vertinimo procesas"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "OiRA internetinė programa suteikia prieigą prie konkrečios ekonominės "
@@ -1430,7 +1435,7 @@ msgstr ""
 "organizacijos nacionaliniu lygmeniu."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} ragina pritaikyti šią priemonę ir pagreitinti rizikos vertinimo "
@@ -1442,7 +1447,7 @@ msgstr ""
 "prasme. To OiRA projektu ir siekiama."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "OiRA projektą ir susijusias internetines programas sukūrė ${eu-osha}, "
@@ -1453,12 +1458,12 @@ msgstr ""
 "sąjungomis FNV, CNV ir MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "Prie OiRA projekto prisidėjo šie techniniai partneriai:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Agentūrai dėl OiRA projekto kūrimo ir įgyvendinimo taip pat talkino "
@@ -1466,32 +1471,38 @@ msgstr ""
 "interesų grupes valdyboje paskyrė Komisija ir ES-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikro ir nedidelės įmonės turi tam tikrų trūkumų"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Kai kurios priemonės nekainuoja nė cento, tačiau daugelis kainuoja. Dėl to "
 "jas reikia finansuoti. Jas reikia įtraukti į metinį biudžetą (jei reikia)."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Paskirkite ką nors iš savo kompanijos atsakingu už šios priemonės "
 "pritaikymą. Šis asmuo turėtų turėti teisę imtis plane aprašytų veiksmų ir "
 "(arba) užtikrinti, kad jie yra atliekami."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Nurodykite: 1) koks yra pagrindinis būdas pašalinti arba (jei neišvengiama) "
 "sumažinti riziką; 2) kokių konkrečių veiksmų reikia imtis, norint šį metodą "
-"(pašalinti arba sumažinti riziką) pritaikyti; 3) koks yra reikalingų žinių "
+"(pašalinti arba sumažinti riziką) pritaikyti."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Nurodykite: 3) koks yra reikalingų žinių "
 "lygis, pavyzdžiui, „sveikas protas (DSS žinios nereikalingos)“, „specialios "
 "DSS patirties nereikia, tačiau minimalių DSS žinių arba mokymo ir (arba) "
 "konsultacijos apie DSS reikia“ arba „DSS ekspertas“. Čia taip pat galite "
@@ -1555,7 +1566,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: teigiami atsakymai, kurie pateikiami moduliuose."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Įkelti"
 
@@ -1603,7 +1614,7 @@ msgstr "Atšaukti"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1926,7 +1937,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Priemonė automatiškai atliko rizikos vertinimą. Veiksmų plane, jeigu "
@@ -1979,7 +1990,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "2009 m. sukūrusi priemonę, 2010 m. (iki pirmojo 2011 m. pusmečio) Agentūra "
@@ -2020,17 +2031,17 @@ msgid "effect_high"
 msgstr "Didelis (labai didelis) sunkumas"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Nedidelis sunkumas"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Žymus sunkumas"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Didelis (labai didelis) sunkumas"
 
@@ -2105,7 +2116,7 @@ msgid "error_existing_login"
 msgstr "Šis prisijungimo vardas jau naudojamas."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Biudžetą sudarinėkite sumas nurodydami eurais."
 
@@ -2141,17 +2152,17 @@ msgid "error_password_mismatch"
 msgstr "Slaptažodis netinkamas"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Ši data turi sutapti su pradžios data arba būti už ją vėlesnė."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Ši data turi sutapti su pabaigos data arba būti už ją ankstesnė."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Šioje vietoje nurodykite teigiamą sveikąjį skaičių."
 
@@ -2260,7 +2271,7 @@ msgstr ""
 "šiuos pakeitimus turite patvirtinti."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2269,12 +2280,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Prevencinių veiksmų planas ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Nustatymo ataskaitos ${title}"
 
@@ -2294,7 +2305,7 @@ msgid "french"
 msgstr "Du supaprastinti kriterijai"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Beveik niekada"
 
@@ -2304,57 +2315,57 @@ msgid "frequency_almostnever"
 msgstr "Beveik niekada"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Nuolat"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Nelabai dažnas"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Kartą per mėnesį"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Dažnas"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Kartą per savaitę"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Retas"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Kartą per metus"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Labai dažnas arba reguliarus"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Mažiausiai kartą per dieną"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Reguliariai"
@@ -2381,12 +2392,12 @@ msgid "header_additional_content"
 msgstr "Papildomas turinys"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Papildomi rizikos vertinimo šaltiniai"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Papildomi šaltiniai šram modulini"
 
@@ -2401,12 +2412,12 @@ msgid "header_country_managers"
 msgstr "Šalies administratoriai"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Plėtros ir bandymų etapas – 2009-2011 m."
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Plėtros partneriai"
 
@@ -2442,18 +2453,18 @@ msgstr "Nustatymas"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informacija"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Oficiali projekto paleidimo data – 2011 m. rugsėjo mėn."
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Nuorodos į teisės aktus"
 
@@ -2463,13 +2474,13 @@ msgid "header_legend"
 msgstr "Legenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licencijos"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prisijungimo vardas"
@@ -2480,12 +2491,12 @@ msgid "header_main_image"
 msgstr "Pagrindinis atvaizdas"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Priemonė ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Priemonė"
 
@@ -2511,12 +2522,12 @@ msgid "header_not_complicated"
 msgstr "Vertinimas nėra sudėtingas"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2551,7 +2562,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2571,7 +2582,7 @@ msgid "header_profile_questions"
 msgstr "Profilio klausimai"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projekto etapai"
 
@@ -2587,7 +2598,7 @@ msgstr "Modulyje atsakyti klausimai"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registruotis"
 
@@ -2608,23 +2619,23 @@ msgid "header_risk_aware"
 msgstr "Ar žinote visas rizikas?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Koks yra žalos sunkumas?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Kaip dažnai žmonės su šia rizika susiduria?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Pasirinkite šios rizikos lygį"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Kokia tikimybė, kad ši rizika atsiras?"
 
@@ -2636,7 +2647,7 @@ msgid "header_risks"
 msgstr "Rizikos"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2696,12 +2707,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2716,17 +2727,17 @@ msgid "header_welcome"
 msgstr "Sveiki"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Kas yra OiRA (internetinio interaktyvaus rizikos vertinimo) projektas"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Kodėl OiRA projektas"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Komentarai"
 
@@ -2747,142 +2758,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Vidutinio reikšmingumo rizikos"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Didelio reikšmingumo rizikos"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Didelio reikšmingumo rizikos"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Didelio reikšmingumo rizikos"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Didelio reikšmingumo rizikos"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Mažo reikšmingumo rizikos"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Mažo reikšmingumo rizikos"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Mažo reikšmingumo rizikos"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Mažo reikšmingumo rizikos"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Vidutinio reikšmingumo rizikos"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Vidutinio reikšmingumo rizikos"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Vidutinio reikšmingumo rizikos"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Vidutinio reikšmingumo rizikos"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Atidėtos rizikos"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Atidėtos rizikos"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Atidėtos rizikos"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Atidėtos rizikos"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Neatsakytos rizikos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Neatsakytos rizikos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Neatsakytos rizikos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Neatsakytos rizikos"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Galimos rizikos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Galimos rizikos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Galimos rizikos"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Galimos rizikos"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Esamos rizikos"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Esamos rizikos"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Esamos rizikos"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Esamos rizikos"
 
@@ -2906,7 +2917,7 @@ msgstr ""
 "prisijungti."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Atsakykite į toliau pateiktus klausimus. Atsižvelgiant į jūsų atsakymus, "
@@ -2934,7 +2945,7 @@ msgstr ""
 "pradėti nuo esamos OiRA priemonės kopijos."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Nurodyti, kaip dažnai rizika pasireiškia normaliose situacijose."
 
@@ -2946,12 +2957,12 @@ msgstr ""
 "prioritetą vis dar gali pakeisti."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Nurodyti, kokia rizikos pasireiškimo normaliose situacijose tikimybė."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Nurodyti atsiradusios rizikos sunkumą."
 
@@ -3046,6 +3057,11 @@ msgstr ""
 "Įkelkite atvaizdą, kurio formatas būtinai turi būti „.png“, „.jpg“ arba „."
 "gif“. Jame negali būti jokių specialiųjų simbolių."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3061,7 +3077,7 @@ msgstr ""
 "(rizikos šalinimo arba sumažinimo) pritaikyti."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Nurodykite profesinės patirties lygis, kurio reikia šio būdo pritaikymui, "
@@ -3220,7 +3236,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Pavadinimo nenurodžius, jis bus paimtas iš pradinio failo."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3306,7 +3322,7 @@ msgstr ""
 "arba ${start_session}."
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Tai yra bandomoji sesija"
 
@@ -3502,13 +3518,13 @@ msgstr "Paskyra užblokuota"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Veiksmų planas"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Biudžetas"
 
@@ -3518,27 +3534,22 @@ msgid "label_action_plan_download"
 msgstr "Veiksmų planas"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Įgyvendinimo pabaiga"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Kas atsakingas?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Įgyvendinimo pradžia"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Įkelti naują priemonę"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3581,8 +3592,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Šiame laukelyje galite įrašyti norimą komentarą. Šie komentarai bus "
@@ -3669,7 +3680,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Aprašymas"
@@ -3699,7 +3710,7 @@ msgstr "Rodyti šios OiRA priemonės individualizuotą pranešimą?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Vertinimas"
 
@@ -3719,10 +3730,19 @@ msgid "label_evaluation_phase"
 msgstr "Vertinimo etapas"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Jau įdiegta priemonė"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3797,7 +3817,7 @@ msgstr "Atlikite rizikos vertinimą"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Nustatymas"
 
@@ -3805,6 +3825,11 @@ msgstr "Nustatymas"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Atvaizdo failas"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3827,7 +3852,7 @@ msgid "label_language"
 msgstr "Kalba"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Nuorodos į teisės aktus"
@@ -3862,22 +3887,27 @@ msgstr "Logotipas"
 msgid "label_logo_selection"
 msgstr "Kurį logotipą norėtumėte matyti viršutiniame kairiajame kampe?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Pagrindinis sprendimas (pašalinti arba sumažinti riziką)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 "Specialūs veiksmai, kuriuos reikia atlikti, norint šį metodą įgyvendinti"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Reikalingų žinių ir (arba) reikalavimų lygis"
 
@@ -3933,25 +3963,25 @@ msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Rizikos nėra (labai maža)"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Rizikos nėra (labai maža)"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Rizikos nėra (labai maža)"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Rizikos nėra (labai maža)"
@@ -3991,15 +4021,10 @@ msgstr "Slaptažodis"
 msgid "label_password_confirm"
 msgstr "Pakartoti slaptažodį"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Užpildykite iš anksto"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Paruošimas"
 
@@ -4010,7 +4035,7 @@ msgstr "Peržiūra"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Ankstesnis"
@@ -4073,15 +4098,15 @@ msgstr "Galite atsisiųsti išsamią ataskaitą ir veiksmų planą."
 msgid "label_register_first"
 msgstr "registruotis"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Pašalinti šią priemonę"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Ataskaita"
 
@@ -4091,12 +4116,12 @@ msgid "label_report_comment"
 msgstr "Šiame laukelyje įrašykite norimus komentarus"
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4116,49 +4141,49 @@ msgid "label_risk_type"
 msgstr "Rizikos tipas"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Rizika, numatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Rizika, kuriai nenumatyta (-os) priemonė (-ės)"
@@ -4171,7 +4196,7 @@ msgstr "Išsaugoti ir nurodyti kitą riziką"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Išsaugoti ir tęsti"
 
@@ -4196,7 +4221,7 @@ msgid "label_sector_title"
 msgstr "Ekonominės veiklos pavadinimas."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Pasirinkite vieną ar kelias iš pateiktų priemonių."
 
@@ -4227,7 +4252,7 @@ msgid "label_show_less_hellip"
 msgstr "Rodyti mažiau"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} apie šią riziką."
 
@@ -4257,7 +4282,7 @@ msgid "label_start_identification"
 msgstr "Pradėti rizikų nustatymo procesą"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Pradžia"
 
@@ -4302,29 +4327,29 @@ msgid "label_surveygroup_title"
 msgstr "Įkeltos OiRA priemonės pavadinimas"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "didelė"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "maža"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "vidutinė"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Pavadinimas"
 
@@ -4384,12 +4409,12 @@ msgid "label_user_title"
 msgstr "Vardas"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 priemonės)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "Priemonių nėra"
 
@@ -4436,7 +4461,7 @@ msgid "limitations"
 msgstr "apribojimai"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Prisijungimo vardas"
 
@@ -4524,7 +4549,7 @@ msgid "menu_import"
 msgstr "Įkelti OiRA priemonę"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4632,32 +4657,32 @@ msgid "nav_usermanagement"
 msgstr "Administravimas"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Pagalba"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Išsiregistruoti"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Parametrai"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Būsena"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Mano vertinimai"
 
@@ -4707,27 +4732,27 @@ msgid "notice_country_manager"
 msgstr "${country} administratorius."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Internetinis interaktyvus"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Rizikos vertinimas"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4747,7 +4772,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4759,7 +4784,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Oficiali projekto paleidimo data yra numatyta 2011 m. rugsėjo mėn., kai tik "
@@ -4788,45 +4813,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Aukštas"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Žemas"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Vidutinis"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Didelė"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Vidutinė"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Nedidelė"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Baigtas"
 
@@ -4879,18 +4904,13 @@ msgstr "Neturite paskyros? Tuomet pirmiausia ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4902,7 +4922,7 @@ msgstr ""
 "atsisiuntimo funkcija. Registracija trunka tik akimirką ir yra naudinga, nes:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4916,17 +4936,17 @@ msgstr ""
 "kuriuos norite įtraukti į žemiau esantį ataskaitos laukelį."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Ši ataskaita remiasi OiRA priemone '${title}' (peržiūros data ${date})."
@@ -4957,35 +4977,35 @@ msgid "request_an_email_reminder"
 msgstr "priminimo el. paštu užklausa"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Tai ${priority_value} rizika."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "didelė"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "maža"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "vidutinė"
 
@@ -5005,7 +5025,7 @@ msgid "risk_solution_header"
 msgstr "Priemonė ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Šią riziką reikia peržiūrėti."
@@ -5053,46 +5073,46 @@ msgid "select_add_existing_measure"
 msgstr "Pasirinkti arba pridėti jau įdiegtas priemones."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Nelabai sunkus"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Reikia nutraukti darbus mažiau nei 3 dienoms"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Didelis sunkumas"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Reikia nutraukti darbus daugiau nei 3 dienoms"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Labai didelis sunkumas"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Nepagydomas sužalojimas, nepagydoma liga, mirtis"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Silpnas"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Nutraukti darbo nereikia"
 
@@ -5165,7 +5185,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Apie"
 
@@ -5180,7 +5200,7 @@ msgid "title_account_settings"
 msgstr "Paskyros nustatymai"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Keisti slaptažodį"
@@ -5191,7 +5211,7 @@ msgid "title_client_help"
 msgstr "Programos pagalbos tekstas"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Priemonė"
 
@@ -5226,7 +5246,7 @@ msgid "title_import_sector_survey"
 msgstr "Įkėlimo sektorius ir OiRA priemonė"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Jūsų įtrauktos rizikos"
@@ -5253,8 +5273,8 @@ msgstr "${survey_title} statusas"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 "OiRA - internetinis interaktyvus rizikos vertinimas (angl. Online "
@@ -5281,19 +5301,19 @@ msgid "title_with_vowel_status_of"
 msgstr "${survey_title} statusas"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Turinys"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Ši rizika šiuo metu jūsų organizacijoje nekyla, bet kadangi ekonominėje "
@@ -5301,7 +5321,7 @@ msgstr ""
 "ją būtina įtraukti."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Ši rizika šiuo metu jūsų organizacijoje nekyla, bet kadangi ekonominėje "
@@ -5309,7 +5329,7 @@ msgstr ""
 "ją būtina įtraukti."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Jūsų organizacijoje ši rizika yra labai maža, tačiau ji laikoma viena iš "
@@ -5337,7 +5357,7 @@ msgid "use_it_to_full_report"
 msgstr "Naudokite ją"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Naudokite ją"
 
@@ -5347,12 +5367,12 @@ msgid "use_it_to_measures_report"
 msgstr "Naudokite ją"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Naudokite ją"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Naudokite ją"
 
@@ -5367,7 +5387,7 @@ msgid "warn_fix_errors"
 msgstr "Ištaisykite nurodytas klaidas."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Apie ankstesnį teiginį atsiliepėte neigiamai."
@@ -5391,6 +5411,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Taip"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Įkelti naują priemonę"
+
+#~ msgid "label_prefill"
+#~ msgstr "Užpildykite iš anksto"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Jūsų veiksmų plane nėra padaryta pakeitimų."

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -665,7 +665,7 @@ msgid "Montenegro"
 msgstr "Juodkalnija"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -709,7 +709,7 @@ msgstr "Ne"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1540,10 +1540,6 @@ msgstr "Apie"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Sukūrė: ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "pagal"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4358,6 +4354,11 @@ msgstr "vidutinė"
 msgid "label_title"
 msgstr "Pavadinimas"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "pagal ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4767,7 +4768,7 @@ msgid "optional"
 msgstr "Papildomas"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5416,6 +5417,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Taip"
+
+#~ msgid "based on"
+#~ msgstr "pagal"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Įkelti naują priemonę"

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -580,9 +580,9 @@ msgstr "Informacija"
 msgid "Information"
 msgstr "Informacija"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr ""
+msgstr "Netinkamas vaizdo failo formatas. Naudokite PNG, JEPG arba GIF."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -1037,7 +1037,7 @@ msgstr "Standartinis"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Standartinės priemonės"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1111,7 +1111,7 @@ msgstr ""
 "Pagrindinės internetinės interaktyviosios rizikos vertinimo priemonės "
 "sudedamosios dalys yra šios:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1249,7 +1249,7 @@ msgstr "Įkelti"
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:198
 msgid "Upload an image that illustrates this risk."
-msgstr ""
+msgstr "Įkelkite vaizdo failą, kuris iliustruoja šią riziką."
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:217
 msgid "Upload image"
@@ -1502,11 +1502,11 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Nurodykite: 3) koks yra reikalingų žinių "
-"lygis, pavyzdžiui, „sveikas protas (DSS žinios nereikalingos)“, „specialios "
-"DSS patirties nereikia, tačiau minimalių DSS žinių arba mokymo ir (arba) "
-"konsultacijos apie DSS reikia“ arba „DSS ekspertas“. Čia taip pat galite "
-"nurodyti bet kokius kitus papildomus reikalavimus (jei yra)."
+"Nurodykite: 3) koks yra reikalingų žinių lygis, pavyzdžiui, „sveikas protas "
+"(DSS žinios nereikalingos)“, „specialios DSS patirties nereikia, tačiau "
+"minimalių DSS žinių arba mokymo ir (arba) konsultacijos apie DSS reikia“ "
+"arba „DSS ekspertas“. Čia taip pat galite nurodyti bet kokius kitus "
+"papildomus reikalavimus (jei yra)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2152,17 +2152,17 @@ msgid "error_password_mismatch"
 msgstr "Slaptažodis netinkamas"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Ši data turi sutapti su pradžios data arba būti už ją vėlesnė."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Ši data turi sutapti su pabaigos data arba būti už ją ankstesnė."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Šioje vietoje nurodykite teigiamą sveikąjį skaičių."
 
@@ -2945,7 +2945,7 @@ msgstr ""
 "pradėti nuo esamos OiRA priemonės kopijos."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Nurodyti, kaip dažnai rizika pasireiškia normaliose situacijose."
 
@@ -2957,12 +2957,12 @@ msgstr ""
 "prioritetą vis dar gali pakeisti."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Nurodyti, kokia rizikos pasireiškimo normaliose situacijose tikimybė."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Nurodyti atsiradusios rizikos sunkumą."
 
@@ -3238,7 +3238,7 @@ msgstr "Pavadinimo nenurodžius, jis bus paimtas iš pradinio failo."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Meniu juosta"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3592,7 +3592,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3740,9 +3740,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Įtraukite papildomą priemonę"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4035,7 +4035,7 @@ msgstr "Peržiūra"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Ankstesnis"
@@ -4196,7 +4196,7 @@ msgstr "Išsaugoti ir nurodyti kitą riziką"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Išsaugoti ir tęsti"
 
@@ -4240,6 +4240,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Pasirinkite standartines priemones"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4401,7 +4406,7 @@ msgstr ""
 #. Default: "Used tool"
 #: euphorie/client/browser/templates/status_info.pt:36
 msgid "label_used_tool"
-msgstr ""
+msgstr "Naudojama priemonė"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -5309,7 +5314,7 @@ msgstr "Turinys"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Rodyti/slėpti meniu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -661,7 +661,7 @@ msgid "Montenegro"
 msgstr "Melnkalne"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr "Nē"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1547,10 +1547,6 @@ msgstr "Informācija"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Autors: ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "balstīts uz"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4352,6 +4348,11 @@ msgstr "Vidēja"
 msgid "label_title"
 msgstr "Nosaukums"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "balstīts uz ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4761,7 +4762,7 @@ msgid "optional"
 msgstr "Neobligāts"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5407,6 +5408,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Jā"
+
+#~ msgid "based on"
+#~ msgstr "balstīts uz"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Pievienot citu pasâkumu"

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -578,9 +578,9 @@ msgstr "Informācija"
 msgid "Information"
 msgstr "Informācija"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr ""
+msgstr "Nepiemērots attēla faila formāts. Lūdzu izmantot PNG, JPEG vai GIF."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -1039,7 +1039,7 @@ msgstr "Standarta"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Tipveida pasākums"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1110,7 +1110,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Riska interaktīvā novērtēšanas tiešsaistes rīka arhitektūra sastāv no:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1253,7 +1253,7 @@ msgstr "Augšupielādēt"
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:198
 msgid "Upload an image that illustrates this risk."
-msgstr ""
+msgstr "Augšupielādēt attēlu, kas atspoguļo risku."
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:217
 msgid "Upload image"
@@ -1504,15 +1504,14 @@ msgstr ""
 "novēršams) – obligāts lauks; 2) specifiskās darbības, kas jāveic, lai "
 "īstenotu šo pieeju (lai samazinātu vai novērstu risku) – nav obligāts lauks."
 
-
 #. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Aprakstiet: 3) pieredzes līmeni, kas nepieciešams šo pasākumu īstenotu, piemēram, "
-"\"vispārīga izpratne (nav nepieciešamas zināšanas par darba aizsardzību)\", "
-"\"nav nepieciešamas specifiskas padziļinātas zināšanas par darba "
-"aizsardzību, bet jābūt minimālām zināšanām par darba aizsardzību” vai "
+"Aprakstiet: 3) pieredzes līmeni, kas nepieciešams šo pasākumu īstenotu, "
+"piemēram, \"vispārīga izpratne (nav nepieciešamas zināšanas par darba "
+"aizsardzību)\", \"nav nepieciešamas specifiskas padziļinātas zināšanas par "
+"darba aizsardzību, bet jābūt minimālām zināšanām par darba aizsardzību” vai "
 "„mērījumu laboratorijai jābūt akreditētai\". Šeit varat arī aprakstīt "
 "jebkādas papildu prasības (ja jums tādas ir)."
 
@@ -2165,17 +2164,17 @@ msgid "error_password_mismatch"
 msgstr "Paroles nesakrīt."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Šim datumam ir jābūt sākuma datumam vai pēc tā."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Šim datumam ir jābūt beigu datumam vai pirms tā."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Šim lielumam ir jābūt pozitīvam veselam skaitlim."
 
@@ -2952,7 +2951,7 @@ msgstr ""
 "ar esoša OiRA rīka kopiju."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Norādiet, cik bieži šāds risks pastāv normālos apstākļos."
 
@@ -2964,12 +2963,12 @@ msgstr ""
 "noklusējuma. Lietotājs tik un tā varēs pats mainīt prioritātes līmeni."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Norādiet, cik ticama ir šī riska rašanās normālos apstākļos."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Norādiet bīstamības pakāpi, ko izraisa šī riska īstenošanās."
 
@@ -3239,7 +3238,7 @@ msgstr "Ja nenorādīsit nosaukumu, tas tiks izveidots no ievadītajiem datiem."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Infopanelis"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3588,7 +3587,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3736,9 +3735,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Pievienot papildus pasākumu"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3763,7 +3762,7 @@ msgstr "Formāts"
 #. Default: "General information"
 #: euphorie/client/browser/templates/status_info.pt:31
 msgid "label_general_information"
-msgstr "Galvenā informācija"
+msgstr "Vispārīga informācija"
 
 #. Default: "4. Action Plan"
 #: euphorie/content/help.py:68 euphorie/content/templates/help_view.pt:33
@@ -4030,7 +4029,7 @@ msgstr "Priekšskatījums"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Atpakaļ"
@@ -4193,7 +4192,7 @@ msgstr "Saglabāt un pievienot citu risku"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Saglabāt un turpināt"
 
@@ -4235,6 +4234,11 @@ msgstr "Sāciet jaunu sesiju, atlasot vienu no tālāk minētajiem sektoru rīki
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Izvēlēties tipveida pasākumus"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4396,7 +4400,7 @@ msgstr ""
 #. Default: "Used tool"
 #: euphorie/client/browser/templates/status_info.pt:36
 msgid "label_used_tool"
-msgstr ""
+msgstr "Izmantots rīks"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -5304,7 +5308,7 @@ msgstr "Saturs"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Parādīt / paslēpt izvēlni"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -80,7 +80,7 @@ msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 "${provide-evidence} Valsts darba inspekcijai vai citām uzraudzības iestādēm,."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr "Pievienot saturu no bibliotēkas"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -263,7 +263,7 @@ msgstr "Pieejamie OiRA rīki"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgstr "Kandidātvalstis"
 msgid "Candidate country"
 msgstr "Kandidātvalsts"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Mainīt e-pasta adresi"
 
@@ -329,11 +329,11 @@ msgstr ""
 "Ietver: visu Jūsu informāciju un datus, ko sniedzāt, veicot darba vides "
 "riska novērtējumu."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Satur: īstenojamo pasākumu pārskatu sarakstu."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Satur: pārskatu par identificētajiem riskiem"
 
@@ -370,15 +370,15 @@ msgstr "Klientam paredzētā informācija par valsti un sadalījums grupās."
 msgid "Country manager"
 msgstr "Vadītājs attiecīgajā valstī"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 vispārēja licence"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "\"Creative Commons\" licence"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -437,15 +437,15 @@ msgstr "Lejuplādēt pasākumu plānu"
 msgid "Download the full report"
 msgstr "Lejuplādēt darba vides riska novērtējumu"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Lejuplādēt drīzumā īstenojamo pasākumu sarakstu"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Lejuplādēt riska novērtējuma statusu"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-pasts"
@@ -519,7 +519,7 @@ msgstr "Mape"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formāts: Excel (.xls)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Formāts: Pārvietojams dokumenta formāts (.pdf)"
 
@@ -527,7 +527,7 @@ msgstr "Formāts: Pārvietojams dokumenta formāts (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Vācija"
 
@@ -553,7 +553,7 @@ msgstr ""
 "brīdī, un atgriezties jebkurā laikā, lai turpinātu procesu no vietas, kurā "
 "apstājāties iepriekšējā reizē."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Es vēlos dalīties ar Jums šādos jaunumos"
 
@@ -569,8 +569,7 @@ msgstr ""
 msgid "Important"
 msgstr "Svarīgi"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informācija"
 
@@ -579,7 +578,7 @@ msgstr "Informācija"
 msgid "Information"
 msgstr "Informācija"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -613,11 +612,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "tika saglabāta"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Uzziniet vairāk par šo rīku…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -629,7 +628,7 @@ msgstr "Pieteikties"
 msgid "Manage"
 msgstr "Veiktu"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Pasākums"
@@ -648,12 +647,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "uzraudzīt un novērtēt, vai ir veikti nepieciešamie pasākumi,"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Noskaidrot, kuri pasākumi jāīsteno nākamajos 3 mēnešos."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Uzraudzīt, vai riskus precīzi novērš /pasākumus īsteno."
 
@@ -780,12 +779,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Tiešsaistes palīdzība"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Pārskats par veicamajiem pasākumiem"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Risku pārskats"
@@ -804,8 +805,8 @@ msgstr ""
 "speciālistiem u. c.),"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Nodot informāciju iesaistītajiem cilvēkiem."
 
@@ -835,9 +836,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Lūdzu, aplūkojiet piemērus zem veidlapas."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Atlikts jautājums"
 
@@ -880,7 +881,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Lasīt vairāk"
 
@@ -915,8 +916,8 @@ msgstr ""
 "uzsāktos novērtējumus vai veiktu jaunus."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Noņemt"
 
@@ -937,11 +938,11 @@ msgstr "Risks"
 msgid "Risk assessments made with this tool"
 msgstr "Ar šo rīku veidotie riska novērtējumi"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Viss kārtībā"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Uzmanību"
 
@@ -1019,7 +1020,7 @@ msgstr "Kopīgojiet šo OiRA rīku"
 msgid "Show library from ${dropdown}."
 msgstr "Parādīt bibliotēku no ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Pieteikties"
 
@@ -1035,6 +1036,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standarta"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1088,7 +1093,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nīderlande"
 
@@ -1105,7 +1110,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Riska interaktīvā novērtēšanas tiešsaistes rīka arhitektūra sastāv no:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1215,7 +1220,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Pasaulei jāuzzina par šo rīku! Dalieties ar to!"
 
@@ -1223,8 +1228,8 @@ msgstr "Pasaulei jāuzzina par šo rīku! Dalieties ar to!"
 msgid "Tip"
 msgstr "Ieteikums"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Ieslēdziet ekrāna palīdzību"
 
@@ -1236,9 +1241,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Neatbildēts"
 
@@ -1355,34 +1360,34 @@ msgid "Your password was successfully changed."
 msgstr "Jūsu parole ir veiksmīgi mainīta."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "OiRA lietotnes pirmkodam ir ${GPL} licence."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "OiRA sektoru rīku saturs ir licencēts ar ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "OiRA sektoru rīkus visi lietotāji var lietot bez maksas."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Sīkāka informācija par OiRA projektu (angļu valodā)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 " Eiropas Kopienas Stratēģija attiecībā uz veselības aizsardzību un drošību "
 "darbā (2007.-2012.)"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Pieredze rāda, ka ${key}. Tāpēc EU-OSHA izstrādāja OiRA projektu "
@@ -1393,49 +1398,49 @@ msgstr ""
 "${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "vienkārši lietojama tīmekļa lietotne, kas nerada izmaksas"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "novērtēšanu"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identifikāciju"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "pienācīgai riska novērtēšanai ir nenovērtējama loma darba vietā"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "aizsardzības risinājumiem"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "pārskatu veidošanu"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "pakāpenisku riska novērtēšanas procesu"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "OiRA tīmekļa lietotne jums ļauj piekļūt sektora risku izvērtēšanas rīkiem, "
 "kurus izveidojušas un uztur valsts līmeņa sektoru organizācijas."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} aicina izstrādāt vienkāršus rīkus, lai atvieglotu riska "
@@ -1447,7 +1452,7 @@ msgstr ""
 "ir šos trūkumus novērst."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "OiRA projektu un tam domāto tīmekļa lietotni izstrādāja ${eu-osha}, par "
@@ -1458,12 +1463,12 @@ msgstr ""
 "MHP palīdzēja turpināt lietotnes izstrādi."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "OiRA projekta izstrādē piedalījās šādi tehniskie partneri:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "OiRA projekta izstrādes un ieviešanas laikā Aģentūra saņēma stratēģiskus un "
@@ -1471,12 +1476,12 @@ msgstr ""
 "aizstājējus iecēla padomes interešu grupas, Komisija un EU-OSHA organizācija."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikrouzņēmumiem un maziem uzņēmumiem ir daži trūkumi"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Lai gan daži pasākumi riska novēršanai ir bezmaksas, lielākā daļa tomēr rada "
@@ -1484,21 +1489,27 @@ msgstr ""
 "pasākumus ikgadējā uzņēmuma budžetā."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Uzticiet kādam uzņēmuma darbiniekam atbildību par šī pasākuma ieviešanu. Šim "
 "darbiniekam būs pilnvaras veikt plānā minētās darbības un/vai pienākums "
 "gādāt par to izpildi."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Aprakstiet: 1) savu pasākumu, lai risku novērstu vai samazinātu (ja tas nav "
 "novēršams) – obligāts lauks; 2) specifiskās darbības, kas jāveic, lai "
-"īstenotu šo pieeju (lai samazinātu vai novērstu risku) – nav obligāts lauks; "
-"3) pieredzes līmeni, kas nepieciešams šo pasākumu īstenotu, piemēram, "
+"īstenotu šo pieeju (lai samazinātu vai novērstu risku) – nav obligāts lauks."
+
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Aprakstiet: 3) pieredzes līmeni, kas nepieciešams šo pasākumu īstenotu, piemēram, "
 "\"vispārīga izpratne (nav nepieciešamas zināšanas par darba aizsardzību)\", "
 "\"nav nepieciešamas specifiskas padziļinātas zināšanas par darba "
 "aizsardzību, bet jābūt minimālām zināšanām par darba aizsardzību” vai "
@@ -1563,7 +1574,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: apgalvojumi, kas iekļauti moduļos."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Pievienot"
 
@@ -1611,7 +1622,7 @@ msgstr "Atcelt"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Aizvērt"
 
@@ -1938,7 +1949,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Riska novērtējumu automātiski ir veicis rīks. Jūs varēsiet mainīt šim riska "
@@ -1988,7 +1999,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "2009. gadā notika rīka tehniskā izstrāde, bet 2010. gadā (līdz 2011. gada "
@@ -2031,17 +2042,17 @@ msgid "effect_high"
 msgstr "Augsta (ļoti augsta) bīstamības pakāpe"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Zema bīstamība"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Ievērojama bīstamība"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Augsta (ļoti augsta) bīstamība"
 
@@ -2118,7 +2129,7 @@ msgid "error_existing_login"
 msgstr "Šis pieteikumvārds jau ir aizņemts."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Lūdzu, ievadiet budžetu eiro valūtā, pilnos skaitļos."
 
@@ -2154,17 +2165,17 @@ msgid "error_password_mismatch"
 msgstr "Paroles nesakrīt."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Šim datumam ir jābūt sākuma datumam vai pēc tā."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Šim datumam ir jābūt beigu datumam vai pirms tā."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Šim lielumam ir jābūt pozitīvam veselam skaitlim."
 
@@ -2273,7 +2284,7 @@ msgstr ""
 "jums ir jāievieš šie atjauninājumi."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2282,12 +2293,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Rīcības plāns ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Identifikācijas pārskats ${title}"
 
@@ -2307,7 +2318,7 @@ msgid "french"
 msgstr "Vienkāršoti divi kritēriji"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Gandrīz nekad"
 
@@ -2317,57 +2328,57 @@ msgid "frequency_almostnever"
 msgstr "Gandrīz nekad"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Nepārtraukti"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Ne pārāk bieži"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Reizi mēnesī"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Bieži"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Reizi nedēļā"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Reti"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Reizi gadā"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Ļoti bieži vai regulāri"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Vismaz reizi dienā"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regulāri"
@@ -2394,12 +2405,12 @@ msgid "header_additional_content"
 msgstr "Papildu saturs"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Papildu resursi riska novērtēšanai"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Papildu resursi šim modulim"
 
@@ -2414,12 +2425,12 @@ msgid "header_country_managers"
 msgstr "Vadītāji valstī"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Izstrādes un izmēģinājuma posms 2009.-2011. g."
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Attīstības modeļi"
 
@@ -2455,18 +2466,18 @@ msgstr "Identifikācija"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informācija"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Oficiāla projekta atklāšana – 2011. gada septembris"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Atsauces uz normatīvajiem aktiem"
 
@@ -2476,13 +2487,13 @@ msgid "header_legend"
 msgstr "Skaidrojums"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licences"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Pieteikšanās"
@@ -2493,12 +2504,12 @@ msgid "header_main_image"
 msgstr "Galvenais attēls"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Pasākums ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Pasākums"
 
@@ -2524,12 +2535,12 @@ msgid "header_not_complicated"
 msgstr "Novērtēšana nav nekas sarežģīts."
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2564,7 +2575,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2584,7 +2595,7 @@ msgid "header_profile_questions"
 msgstr "Profila jautājumi"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projekta posmi"
 
@@ -2600,7 +2611,7 @@ msgstr "Atbildētie jautājumi katrā modulī"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Reģistrēšanās"
 
@@ -2621,23 +2632,23 @@ msgid "header_risk_aware"
 msgstr "Vai esat informēts par visiem riskiem?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Kāda ir kaitējuma bīstamības pakāpe?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Cik bieži cilvēki tiek pakļauti šim riskam?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Atlasiet šī riska prioritātes līmeni"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Cik liela ir šī riska rašanās iespējamība?"
 
@@ -2649,7 +2660,7 @@ msgid "header_risks"
 msgstr "Riski"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2709,12 +2720,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2729,17 +2740,17 @@ msgid "header_welcome"
 msgstr "Laipni lūgti!"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Kas ir OiRA projekts (interaktīvā risku novērtēšana tiešsaistē)?"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Kāpēc OiRA projekts ir tik īpašs?"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Komentāri"
 
@@ -2760,142 +2771,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Vidējas prioritātes riski"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} riski ar augstu prioritāti"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} riski ar augstu prioritāti"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} riski ar augstu prioritāti"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} riski ar augstu prioritāti"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} riski ar zemu prioritāti"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} riski ar zemu prioritāti"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} riski ar zemu prioritāti"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} riski ar zemu prioritāti"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} riski ar vidēju prioritāti"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} riski ar vidēju prioritāti"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} riski ar vidēju prioritāti"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} riski ar vidēju prioritāti"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} riski atlikti"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} riski atlikti"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} riski atlikti"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} riski atlikti"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} riski nav atbildēti"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} riski nav atbildēti"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} riski nav atbildēti"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} riski nav atbildēti"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} iespējami riski"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} iespējami riski"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} iespējami riski"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} iespējami riski"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} esoši riski"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} esoši riski"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} esoši riski"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} esoši riski"
 
@@ -2915,7 +2926,7 @@ msgid "help_authentication"
 msgstr "Šim tekstam jāizskaidro reģistrēšanās un pieteikšanās process."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Lūdzu, atbildiet uz zemāk norādītajiem jautājumiem. Balstoties uz jūsu "
@@ -2941,7 +2952,7 @@ msgstr ""
 "ar esoša OiRA rīka kopiju."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Norādiet, cik bieži šāds risks pastāv normālos apstākļos."
 
@@ -2953,12 +2964,12 @@ msgstr ""
 "noklusējuma. Lietotājs tik un tā varēs pats mainīt prioritātes līmeni."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Norādiet, cik ticama ir šī riska rašanās normālos apstākļos."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Norādiet bīstamības pakāpi, ko izraisa šī riska īstenošanās."
 
@@ -3052,6 +3063,11 @@ msgstr ""
 "Augšupielādējiet attēlu. Tam jābūt png, jpg vai gif formātā, un tajā "
 "nedrīkst būt nekādu īpašu rakstzīmju."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3067,7 +3083,7 @@ msgstr ""
 "samazinātu vai novērstu risku)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Aprakstiet pieredzes līmeni, kas nepieciešams šī līdzekļa realizēšanai, "
@@ -3221,7 +3237,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Ja nenorādīsit nosaukumu, tas tiks izveidots no ievadītajiem datiem."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3306,7 +3322,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Šī ir testa sesija"
 
@@ -3498,13 +3514,13 @@ msgstr "Konts ir bloķēts"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Rīcības plāns"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budžets"
 
@@ -3514,27 +3530,22 @@ msgid "label_action_plan_download"
 msgstr "Rīcības plāns"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Pabeigšanas datums"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Kura ir atbildīgā persona?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Uzsākšanas datums"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Pievienot citu pasâkumu"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3577,8 +3588,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Šajā laukā lūdzu norādīt papildus komentārus par augstāk minēto jautājumu. "
@@ -3665,7 +3676,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Apraksts"
@@ -3695,7 +3706,7 @@ msgstr "Rādīt pielāgotu paziņojumu šim OiRA rīkam?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Novērtēšana"
 
@@ -3715,10 +3726,19 @@ msgid "label_evaluation_phase"
 msgstr "Novērtēšanas posms"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Pasākums jau īstenots"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3793,7 +3813,7 @@ msgstr "Riska novērtējums"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identifikācija"
 
@@ -3801,6 +3821,11 @@ msgstr "Identifikācija"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Attēla fails"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3823,7 +3848,7 @@ msgid "label_language"
 msgstr "Valoda"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Juridiskās un ar politikas nostādnēm saistītās atsauces"
@@ -3858,21 +3883,26 @@ msgstr "Logotips"
 msgid "label_logo_selection"
 msgstr "Kuru logotipu vēlaties rādīt kreisajā augšējā stūrī?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Vispārējā pieeja (riska novēršana vai samazināšana)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Specifiskas darbības, kas jāveic, lai īstenotu šo pieeju"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Nepieciešamais pieredzes līmenis un/vai prasības"
 
@@ -3928,25 +3958,25 @@ msgid "label_no"
 msgstr "Nē"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Riska nav"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Riska nav"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Riska nav"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Riska nav"
@@ -3986,15 +4016,10 @@ msgstr "Parole"
 msgid "label_password_confirm"
 msgstr "Ievadiet paroli vēlreiz"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Tipveida pasākumi"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Sagatavošanās"
 
@@ -4005,7 +4030,7 @@ msgstr "Priekšskatījums"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Atpakaļ"
@@ -4069,15 +4094,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr "reģistrēties"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Dzēst šo pasākumu"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Pārskats"
 
@@ -4088,12 +4113,12 @@ msgstr ""
 "Šajā laukā lūdzu norādīt papildus komentārus par augstāk minēto jautājumu"
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4113,49 +4138,49 @@ msgid "label_risk_type"
 msgstr "Riska tips"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Risks bez pasākuma"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risks ar pasākumu(-iem)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Risks bez pasākuma"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Risks bez pasākuma"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risks bez pasākuma"
@@ -4168,7 +4193,7 @@ msgstr "Saglabāt un pievienot citu risku"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Saglabāt un turpināt"
 
@@ -4193,7 +4218,7 @@ msgid "label_sector_title"
 msgstr "Sektora nosaukums."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Izvēlieties vienu tipveida pasākumu"
 
@@ -4222,7 +4247,7 @@ msgid "label_show_less_hellip"
 msgstr "Rādīt mazāk"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} par šo risku."
 
@@ -4252,7 +4277,7 @@ msgid "label_start_identification"
 msgstr "Sākt risku identificēšanu"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Sākt"
 
@@ -4297,29 +4322,29 @@ msgid "label_surveygroup_title"
 msgstr "Importētā OiRA rīka nosaukums"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Augsta"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Zema"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Vidēja"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Nosaukums"
 
@@ -4379,12 +4404,12 @@ msgid "label_user_title"
 msgstr "Vārds"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 pasākums)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(bez pasākumiem)"
 
@@ -4432,7 +4457,7 @@ msgid "limitations"
 msgstr "ierobežojumiem"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Pieteikšanās"
 
@@ -4523,7 +4548,7 @@ msgid "menu_import"
 msgstr "Importēt OiRA rīku"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4627,32 +4652,32 @@ msgid "nav_usermanagement"
 msgstr "Lietotāju pārvaldība"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Palīdzība"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Iziet"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Iestatījumi"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Statuss"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Mani novērtējumi"
 
@@ -4702,27 +4727,27 @@ msgid "notice_country_manager"
 msgstr "Vadītājs šajā valstī: ${country}. "
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Riska interaktīvā"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "novērtēšana tiešsaistē"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4742,7 +4767,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4756,7 +4781,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Pēc izmēģinājuma posma mērķu sasniegšanas un OiRA tīmekļa vietnes, mācību "
@@ -4785,45 +4810,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Augsts"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Zems"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Vidējs"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Liela"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Vidēja"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Neliela"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Pabeigts"
 
@@ -4875,18 +4900,13 @@ msgstr "Jums vēl nav konta? Vispirms nepieciešams  ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4899,7 +4919,7 @@ msgstr ""
 "priekšrocībām."
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4913,17 +4933,17 @@ msgstr ""
 "komentārus, kas jāiekļauj pārskatā."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Šī pārskata pamats ir OiRA rīks '${title}', kas pēdējoreiz pārskatīts šādā "
@@ -4955,35 +4975,35 @@ msgid "request_an_email_reminder"
 msgstr "pieprasīt atgādinājuma e-pastu"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Šis ir ${priority_value}"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "augstas prioritātes risks"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "zemas prioritātes risks"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "vidējas prioritātes risks"
 
@@ -5003,7 +5023,7 @@ msgid "risk_solution_header"
 msgstr "Līdzeklis Nr. ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Šis risks vēl ir jāinventarizē."
@@ -5051,46 +5071,46 @@ msgid "select_add_existing_measure"
 msgstr "Atlasīt vai pievienot pasākumus, kas jau tiek īstenoti."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Ne īpaši augsta bīstamības pakāpe"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Ir nepieciešams pārtraukt darbu uz ne vairāk kā 3 dienām"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Augsta bīstamības pakāpe"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Ir nepieciešams pārtraukt darbu uz vairāk nekā 3 dienām"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Ļoti augsta bīstamības pakāpe"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Neatgriezeniski ievainojumi, neizārstējamas slimības, nāve"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Zema bīstamības pakāpe"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Nav nepieciešamības pārtraukt darbu"
 
@@ -5162,7 +5182,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Informācija"
 
@@ -5177,7 +5197,7 @@ msgid "title_account_settings"
 msgstr "Konta iestatījumi"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Mainīt paroli"
@@ -5188,7 +5208,7 @@ msgid "title_client_help"
 msgstr "Klienta palīdzības teksts"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Pasākums"
 
@@ -5223,7 +5243,7 @@ msgid "title_import_sector_survey"
 msgstr "Sektora un OiRA rīka importēšana"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Jūsu pievienotie riski"
@@ -5250,8 +5270,8 @@ msgstr "${survey_title} statuss"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - riska interaktīvā novērtēšana tiešsaistē"
 
@@ -5276,33 +5296,33 @@ msgid "title_with_vowel_status_of"
 msgstr "${survey_title} statuss"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Saturs"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Šāds risks jūsu organizācijā nepastāv, taču sektora organizācija to uzskata "
 "par vienu no prioritārajiem riskiem, tāpēc tas jāiekļauj pārskatā."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Šāds risks jūsu organizācijā nepastāv, taču sektora organizācija to uzskata "
 "par vienu no prioritārajiem riskiem, tāpēc tas jāiekļauj pārskatā."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Šo risku Jūs neesat norādījuši kā sava uzņēmuma risku, tomēr nozarei šis "
@@ -5329,7 +5349,7 @@ msgid "use_it_to_full_report"
 msgstr "Izmantojiet to, lai"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Izmantojiet to, lai"
 
@@ -5339,12 +5359,12 @@ msgid "use_it_to_measures_report"
 msgstr "Izmantojiet to, lai"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Izmantojiet to, lai"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Izmantojiet to, lai"
 
@@ -5359,7 +5379,7 @@ msgid "warn_fix_errors"
 msgstr "Lūdzu, izlabojiet norādītās kļūdas."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Jūs uz iepriekšējo apgalvojumu atbildējāt noliedzoši."
@@ -5383,6 +5403,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Jā"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Pievienot citu pasâkumu"
+
+#~ msgid "label_prefill"
+#~ msgstr "Tipveida pasākumi"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Pasākumu plānā netika veiktas izmaiņas."

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -674,7 +674,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -718,7 +718,7 @@ msgstr "Le"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1582,10 +1582,6 @@ msgstr "Dwar"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Prodotta minn ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "ibbażat fuq"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4423,6 +4419,11 @@ msgstr "Medja"
 msgid "label_title"
 msgstr "Titlu"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "ibbażat fuq ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4829,7 +4830,7 @@ msgid "optional"
 msgstr "Fakultattiv"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5482,6 +5483,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Iva"
+
+#~ msgid "based on"
+#~ msgstr "ibbażat fuq"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Żid miżura oħra"

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,7 +83,7 @@ msgstr ""
 "${provide-evidence} għall-awtoritajiet ta' sorveljanza (spettorat tax-"
 "xogħol)."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -200,7 +200,7 @@ msgstr "Żid kontenut mil-librerija"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -272,7 +272,7 @@ msgstr "Għodod tal-OiRA disponibbli"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr "Pajjiżi Kandidati"
 msgid "Candidate country"
 msgstr "Pajjiż kandidat"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Ibdel l-indirizz elettroniku"
 
@@ -339,11 +339,11 @@ msgstr ""
 "Fih: l-informazzjoni u l-kontribuzzjoni kollha pprovduta minnek tul il-"
 "proċess tal-valutazzjoni tar-riskji."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Tinkludi: ħarsa ġenerali tal-miżuri li għandhom jiġu implimentati."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Jinkludi: ħarsa ġenerali tar-riskji identifikati"
 
@@ -382,15 +382,15 @@ msgstr "Informazzjoni u ggruppar tal-pajjiżi għall-klijent."
 msgid "Country manager"
 msgstr "Maniġer tal-Pajjiż"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons License"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -448,15 +448,15 @@ msgstr "Niżżel il-pjan ta' azzjoni"
 msgid "Download the full report"
 msgstr "Niżżel ir-rapport kollu"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Niżżel il-ħarsa ġenerali tal-miżuri"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Niżżel il-ħarsa ġenerali tar-riskji"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Posta elettronika"
@@ -530,7 +530,7 @@ msgstr "Folder"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Format: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Format: Portable Document Format (.pdf)"
 
@@ -538,7 +538,7 @@ msgstr "Format: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Il-Ġermanja"
 
@@ -565,7 +565,7 @@ msgstr ""
 "tiegħek fuq valutazzjoni, u mbagħad tista' tmur lura għaliha meta jkun komdu "
 "għalik u terġa' taqbadha minn fejn ħallejtha."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Nixtieq naqsam dan miegħek"
 
@@ -581,8 +581,7 @@ msgstr ""
 msgid "Important"
 msgstr "Importanti"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Info"
 
@@ -591,7 +590,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informazzjoni"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Format tal-istampa invalidu. Jekk jogħġbok uża PNG, JPEG jew GIF."
 
@@ -625,11 +624,11 @@ msgstr "Il-Kosovo"
 msgid "Last saved"
 msgstr "issejvjata"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Tgħallem aktar dwar din l-għodda…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -641,7 +640,7 @@ msgstr "Login"
 msgid "Manage"
 msgstr "Immaniġġja"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Miżura"
@@ -660,13 +659,13 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "Immoniterja u vvaluta jekk ġewx introdotti miżuri neċessarji."
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Issorvelja l-miżuri li għandhom jiġu implimentati fit-3 xhur li ġejjin."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Issorvelja jekk ir-riskji / il-miżuri humiex indirizzati sew."
 
@@ -795,12 +794,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Għajnuna onlajn"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Ħarsa ġenerali tal-miżuri."
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Ħarsa ġenerali tar-riskji"
@@ -819,8 +820,8 @@ msgstr ""
 "xogħol, ...)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Għaddi informazzjoni lill-persuni kkonċernati."
 
@@ -851,9 +852,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Irreferi għall-eżempji taħt il-formola."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Posponiment"
 
@@ -894,7 +895,7 @@ msgstr "Tipprovdi evidenza għall-awtoritajiet ta' sorveljanza."
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Aqra aktar"
 
@@ -928,8 +929,8 @@ msgstr ""
 "tkompli valutazzjonijiet preċedenti jew biex tibda oħrajn ġodda."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Neħħi"
 
@@ -950,11 +951,11 @@ msgstr "Riskju"
 msgid "Risk assessments made with this tool"
 msgstr "Valutazzjonijiet tar-riskju li jsiru b’din l-għodda"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Riskju mhux preżenti"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Riskju preżenti"
 
@@ -1032,7 +1033,7 @@ msgstr "Aqsam din l-Għodda ta' OiRA ma' ħaddieħor"
 msgid "Show library from ${dropdown}."
 msgstr "Uri librerija minn ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Idħol"
 
@@ -1048,6 +1049,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1103,7 +1108,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Il-Pajjiżi l-Baxxi"
 
@@ -1122,7 +1127,7 @@ msgstr ""
 "L-istruttura bażika ta’ Valutazzjoni tar-Riskji interattiva Onlajn "
 "tikkonsisti f’dan li ġej:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1232,7 +1237,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Din l-għodda jistħoqqilha li tkun magħrufa mid-dinja! Aqsamha ma' ħaddieħor!"
@@ -1241,8 +1246,8 @@ msgstr ""
 msgid "Tip"
 msgstr "Parir"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Agħfas fuq screen help"
 
@@ -1254,9 +1259,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Ma saritx żjara"
 
@@ -1377,36 +1382,36 @@ msgid "Your password was successfully changed."
 msgstr "Il-password tiegħek inbidlet."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Il-kodiċi sors tal-applikazzjoni tal-OiRA huwa liċenzjat minn ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "Il-kontenut tal-għodda settorjali tal-OiRA huwa liċenzjat bi ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "L-għodda settorjali tal-OiRA jistgħu jintużaw b'xejn mill-utenti kollha."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Aktar informazzjoni dwar il-proġett tal-OiRA (bl-Ingliż)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Strateġija tal-Komunità Ewropea dwar is-Saħħa u s-Sigurtà fuq il-Post tax-"
 "Xogħol 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "L-esperjenza turi li ${key}. Hija għal din ir-raġuni li EU-OSHA żviluppat "
@@ -1417,44 +1422,44 @@ msgstr ""
 "azzjonijiet, u li tinkludi wkoll monitoraġġ u ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "applikazzjonijiet tal-web faċli biex tużahom u bla spejjeż"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "il-valutazzjoni"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "l-identifikazzjoni"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "valutazzjoni tar-riskji adegwata hija essenzjali għal postijiet tax-xogħol "
 "sikuri"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "l-azzjonijiet preventivi"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "ir-rappurtar"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "il-proċess pass pass tal-valutazzjoni tar-riskji"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "L-applikazzjoni tal-web tal-OiRA tagħti aċċess għall-għodda tal-Valutazzjoni "
@@ -1462,7 +1467,7 @@ msgstr ""
 "fil-livell nazzjonali."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "L-${agency} tappella għall-iżvilupp ta' għodda sempliċi li jiffaċilitaw il-"
@@ -1476,7 +1481,7 @@ msgstr ""
 "għan jegħleb."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Il-proġett tal-OiRA u l-applikazzjoni tal-web relatata miegħu ġew żviluppati "
@@ -1488,14 +1493,14 @@ msgstr ""
 "kontrobuzzjoni u l-parteċipazzjoni tat-trejdjunjins FNV, CNV u MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "L-imsieħba tekniċi li ġejjin ikkontribwew għall-iżvilupp tal-proġett tal-"
 "OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "L-Aġenzija ngħatat ukoll pariri strateġiċi u kompetenti minn Kumitat ta' "
@@ -1504,12 +1509,12 @@ msgstr ""
 "fil-Bord, mill-Kummissjoni u l-EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "l-intrapriżi mikro u żgħar għandhom xi nuqqasijiet"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Għalkemm xi miżuri ma jiswewx flus, il-biċċa l-kbira jiswew. Għaldaqstant, "
@@ -1517,7 +1522,7 @@ msgstr ""
 "bżonn."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Aħtar persuna fil-kumpanija tiegħek biex tkun responsabbli mill-"
@@ -1525,14 +1530,20 @@ msgstr ""
 "l-passi deskritti fil-Pjan u/jew ir-responsabilità li jiġi żgurat li dawn il-"
 "passi jittieħdu."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Iddeskrivi: 1) x'inhu l-approċċ ġenerali tiegħek biex telimina jew (jekk ir-"
 "riskju ma jistax jiġi evitat) tnaqqas ir-riskju; 2) l-azzjoni(jiet) "
 "speċifiku/speċifiċi meħtieġa biex jiġi implimentat dan l-approċċ (biex "
-"telimina jew tnaqqas ir-riskju); 3) il-livell ta' kompetenza meħtieġ biex "
+"telimina jew tnaqqas ir-riskju)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Iddeskrivi: 3) il-livell ta' kompetenza meħtieġ biex "
 "tiġi implimentata l-miżura, pereżempju “sens komun (mhux meħtieġ għarfien "
 "dwar l-OSH)”, “mhix meħtieġa kompetenza speċifika dwar l-OSH, iżda huma "
 "meħtieġa kompetenza jew taħriġ minimi dwar l-OSH u/jew konsultazzjoni tal-"
@@ -1599,7 +1610,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: dikjarazzjonijiet pożittivi, li jinsabu fil-moduli."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Żid"
 
@@ -1647,7 +1658,7 @@ msgstr "Ikkanċella"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Agħlaq"
 
@@ -1980,7 +1991,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "L-evalwazzjoni tar-riskju saret b'mod awtomatiku mill-għodda. Ser tkun "
@@ -2035,7 +2046,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Wara l-iżvilupp tekniku tal-għodda fl-2009, fl-2010 (sal-ewwel nofs "
@@ -2077,17 +2088,17 @@ msgid "effect_high"
 msgstr "Severità kbira (kbira ħafna)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Severità dgħajfa"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Severità sinifikanti"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Severità kbira (kbira ħafna) "
 
@@ -2163,7 +2174,7 @@ msgid "error_existing_login"
 msgstr "Dan l-isem tal-login diġà meħud."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Daħħal il-baġit f'Euros sħaħ."
 
@@ -2200,17 +2211,17 @@ msgid "error_password_mismatch"
 msgstr "Il-passwords ma jaqblux"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Din id-data għandha tkun fid-data tal-bidu jew warajha."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Din id-data għandha tkun fid-data ta' tmiem jew qabilha."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Dan il-valur għandu jkun numru sħiħ pożittiv."
 
@@ -2320,7 +2331,7 @@ msgstr ""
 "trid taġġorna b'dawn il-bidliet."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2329,12 +2340,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Pjan ta' azzjoni ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Rapport ta' identifikazzjoni ${title}"
 
@@ -2354,7 +2365,7 @@ msgid "french"
 msgstr "Żewġ kriterji semplifikati"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Kważi qatt"
 
@@ -2364,57 +2375,57 @@ msgid "frequency_almostnever"
 msgstr "Kważi qatt"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Kostantement"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Mhux ta' spiss ħafna"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Darba fix-xahar"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Ta' spiss"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Darba fil-ġimgħa"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Rari"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Darba fis-sena"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Ta' spiss ħafna jew regolarment"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Mill-inqas darba kuljum"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regolarment"
@@ -2441,12 +2452,12 @@ msgid "header_additional_content"
 msgstr "Kontenut addizzjonali"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Riżorsi addizzjonali għall-evalwazzjoni tar-riskju"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Rizörsi addizzjonali għal din it-taqsima"
 
@@ -2461,12 +2472,12 @@ msgid "header_country_managers"
 msgstr "Maniġers tal-pajjiżi"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Il-fażi tal-iżvilupp u tal-proġett pilota – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Imsieħba fl-iżvilupp"
 
@@ -2503,18 +2514,18 @@ msgstr "L-Identifikazzjoni"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informazzjoni"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Tnedija uffiċjali tal-proġett – Settembru 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Referenzi legali u tal-politika"
 
@@ -2524,13 +2535,13 @@ msgid "header_legend"
 msgstr "Legend"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Liċenzji"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
@@ -2541,12 +2552,12 @@ msgid "header_main_image"
 msgstr "Stampa ewlenija"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Miżura ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Miżura"
 
@@ -2572,12 +2583,12 @@ msgid "header_not_complicated"
 msgstr "Il-valutazzjoni mhijiex ikkumplikata"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2612,7 +2623,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2632,7 +2643,7 @@ msgid "header_profile_questions"
 msgstr "Mistoqsijiet dwar il-profil"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Il-Fażijiet tal-Proġett"
 
@@ -2648,7 +2659,7 @@ msgstr "Mistoqsijiet imwieġba għal kull modulu"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Irreġistra"
 
@@ -2669,23 +2680,23 @@ msgid "header_risk_aware"
 msgstr "Inti taf bir-riskji kollha?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "X'inhi s-severità tad-dannu?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "B'liema frekwenza n-nies huma esposti għal dan ir-riskju?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Agħżel il-prijorità ta' dan ir-riskju"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "X'inhu ċ-ċans li dan ir-riskju jimmaterjalizza ruħu?"
 
@@ -2697,7 +2708,7 @@ msgid "header_risks"
 msgstr "Riskji"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2757,12 +2768,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2777,19 +2788,19 @@ msgid "header_welcome"
 msgstr "Merħba"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "X'inhu l-proġett tal-OiRA (Online Interactive Risk Assessment -  "
 "Valutazzjoni tar-Riskji Onlajn Interattiva)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Għaliex il-proġett tal-OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Kummenti"
 
@@ -2810,142 +2821,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Riskji ta’ prijorità medja"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Riskji ta’ priorità għolja"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Riskji ta’ priorità għolja"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Riskji ta’ priorità għolja"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Riskji ta’ priorità għolja"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_medium_risks} Riskji ta’ priorità baxxa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_medium_risks} Riskji ta’ priorità baxxa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_medium_risks} Riskji ta’ priorità baxxa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Riskji ta’ priorità baxxa"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Riskji ta’ priorità medja"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Riskji ta’ priorità medja"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Riskji ta’ priorità medja"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Riskji ta’ priorità medja"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Riskji posposti"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Riskji posposti"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Riskji posposti"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Riskji posposti"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Riskji mhux imwieġba"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Riskji mhux imwieġba"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Riskji mhux imwieġba"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Riskji mhux imwieġba"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Riskji possibbli"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Riskji possibbli"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Riskji possibbli"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Riskji possibbli"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Riskji Preżenti"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Riskji Preżenti"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Riskji Preżenti"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Riskji Preżenti"
 
@@ -2965,7 +2976,7 @@ msgid "help_authentication"
 msgstr "Dan it-test għandu jispjegalek kif tirreġistra u tilloggja."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Jekk jogħġbok wieġeb il-mistoqsijiet li ġejjin. Bħala riżultat tal-"
@@ -2993,7 +3004,7 @@ msgstr ""
 "ta' Għodda tal-OiRA eżistenti.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indika l-frekwenza li biha dan ir-riskju jimmaterjalizza ruħu f'sitwazzjoni "
@@ -3007,12 +3018,12 @@ msgstr ""
 "jkunu jistgħu jibdlu l-prijorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Indika l-probabbiltà ta' dan ir-riskju f'sitwazzjoni normali."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indika s-severità jekk dan ir-riskju jimmaterjalizza ruħu."
 
@@ -3105,6 +3116,11 @@ msgstr ""
 "Tella' stampa. Kun żgur li l-istampa hija f'format png, jpg jew gif u ma "
 "jkunx fiha karattri speċjali."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3120,7 +3136,7 @@ msgstr ""
 "implimentat dan l-approċċ (biex ir-riskju jiġi eliminat jew jitnaqqas)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Iddeskrivi il-livell ta' kompetenza meħtieġ biex tiġi implimentata l-miżura, "
@@ -3277,7 +3293,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Jekk ma tispeċifikax titlu, jittieħed mill-input."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3363,7 +3379,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Din hija sessjoni ta' test"
 
@@ -3565,13 +3581,13 @@ msgstr "Kont illokkjat"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Il-Pjan ta' Azzjoni"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Baġit"
 
@@ -3581,27 +3597,22 @@ msgid "label_action_plan_download"
 msgstr "Il-Pjan ta' Azzjoni"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Tmiem tal-ippjanar"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Min hu responsabbli?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Bidu tal-ippjanar"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Żid miżura oħra"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3644,8 +3655,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Tista' tħalli xi kummenti dwar il-mistoqsija t'hawn fuq f'dan il-qasam. Dawn "
@@ -3732,7 +3743,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Deskrizzjoni"
@@ -3762,7 +3773,7 @@ msgstr "Trid turi notifika għal din l-għodda tal-OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Il-Valutazzjoni"
 
@@ -3782,10 +3793,19 @@ msgid "label_evaluation_phase"
 msgstr "Fażi tal-valutazzjoni"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Il-miżura diġà implimentata"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3860,7 +3880,7 @@ msgstr "Kif twettaq il-valutazzjoni tar-riskji"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "L-Identifikazzjoni"
 
@@ -3868,6 +3888,11 @@ msgstr "L-Identifikazzjoni"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Fajl tal-istampa"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3890,7 +3915,7 @@ msgid "label_language"
 msgstr "Lingwa"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referenzi legali u tal-politika"
@@ -3925,23 +3950,28 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Liema logo tixtieq turi fir-rokna ta' fuq, fuq ix-xellug?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Approċċ ġenerali (biex ir-riskju jiġi eliminat jew imnaqqas)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 "Azzjoni(jiet) speċifika/speċifiċi meħtieġa biex jiġi implimentat dan l-"
 "approċċ"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Livell ta' kompetenza u/jew rekwiżiti meħtieġa"
 
@@ -3997,25 +4027,25 @@ msgid "label_no"
 msgstr "Le"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "L-ebda riskju"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "L-ebda riskju"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "L-ebda riskju"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "L-ebda riskju"
@@ -4055,15 +4085,10 @@ msgstr "Password"
 msgid "label_password_confirm"
 msgstr "Erġa' daħħal il-password"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Mimlija minn qabel"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "It-Tħejjija"
 
@@ -4074,7 +4099,7 @@ msgstr "Preview"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Preċedenti"
@@ -4137,15 +4162,15 @@ msgstr "Tista' tniżżel rapport sħiħ u pjan ta' azzjoni."
 msgid "label_register_first"
 msgstr "irreġistra"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Ħassar din il-miżura"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Ir-Rapport"
 
@@ -4157,12 +4182,12 @@ msgstr ""
 "qasam."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4182,49 +4207,49 @@ msgid "label_risk_type"
 msgstr "Tip ta' riskju"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Riskju mingħajr miżura"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riskju b'miżura/miżuri"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Riskju mingħajr miżura"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Riskju mingħajr miżura"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riskju mingħajr miżura"
@@ -4237,7 +4262,7 @@ msgstr "Issejvja u żid riskju ieħor"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Issejvja u kompli"
 
@@ -4262,7 +4287,7 @@ msgid "label_sector_title"
 msgstr "Titlu tas-settur."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Agħżel waħda jew iktar mill-miżuri komuni pprovduti."
 
@@ -4292,7 +4317,7 @@ msgid "label_show_less_hellip"
 msgstr "Uri inqas…"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} dwar dan ir-riskju."
 
@@ -4322,7 +4347,7 @@ msgid "label_start_identification"
 msgstr "Ibda l-Identifikazzjoni tar-Riskji"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Ibda"
 
@@ -4367,29 +4392,29 @@ msgid "label_surveygroup_title"
 msgstr "Titlu tal-Għodda tal-OiRA impurtata"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Għolja"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Baxxa"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Medja"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titlu"
 
@@ -4449,12 +4474,12 @@ msgid "label_user_title"
 msgstr "Isem"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 miżuri)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(mingħajr miżuri)"
 
@@ -4501,7 +4526,7 @@ msgid "limitations"
 msgstr "limitazzjonijiet"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Login"
 
@@ -4590,7 +4615,7 @@ msgid "menu_import"
 msgstr "Importa Għodda tal-OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4694,32 +4719,32 @@ msgid "nav_usermanagement"
 msgstr "Immaniġġjar tal-utent"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Għajnuna"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Illoggja 'l barra"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Settings"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Stat"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Il-Valutazzjonijiet Tiegħi"
 
@@ -4769,27 +4794,27 @@ msgid "notice_country_manager"
 msgstr "Maniġer tal-pajjiż għal ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Valutazzjoni tar-Riskji"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Onlajn interattiva"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4809,7 +4834,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4823,7 +4848,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "It-tnedija uffiċjali tal-għodda hija ppjanata għal Settembru 2011, ladarba l-"
@@ -4853,45 +4878,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Għolja"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Baxxa"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Medja"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Kbir"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Medju"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Żgħir"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Tlesti"
 
@@ -4944,18 +4969,13 @@ msgstr "M'għandekx kont? Mela ${register_link} l-ewwel."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4968,7 +4988,7 @@ msgstr ""
 "ġejjin:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4982,17 +5002,17 @@ msgstr ""
 "inklużi f'dan ir-rapport fil-qasam ta' hawn taħt."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Dan ir-rapport ġie bbażat fuq l-Għodda tal-OiRA '${title}' b'data ta' "
@@ -5024,35 +5044,35 @@ msgid "request_an_email_reminder"
 msgstr "itlob tfakkira għall-posta elettronika"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Dan huwa riskju ta' prijorità ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "għolja"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "baxxa"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "medja"
 
@@ -5072,7 +5092,7 @@ msgid "risk_solution_header"
 msgstr "Miżura ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Ir-riskju għad irid jiġi elenkat."
@@ -5120,46 +5140,46 @@ msgid "select_add_existing_measure"
 msgstr "Agħżel jew żid kwalunkwe miżura diġà fis-seħħ."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Mhux severa ħafna"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Hemm bżonn tieqaf il-ħidma għal inqas minn 3 ijiem"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Kbira"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Hemm bżonn tieqaf il-ħidma għal iktar minn 3 ijiem"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Kbira ħafna"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Korriment irriversibbli, mard inkurabbli, mewt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Dgħajfa"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "M'hemmx bżonn titwaqqaf il-ħidma"
 
@@ -5230,7 +5250,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Dwar"
 
@@ -5245,7 +5265,7 @@ msgid "title_account_settings"
 msgstr "Settings tal-kont"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Ibdel il-password"
@@ -5256,7 +5276,7 @@ msgid "title_client_help"
 msgstr "Test tal-għajnuna għall-klijent"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Miżura"
 
@@ -5291,7 +5311,7 @@ msgid "title_import_sector_survey"
 msgstr "Settur tal-Importazzjoni u l-Għodda tal-OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Riskji miżjuda (minnek)"
@@ -5318,8 +5338,8 @@ msgstr "Status ta' ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 "OiRA - Valutazzjoni tar-Riskji Onlajn Interattiva (Online interactive Risk "
@@ -5346,19 +5366,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Status ta' ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Werrej"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Dan ir-riskju mhuwiex preżenti fl-organizzazzjoni tiegħek, iżda minħabba li "
@@ -5366,7 +5386,7 @@ msgstr ""
 "prijorità, dan għandu jiġi inkluż f'dan ir-rapport."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Dan ir-riskju mhuwiex preżenti fl-organizzazzjoni tiegħek, iżda minħabba li "
@@ -5374,7 +5394,7 @@ msgstr ""
 "prijorità, dan għandu jiġi inkluż f'dan ir-rapport."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Dan ir-riskju għadu ma ġiex evalwat, iżda peress li huwa meqjus bħala "
@@ -5403,7 +5423,7 @@ msgid "use_it_to_full_report"
 msgstr "Uża dan biex"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Uża dan biex"
 
@@ -5413,12 +5433,12 @@ msgid "use_it_to_measures_report"
 msgstr "Uża dan biex"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Uża dan biex"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Uża dan biex"
 
@@ -5433,7 +5453,7 @@ msgid "warn_fix_errors"
 msgstr "Irranġa l-iżbalji indikati."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Inti weġibt b'mod negattiv għad-dikjarazzjoni t'hawn fuq."
@@ -5457,6 +5477,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Iva"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Żid miżura oħra"
+
+#~ msgid "label_prefill"
+#~ msgstr "Mimlija minn qabel"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Ma saru l-ebda bidliet fil-miżuri tal-pjan t’azzjoni tiegħek."

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -590,7 +590,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informazzjoni"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Format tal-istampa invalidu. Jekk jogħġbok uża PNG, JPEG jew GIF."
 
@@ -1052,7 +1052,7 @@ msgstr "Standard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Miżuri standard"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1127,7 +1127,7 @@ msgstr ""
 "L-istruttura bażika ta’ Valutazzjoni tar-Riskji interattiva Onlajn "
 "tikkonsisti f’dan li ġej:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1543,12 +1543,12 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Iddeskrivi: 3) il-livell ta' kompetenza meħtieġ biex "
-"tiġi implimentata l-miżura, pereżempju “sens komun (mhux meħtieġ għarfien "
-"dwar l-OSH)”, “mhix meħtieġa kompetenza speċifika dwar l-OSH, iżda huma "
-"meħtieġa kompetenza jew taħriġ minimi dwar l-OSH u/jew konsultazzjoni tal-"
-"gwida tal-OSH”, jew “espert tal-OSH”. Hawnhekk tista' tiddeskrivi wkoll "
-"kwalunkwe rekwiżit addizzjonali (jekk applikabbli)."
+"Iddeskrivi: 3) il-livell ta' kompetenza meħtieġ biex tiġi implimentata l-"
+"miżura, pereżempju “sens komun (mhux meħtieġ għarfien dwar l-OSH)”, “mhix "
+"meħtieġa kompetenza speċifika dwar l-OSH, iżda huma meħtieġa kompetenza jew "
+"taħriġ minimi dwar l-OSH u/jew konsultazzjoni tal-gwida tal-OSH”, jew "
+"“espert tal-OSH”. Hawnhekk tista' tiddeskrivi wkoll kwalunkwe rekwiżit "
+"addizzjonali (jekk applikabbli)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2211,17 +2211,17 @@ msgid "error_password_mismatch"
 msgstr "Il-passwords ma jaqblux"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Din id-data għandha tkun fid-data tal-bidu jew warajha."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Din id-data għandha tkun fid-data ta' tmiem jew qabilha."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Dan il-valur għandu jkun numru sħiħ pożittiv."
 
@@ -3004,7 +3004,7 @@ msgstr ""
 "ta' Għodda tal-OiRA eżistenti.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 "Indika l-frekwenza li biha dan ir-riskju jimmaterjalizza ruħu f'sitwazzjoni "
@@ -3018,12 +3018,12 @@ msgstr ""
 "jkunu jistgħu jibdlu l-prijorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Indika l-probabbiltà ta' dan ir-riskju f'sitwazzjoni normali."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indika s-severità jekk dan ir-riskju jimmaterjalizza ruħu."
 
@@ -3295,7 +3295,7 @@ msgstr "Jekk ma tispeċifikax titlu, jittieħed mill-input."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Dashboard"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3655,7 +3655,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3803,9 +3803,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Żid miżura oħra"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4099,7 +4099,7 @@ msgstr "Preview"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Preċedenti"
@@ -4262,7 +4262,7 @@ msgstr "Issejvja u żid riskju ieħor"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Issejvja u kompli"
 
@@ -4305,6 +4305,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Agħżel miżuri standard"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -5374,7 +5379,7 @@ msgstr "Werrej"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Uri/aħbi l-menu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -230,7 +230,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -248,7 +248,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:26
 msgid "Are you sure you want to proceed?"
-msgstr ""
+msgstr "Bent u zeker dat u wil doorgaan?"
 
 #: euphorie/content/behaviour/configure.zcml:33
 msgid "Automatically generate unique ids for content"
@@ -277,6 +277,7 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
+"Door een risicoanalyse te klonen, zal u een nieuwe risicoanalyse creëren gebaseerd op de inhoud van deze risicoanalyse als startpunt."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -581,7 +582,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informatie"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
@@ -1043,7 +1044,7 @@ msgstr "Standaard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Standaard maatregelen"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1109,7 +1110,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1303,7 +1304,7 @@ msgstr "Ja"
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:34
 msgid "Yes, clone risk assessment"
-msgstr ""
+msgstr "Ja, kloon risicoanalyse"
 
 #: euphorie/content/templates/library.pt:17
 msgid ""
@@ -2168,17 +2169,17 @@ msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2987,7 +2988,7 @@ msgstr ""
 "kopie van een bestaande RI&E."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -2999,14 +3000,14 @@ msgstr ""
 "kan dit zelf alsnog wijzigen bij het invullen van de RI&E."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 "Geef een indicatie van de zwaarte van het effect (hoe schadelijk is het voor "
@@ -3294,7 +3295,7 @@ msgstr "Als u geen titel opgeeft zal titel uit het bestand worden overgenomen."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Dashboard"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3647,7 +3648,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3796,9 +3797,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Voeg een extra maatregel toe"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4090,7 +4091,7 @@ msgstr "Preview"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorige"
@@ -4253,7 +4254,7 @@ msgstr "Sla op en voeg nog een risico toe"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Opslaan en verdergaan"
 
@@ -4295,6 +4296,11 @@ msgstr "Start een nieuwe RI&E in de volgende branche"
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr "Kies uit een van onderstaande instrumenten"
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Selecteer standaardmaatregelen"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4346,7 +4352,7 @@ msgstr "Start"
 #. Default: "Started"
 #: euphorie/client/browser/templates/status_info.pt:51
 msgid "label_started"
-msgstr "Gestart"
+msgstr "Gestart op"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -76,7 +76,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} aan toezichthoudende instanties (Inspectie SZW)"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -230,7 +230,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -263,7 +263,7 @@ msgstr "Beschikbare OiRA RI&E instrumenten"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr "Kandidaat lden"
 msgid "Candidate country"
 msgstr "Kandidaat lidstaat"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Wijzig e-mail adres"
 
@@ -327,13 +327,13 @@ msgstr ""
 "Bevat: alle informatie en input die u hebt verstrekt tijdens alle stappen "
 "van de risicoanalyse"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 "Inhoud: een overzicht van de toe te passen maatregelen in de komende 3 "
 "maanden."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Inhoud: een overzicht van de vastgestelde risico's"
 
@@ -371,15 +371,15 @@ msgstr "Landinformatie en groepen voor de gebruiker"
 msgid "Country manager"
 msgstr "Landbeheerder"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons License"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -437,15 +437,15 @@ msgstr "Het actieplan downloaden"
 msgid "Download the full report"
 msgstr "Het volledige rapport downloaden"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Download het overzicht van maatregelen"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Download het overzicht van risico's"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -519,7 +519,7 @@ msgstr "Map"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Bestandsformaat: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Format: Portable Document Format (.pdf)"
 
@@ -527,7 +527,7 @@ msgstr "Format: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Duitsland"
 
@@ -556,7 +556,7 @@ msgstr ""
 "te maken. U kunt op elk moment stoppen en later weer verder gaan waar u "
 "gebleven was of wijzigen aanbrengen."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -572,8 +572,7 @@ msgstr "RI&E import"
 msgid "Important"
 msgstr "Belangrijk:"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Info"
 
@@ -582,7 +581,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informatie"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
@@ -617,11 +616,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "Laatst opgeslagen"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Meer informatie over deze tool…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -633,7 +632,7 @@ msgstr "Login"
 msgid "Manage"
 msgstr "Te gebruiken om"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Maatregel"
@@ -654,12 +653,12 @@ msgstr ""
 "getroffen "
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "te controleren of de maatregelen geïmplementeerd worden."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "na te gaan of er naar behoren wordt omgegaan met risico's/maatregelen."
 
@@ -794,12 +793,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online help"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Overzicht van maatregelen"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Overzicht van de risico‘s"
@@ -818,8 +819,8 @@ msgstr ""
 "op het werk, ...)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "informatie door te geven aan de betrokken personen."
 
@@ -846,9 +847,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Overgeslagen"
 
@@ -885,7 +886,7 @@ msgstr "als bewijs voor toezichthoudende instanties"
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Meer informatie"
 
@@ -919,8 +920,8 @@ msgstr ""
 "wijzigen of een nieuwe RI&E te starten."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -941,11 +942,11 @@ msgstr "Risico"
 msgid "Risk assessments made with this tool"
 msgstr "Risicobeoordelingen die met deze tool zijn gemaakt"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Risico niet aanwezig"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Risico aanwezig"
 
@@ -1023,7 +1024,7 @@ msgstr "Deze OiRA-tool delen"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Meld u aan"
 
@@ -1039,6 +1040,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standaard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1087,7 +1092,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nederland"
 
@@ -1104,7 +1109,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1212,7 +1217,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Deze tool verdient wereldwijde bekendheid! Deel de tool!"
 
@@ -1220,8 +1225,8 @@ msgstr "Deze tool verdient wereldwijde bekendheid! Deel de tool!"
 msgid "Tip"
 msgstr "Tip"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Knop voor toelichting"
 
@@ -1233,9 +1238,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Niet bekekeken"
 
@@ -1347,34 +1352,34 @@ msgid "Your password was successfully changed."
 msgstr "Uw wachtwoord is aangepast."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "De broncode van de OiRA tool heeft een ${GPL} licentie."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "De inhoud van de RI&E's zijn gelicenceerd onder de ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "Deze OiRA branche RI&E's zijn gratis voor alle gebruikers."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Meer informatie over het OiRA project (engelstalig)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "De Europese Gemeenschap strategie voor Veiligheid en Gezondheid op het werk "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "De ervaring leert dat ${key}. Daarom heeft EU-OSHA een \n"
@@ -1384,49 +1389,49 @@ msgstr ""
 "te ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "een eenvoudig te gebruiken en gratis web applicatie"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "evaluatie"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "inventarisatie"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "een goede risico-inventarisatie is de sleutel tot een gezonde werkplek"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "preventieve acties"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "rapportage"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "een stap-voor-stap inventarisatie proces"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "De OiRA web-applicatie geeft toegang tot de branche RI&E's die gemaakt zijn "
 "en worden onderhouden door de brancheorganisaties op nationaal niveau."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "Het ${agency} staat voor de ontwikkeling van eenvoudige tools om de risico-"
@@ -1439,7 +1444,7 @@ msgstr ""
 "algemeen, waarbij het OiRA-project deze wil helpen te overwinnen."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Het OiRA-project en de verwante webapplicatie werden ontwikkeld door de ${eu-"
@@ -1451,14 +1456,14 @@ msgstr ""
 "ontwikkeld met de inbreng en deelname van de vakbonden FNV, CNV en VCP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "De volgende technische partners hebben bijgedragen bij de ontwikkeling van "
 "het OiRA project:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Het Agentschap kreeg strategisch en expertadvies van een stuurgroep voor de "
@@ -1467,12 +1472,12 @@ msgstr ""
 "belangengroepen bij de Raad, de Commissie en door EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "MKB bedrijven hebben enige tekortkomingen"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Alhoewel sommige maatregelen niets zullen kosten, zijn aan de meeste "
@@ -1480,7 +1485,7 @@ msgstr ""
 "in de jaarlijkse begroting, indien nodig."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Wijs iemand in de organisatie aan die verantwoordelijk is voor de "
@@ -1489,8 +1494,8 @@ msgstr ""
 "zijn en/of de verantwoordelijkheid om zorgen dat deze stappen worden "
 "uitgevoerd."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "In het plan van aanpak geeft u aan welke maatregelen genomen gaan worden om "
@@ -1502,6 +1507,11 @@ msgstr ""
 "zal de preventiemedewerker ondersteunen bij de uitvoering van het plan van "
 "aanpak. Hij/zij dient echter wel te beschikken over de mogelijkheden en een "
 "relevante opleiding hebben om dit goed uit te voeren."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1560,7 +1570,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Voeg toe"
 
@@ -1608,7 +1618,7 @@ msgstr "Annuleren"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Sluit"
 
@@ -1941,7 +1951,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "De tool heeft automatisch een risico-evaluatie uitgevoerd. U kunt de "
@@ -1999,7 +2009,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Na de technische ontwikkeling van de tool in 2009 zijn diverse pilots "
@@ -2037,17 +2047,17 @@ msgid "effect_high"
 msgstr "Blijvende gezondheidsschade"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Letsel zonder verzuim"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Letsel met verzuim"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Blijvende gezondheidsschade"
 
@@ -2122,7 +2132,7 @@ msgid "error_existing_login"
 msgstr "Deze gebruikersnaam bestaat al"
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Vul het budget in hele Euros in."
 
@@ -2158,17 +2168,17 @@ msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2300,7 +2310,7 @@ msgstr ""
 "RI&E voordat u verder kunt gaan."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2314,12 +2324,12 @@ msgstr ""
 "voorleggen aan degene die de RI&E gaat toetsen."
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Plan van aanpak ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Inventarisatie ${title}"
 
@@ -2339,7 +2349,7 @@ msgid "french"
 msgstr "Vereenvoudigd (twee critiria)"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Bijna nooit"
 
@@ -2349,57 +2359,57 @@ msgid "frequency_almostnever"
 msgstr "Bijna nooit"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Voortdurend"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Niet vaak"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Een keer per maand"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Vaak"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Een keer per week"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Zeldzaam"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Eens per jaar"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Heel vaak of regelmatig"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Tenminste een keer per dag"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regelmatig"
@@ -2424,12 +2434,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Aanvullende bronnen om het risico te beoordelen"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Aanvullende bronnen voor deze module"
 
@@ -2444,12 +2454,12 @@ msgid "header_country_managers"
 msgstr "Landbeheerders"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Ontwikkeling en pilotfase - 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "ontwikkelingspartners"
 
@@ -2486,18 +2496,18 @@ msgstr "Inventarisatie"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informatie"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Officiële lancering van het project - September 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Wet- en regelgeving"
 
@@ -2507,13 +2517,13 @@ msgid "header_legend"
 msgstr "Legenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licentie"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
@@ -2524,12 +2534,12 @@ msgid "header_main_image"
 msgstr "Belangrijkste afbeelding"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Maatregel ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Maatregel"
 
@@ -2555,12 +2565,12 @@ msgid "header_not_complicated"
 msgstr "Een RI&E is niet ingewikkeld"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr "Plan van aanpak: ${title}"
 
@@ -2595,7 +2605,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2615,7 +2625,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projectfasen"
 
@@ -2631,7 +2641,7 @@ msgstr "Beantwoorde vragen per module"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registreer"
 
@@ -2652,23 +2662,23 @@ msgid "header_risk_aware"
 msgstr "Bent u zich bewust van alle risico's?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Wat is het effect?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Hoe vaak wordt men blootgesteld aan dit risico?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Geef de categorie van dit risico aan"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Hoe groot is de kans op dit risico?"
 
@@ -2680,7 +2690,7 @@ msgid "header_risks"
 msgstr "Risico's"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2740,12 +2750,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2760,17 +2770,17 @@ msgid "header_welcome"
 msgstr "Welkom"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Wat is het OiRA (Online Interactive Risk Assesment) project"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Waarom het OiRA project"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Opmerkingen"
 
@@ -2791,142 +2801,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Hoge  prioriteit risico"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Hoge  prioriteit risico‘s"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Hoge  prioriteit risico‘s"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Hoge  prioriteit risico‘s"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Lage prioriteit risico"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Lage prioriteit risico‘s"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Lage prioriteit risico‘s"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Lage prioriteit risico‘s"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Uitgestelde risico"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Uitgestelde risico‘s"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Uitgestelde risico‘s"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Uitgestelde risico‘s"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Niet beantwoorde risico"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Niet beantwoorde risico‘s"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Niet beantwoorde risico‘s"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Niet beantwoorde risico‘s"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Mogelijke risico"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Mogelijke risico‘s"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Mogelijke risico‘s"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Mogelijke risico‘s"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Aanwezige Risico"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Aanwezige Risico‘s"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Aanwezige Risico‘s"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Aanwezige Risico‘s"
 
@@ -2951,7 +2961,7 @@ msgstr ""
 "wachtwoord en de registratiepagina wordt een link naar deze tekst geplaatst."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Beantwoord de volgende vragen. Het systeem zal op grond van uw antwoorden de "
@@ -2977,7 +2987,7 @@ msgstr ""
 "kopie van een bestaande RI&E."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -2989,14 +2999,14 @@ msgstr ""
 "kan dit zelf alsnog wijzigen bij het invullen van de RI&E."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 "Geef een indicatie van de zwaarte van het effect (hoe schadelijk is het voor "
@@ -3100,6 +3110,11 @@ msgstr ""
 "Upload een afbeelding. Let erop dat de afbeeling een PNG, JPG of GIF\"\n"
 "\"formaat heeft."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3115,7 +3130,7 @@ msgstr ""
 "voorkomt. Deze informatie wordt gekopieerd naar de maatregel."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Beschrijf de standaard maatregelen voor het Plan van aanpak en "
@@ -3277,7 +3292,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Als u geen titel opgeeft zal titel uit het bestand worden overgenomen."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3363,7 +3378,7 @@ msgstr ""
 "Kies een eerdere RI&E om af te maken of te wijzigen of ${start_session}."
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Dit is een proefsessie"
 
@@ -3558,13 +3573,13 @@ msgstr "Het account is geblokkeerd"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Plan van aanpak"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budget (in Euro)"
 
@@ -3574,27 +3589,22 @@ msgid "label_action_plan_download"
 msgstr "Plan van aanpak"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Eind datum"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Wie is er verantwoordelijk?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Begindatum"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Voeg een andere maatregel toe"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3637,8 +3647,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Vul hier eventuele opmerkingen in die moeten worden meegenomen in het "
@@ -3726,7 +3736,7 @@ msgstr ""
 "U staat op het punt om dit risico te verwijderen &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Beschrijving"
@@ -3756,7 +3766,7 @@ msgstr "Zet een melding over deze tool aan."
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Evaluatie"
 
@@ -3776,10 +3786,19 @@ msgid "label_evaluation_phase"
 msgstr "Evaluatie fase"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Maatregel is al toegepast"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3854,7 +3873,7 @@ msgstr "RI&E's"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Inventarisatie"
 
@@ -3862,6 +3881,11 @@ msgstr "Inventarisatie"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Afbeelding"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3884,7 +3908,7 @@ msgid "label_language"
 msgstr "Taal"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Wet- en regelgeving"
@@ -3919,21 +3943,26 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Welk logo wilt u linksboven tonen?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Plan van aanpak"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Preventie plan"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Vereisten"
 
@@ -3989,25 +4018,25 @@ msgid "label_no"
 msgstr "Nee"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Geen risico"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Geen risico"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Geen risico"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Geen risico"
@@ -4047,15 +4076,10 @@ msgstr "Wachtwoord"
 msgid "label_password_confirm"
 msgstr "Nogmaals wachtwoord"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "standaard maatregelen"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Voorbereiding"
 
@@ -4066,7 +4090,7 @@ msgstr "Preview"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorige"
@@ -4129,15 +4153,15 @@ msgstr "U kunt een volledig verslag en een actieplan downloaden."
 msgid "label_register_first"
 msgstr "registreer"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Verwijder"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Rapport"
 
@@ -4149,12 +4173,12 @@ msgstr ""
 "rapport."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4174,49 +4198,49 @@ msgid "label_risk_type"
 msgstr "Type risico"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Risico met maatregel(en)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Risico zonder maatregel"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risico‘s zonder maatregel"
@@ -4229,7 +4253,7 @@ msgstr "Sla op en voeg nog een risico toe"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Opslaan en verdergaan"
 
@@ -4254,7 +4278,7 @@ msgid "label_sector_title"
 msgstr "Titel van de branche"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Selecteer één of meer van de bekende vaak voorkomende maatregelen."
 
@@ -4285,7 +4309,7 @@ msgid "label_show_less_hellip"
 msgstr "Toon minder"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} over dit risico."
 
@@ -4315,7 +4339,7 @@ msgid "label_start_identification"
 msgstr "Start risico inventarisatie"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Start"
 
@@ -4360,29 +4384,29 @@ msgid "label_surveygroup_title"
 msgstr "Titel van geïmporteerde RI&E"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "hoog"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "laag"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "gemiddeld"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titel"
 
@@ -4442,12 +4466,12 @@ msgid "label_user_title"
 msgstr "Naam"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 maatregelen)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(zonder maatregelen)"
 
@@ -4494,7 +4518,7 @@ msgid "limitations"
 msgstr "beperkingen"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Login"
 
@@ -4586,7 +4610,7 @@ msgid "menu_import"
 msgstr "Importeer vragenlijst"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4690,32 +4714,32 @@ msgid "nav_usermanagement"
 msgstr "Gebruikersbeheer"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Help"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Uitloggen"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Instellingen"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Status"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "RI&E's"
 
@@ -4765,27 +4789,27 @@ msgid "notice_country_manager"
 msgstr "Landmanager voor ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Online interactive"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Risicobeoordeling"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4805,7 +4829,7 @@ msgid "osc_search_placeholder"
 msgstr "Zoeken"
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4819,7 +4843,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "De officiële lancering van dit hulpmiddel zal plaatsvinden in september "
@@ -4850,45 +4874,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Hoog"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Laag"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Groot"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Klein"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Voltooid"
 
@@ -4941,18 +4965,13 @@ msgstr "Nog geen account? ${register_link} u dan eerst."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4965,7 +4984,7 @@ msgstr ""
 "volgende voordelen:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4980,17 +4999,17 @@ msgstr ""
 "van aanpak."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Dit rapport is gebaseerd op de RI&E '${title}' van revision datum ${date}."
@@ -5021,35 +5040,35 @@ msgid "request_an_email_reminder"
 msgstr "vraag een e-mail herinnering"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr "Dit risico is aanwezig."
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Dit is een risico in de categorie ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "hoog"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "laag"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "gemiddeld"
 
@@ -5069,7 +5088,7 @@ msgid "risk_solution_header"
 msgstr "Maatregel ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Dit risico is nog niet beoordeeld."
@@ -5117,46 +5136,46 @@ msgid "select_add_existing_measure"
 msgstr "Selecteer of voeg maatregelen toe die al van kracht zijn."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Niet ernstig"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Niet meer dan drie dagen te stoppen met werk"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Ernstig"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Meer dan 3 dagen werkonderbreiking vereist"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Zeer ernstig"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Ongeneesbare verwonding of ziekte, of dood"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Zwak"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Niet nog om te stoppen met werk"
 
@@ -5224,7 +5243,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Over"
 
@@ -5239,7 +5258,7 @@ msgid "title_account_settings"
 msgstr "Instellingen"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Wachtwoord veranderen"
@@ -5250,7 +5269,7 @@ msgid "title_client_help"
 msgstr "Client helptekst"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Standaard maatregel"
 
@@ -5285,7 +5304,7 @@ msgid "title_import_sector_survey"
 msgstr "Importeer RI&E"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Bijkomende risico’s (door u toegevoegd)"
@@ -5312,8 +5331,8 @@ msgstr "Status van ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "Risico Inventarisatie en Evaluatie (RI&E)"
 
@@ -5338,19 +5357,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Status van ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Inhoudsopgave"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr "Toon/verberg menu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Dit risico is nog niet beoordeeld maar aangezien het een top-5 risico is, is "
@@ -5358,14 +5377,14 @@ msgstr ""
 "t. in bij dit risico."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Dit risico is niet aanwezig maar aangezien het een top-5 risico is, is het "
 "hier wel opgenomen."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Dit risico is nog niet beoordeeld maar aangezien het een top-5 risico is, is "
@@ -5395,7 +5414,7 @@ msgid "use_it_to_full_report"
 msgstr "Te gebruiken om"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Te gebruiken om"
 
@@ -5405,12 +5424,12 @@ msgid "use_it_to_measures_report"
 msgstr "Te gebruiken om"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Te gebruiken om"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Te gebruiken om"
 
@@ -5425,7 +5444,7 @@ msgid "warn_fix_errors"
 msgstr "Los de gemarkeerde problemen eerst op."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "U heeft 'nee' ingevuld bij bovenstaande risico."
@@ -5450,6 +5469,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Voeg een andere maatregel toe"
+
+#~ msgid "label_prefill"
+#~ msgstr "standaard maatregelen"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Er zijn geen wijzigingen gedaan in de maatregelen van uw actieplan."

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -277,7 +277,8 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
-"Door een risicoanalyse te klonen, zal u een nieuwe risicoanalyse creëren gebaseerd op de inhoud van deze risicoanalyse als startpunt."
+"Door een risicoanalyse te klonen, zal u een nieuwe risicoanalyse creëren "
+"gebaseerd op de inhoud van deze risicoanalyse als startpunt."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -668,7 +669,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -712,7 +713,7 @@ msgstr "Nee"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1546,10 +1547,6 @@ msgstr "Over"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Geproduceerd door ${EU-OSHA}"
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "gebaseerd op"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4416,6 +4413,11 @@ msgstr "gemiddeld"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "gebaseerd op ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4825,7 +4827,7 @@ msgid "optional"
 msgstr "Optioneel"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5475,6 +5477,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "based on"
+#~ msgstr "gebaseerd op"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Voeg een andere maatregel toe"

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -80,7 +80,7 @@ msgstr ""
 "${provide-evidence} aan toezichthoudende instanties (Inspectie Toezicht van "
 "het welzijn op het werk)"
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Voeg materiaal van bibliotheek toe"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -236,7 +236,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -268,7 +268,7 @@ msgstr "Beschikbare OiRA-tools"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr "Kandidaat-landen"
 msgid "Candidate country"
 msgstr "Kandidaat-land"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Wijzig e-mailadres"
 
@@ -332,11 +332,11 @@ msgstr ""
 "Bevat: alle informatie en input die u hebt verstrekt tijdens alle stappen "
 "van de risicoanalyse"
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Inhoud: een overzicht van de toe te passen maatregelen."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Inhoud: een overzicht van de vastgestelde risico's"
 
@@ -375,15 +375,15 @@ msgstr "Landinformatie en groepen voor de gebruiker."
 msgid "Country manager"
 msgstr "Landbeheerder"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 generieke licentie"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons License"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -441,15 +441,15 @@ msgstr "Het actieplan downloaden"
 msgid "Download the full report"
 msgstr "Het volledige rapport downloaden"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Download het overzicht van maatregelen"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Download het overzicht van risico's"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -523,7 +523,7 @@ msgstr "Map"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Bestandsformaat: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Format: Portable Document Format (.pdf)"
 
@@ -531,7 +531,7 @@ msgstr "Format: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Duitsland"
 
@@ -560,7 +560,7 @@ msgstr ""
 "Het is echter mogelijk om een risicoanalyse aan te vangen en op een later "
 "tijdstip, wanneer het beter uitkomt, vanaf dat punt weer verder te gaan."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Ik wil het volgende met u delen"
 
@@ -576,8 +576,7 @@ msgstr ""
 msgid "Important"
 msgstr "Belangrijk:"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Info"
 
@@ -586,7 +585,7 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informatie"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
@@ -620,11 +619,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "Laatst opgeslagen"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Meer informatie over deze tool…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -636,7 +635,7 @@ msgstr "Login"
 msgid "Manage"
 msgstr "Te gebruiken om"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Maatregel"
@@ -657,14 +656,14 @@ msgstr ""
 "getroffen "
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 "Controleer de maatregelen die geïmplementeerd moeten worden in de komende 3 "
 "maanden."
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Ga na of er naar behoren wordt omgegaan met risico's/maatregelen."
 
@@ -790,12 +789,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online help"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Overzicht van maatregelen"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Overzicht van de risico‘s"
@@ -814,8 +815,8 @@ msgstr ""
 "op het werk, ...)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Geef informatie door aan de betrokken personen."
 
@@ -845,9 +846,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Verwijs naar de voorbeelden onder het formulier."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Uitgesteld"
 
@@ -888,7 +889,7 @@ msgstr "als bewijs voor toezichthoudende instanties"
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Meer informatie"
 
@@ -922,8 +923,8 @@ msgstr ""
 "verder te gaan met eerdere analyses of een nieuwe aan te vangen."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Verwijder"
 
@@ -944,11 +945,11 @@ msgstr "Risico"
 msgid "Risk assessments made with this tool"
 msgstr "Risicobeoordelingen die met deze tool zijn gemaakt"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Aandacht"
 
@@ -1026,7 +1027,7 @@ msgstr "Deze OiRA-tool delen"
 msgid "Show library from ${dropdown}."
 msgstr "Toon bibliotheek van ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Meld u aan"
 
@@ -1042,6 +1043,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standaard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1096,7 +1101,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nederland"
 
@@ -1114,7 +1119,7 @@ msgid ""
 msgstr ""
 "De basisarchitectuur van een Online interactive Risk Assessment bestaat uit:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1222,7 +1227,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Deze tool verdient wereldwijde bekendheid! Deel de tool!"
 
@@ -1230,8 +1235,8 @@ msgstr "Deze tool verdient wereldwijde bekendheid! Deel de tool!"
 msgid "Tip"
 msgstr "Tip"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Schakel schermhulp in"
 
@@ -1243,9 +1248,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Onbeantwoord"
 
@@ -1363,38 +1368,38 @@ msgid "Your password was successfully changed."
 msgstr "Uw wachtwoord werd gewijzigd."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "De broncode van de OiRA-applicatie heeft een ${GPL}-licentie."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "De inhoud van sectoriële OiRA-instrumenten zijn gelicenceerd onder een "
 "${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "De sectoriële OiRA-instrumenten kunnen gratis worden gebruikt door alle "
 "gebruikers."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Meer informatie over het OiRA project (Engelstalig)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "De strategie van de Europese Gemeenschap over gezondheid en veiligheid op "
 "het werk 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Ervaring toont ons dat ${key}. Daarom heeft EU-OSHA een ${easy} (het â€œOiRAâ"
@@ -1405,42 +1410,42 @@ msgstr ""
 "ondernemen van actie, voor monitoring en ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "gebruiksvriendelijke en gratis webapplicatie"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "evaluatie"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identificatie"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "een degelijke risicobeoordeling is de sleutel tot een gezonde werkplek"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "preventieve acties"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "rapportering"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "stapsgewijs risicobeoordelingsproces"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Met de OiRA-webapplicatie krijgt u toegang tot Risicobeoordelinginstrumenten "
@@ -1448,7 +1453,7 @@ msgstr ""
 "organisaties op nationaal niveau."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "Het ${agency} vraagt naar de ontwikkeling van eenvoudige instrumenten om "
@@ -1461,7 +1466,7 @@ msgstr ""
 "beleid dat het OiRA-project tracht te overkomen."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Het OiRA-project en de verwante webapplicatie werden ontwikkeld door de ${eu-"
@@ -1473,14 +1478,14 @@ msgstr ""
 "inbreng en deelname van de vakbonden FNV, CNV en MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "De volgende technische partners hebben bijgedragen aan de ontwikkeling van "
 "het OiRA- project:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Het Agentschap kreeg strategisch en expertadvies van een stuurgroep voor de "
@@ -1489,12 +1494,12 @@ msgstr ""
 "belangengroepen bij de Raad, de Commissie en door EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "micro-ondernemingen en kleine ondernemingen hebben tekortkomingen"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Hoewel sommige maatregelen gratis zijn, zijn de meeste dat niet. De "
@@ -1502,7 +1507,7 @@ msgstr ""
 "jaarlijkse budgetronde, indien nodig."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Stel iemand aan in uw bedrijf die verantwoordelijk is voor de implementatie "
@@ -1510,14 +1515,20 @@ msgstr ""
 "het plan uit te voeren en/of de verantwoordelijkheid op te nemen om ervoor "
 "te zorgen dat de stappen worden uitgevoerd."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Omschrijf: 1) wat is uw algemene aanpak om het risico te verhelpen (als het "
 "risico niet kan worden voorkomen) of te verlagen; 2) de specifieke actie(s) "
 "die is (zijn) vereist om deze aanpak (het risico verhelpen of verlagen) te "
-"implementeren; 3) het niveau van expertise dat is vereist om de maatregel te "
+"implementeren."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Omschrijf: 3) het niveau van expertise dat is vereist om de maatregel te "
 "implementeren, bijvoorbeeld gezond verstand (geen kennis over veiligheid en "
 "gezondheid op het werk vereist), geen specifieke expertise over veiligheid "
 "en gezondheid op het werk, maar toch een minimum aan kennis over veiligheid "
@@ -1585,7 +1596,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: positieve opmerkingen, die in modules zijn opgeslagen."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Toevoegen"
 
@@ -1633,7 +1644,7 @@ msgstr "Annuleren"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Sluit"
 
@@ -1967,7 +1978,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "De tool heeft automatisch een risico-evaluatie uitgevoerd. U kunt de "
@@ -2023,7 +2034,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Na de technische ontwikkeling van het instrument in 2009, onderwerpt het "
@@ -2065,17 +2076,17 @@ msgid "effect_high"
 msgstr "Blijvende gezondheidsschade"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Gering"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Gemiddeld"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Hoog (erg hoog)"
 
@@ -2150,7 +2161,7 @@ msgid "error_existing_login"
 msgstr "Deze loginnaam bestaat al."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Vul het budget in hele euro's in."
 
@@ -2186,17 +2197,17 @@ msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2310,7 +2321,7 @@ msgstr ""
 "verdergaan, moet u deze wijzigingen bijwerken."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2319,12 +2330,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Actieplan ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Identificatierapport ${title}"
 
@@ -2344,7 +2355,7 @@ msgid "french"
 msgstr "Vereenvoudigde twee criteria"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Bijna nooit"
 
@@ -2354,57 +2365,57 @@ msgid "frequency_almostnever"
 msgstr "Bijna nooit"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Voortdurend"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Niet erg vaak"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Eenmaal per maand"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Vaak"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Eenmaal per week"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Zelden"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Eenmaal per jaar"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Erg vaak of regelmatig"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Minimaal eenmaal per jaar"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regelmatig"
@@ -2431,12 +2442,12 @@ msgid "header_additional_content"
 msgstr "Aanvullende inhoud"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Aanvullende bronnen om het risico te beoordelen"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Aanvullende bronnen voor deze module"
 
@@ -2451,12 +2462,12 @@ msgid "header_country_managers"
 msgstr "Landbeheerders"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Ontwikkelings- en pilootfase â€“ 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Ontwikkelingspartners"
 
@@ -2493,18 +2504,18 @@ msgstr "Identificatie"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informatie"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Officiële lancering van het project â€“ September 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Wettelijke bepalingen en beleidsreferenties"
 
@@ -2514,13 +2525,13 @@ msgid "header_legend"
 msgstr "Legende"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licenties"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Inloggen"
@@ -2531,12 +2542,12 @@ msgid "header_main_image"
 msgstr "Belangrijkste afbeelding"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Maatregel ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Maatregel"
 
@@ -2562,12 +2573,12 @@ msgid "header_not_complicated"
 msgstr "De beoordeling is niet ingewikkeld"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2602,7 +2613,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2622,7 +2633,7 @@ msgid "header_profile_questions"
 msgstr "Profielvragen"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projectfase"
 
@@ -2638,7 +2649,7 @@ msgstr "Vragen beantwoord per module"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registreren"
 
@@ -2659,23 +2670,23 @@ msgid "header_risk_aware"
 msgstr "Are you aware of all the risks?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Wat is de ernst van de schade?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Hoe vaak worden mensen blootgesteld aan dit risico?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Selecteer de prioriteit van dit risico"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Hoe groot is de kans dat dit risico zich voordoet?"
 
@@ -2687,7 +2698,7 @@ msgid "header_risks"
 msgstr "Risico's"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2747,12 +2758,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2767,17 +2778,17 @@ msgid "header_welcome"
 msgstr "Welkom"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Wat is het OiRA-project (Online Interactive Risk Assessment)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Waarom het OiRA-project"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Commentaar"
 
@@ -2798,142 +2809,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} Hoge  prioriteit risico"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} Hoge  prioriteit risico‘s"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} Hoge  prioriteit risico‘s"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} Hoge  prioriteit risico‘s"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} Lage prioriteit risico"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} Lage prioriteit risico‘s"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} Lage prioriteit risico‘s"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} Lage prioriteit risico‘s"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} Gemiddelde prioriteit risico‘s"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} Uitgestelde risico"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} Uitgestelde risico‘s"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} Uitgestelde risico‘s"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} Uitgestelde risico‘s"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} Niet beantwoorde risico"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} Niet beantwoorde risico‘s"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} Niet beantwoorde risico‘s"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} Niet beantwoorde risico‘s"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Mogelijke risico"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Mogelijke risico‘s"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Mogelijke risico‘s"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Mogelijke risico‘s"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Aanwezige Risico"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Aanwezige Risico‘s"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Aanwezige Risico‘s"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Aanwezige Risico‘s"
 
@@ -2953,7 +2964,7 @@ msgid "help_authentication"
 msgstr "Deze tekst moet uitleggen hoe de registratie en aanmelding verlopen."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Beantwoord de volgende vragen. Het systeem zal op grond van uw antwoorden de "
@@ -2981,7 +2992,7 @@ msgstr ""
 "wilt aanvangen met een exemplaar van een bestaand OiRA-instrument.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -2993,14 +3004,14 @@ msgstr ""
 "Hij/zij kan de prioriteit later nog wel wijzigen."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Geef de ernst aan wanneer dit risico zich voordoet."
 
@@ -3095,6 +3106,11 @@ msgstr ""
 "Upload een afbeelding. Zorg ervoor dat de afbeelding een png, jpg of gif is "
 "en geen speciale karakters bevat."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3110,7 +3126,7 @@ msgstr ""
 "van deze aanpak (om het risico te verhelpen of te verlagen)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Omschrijf het niveau van vakkennis dat nodig is om de maatregel te "
@@ -3274,7 +3290,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Als u geen titel opgeeft, zal titel uit het bestand worden gehaald."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3360,7 +3376,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Dit is een proefsessie"
 
@@ -3560,13 +3576,13 @@ msgstr "De account is vergrendeld"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Actieplan"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budget"
 
@@ -3576,27 +3592,22 @@ msgid "label_action_plan_download"
 msgstr "Actieplan"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Einde van planning"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Wie is er verantwoordelijk?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Aanvang van planning"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Voeg een andere maatregel toe"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3639,8 +3650,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Gelieve hier al uw opmerkingen met betrekking tot de bovenstaande vraag te "
@@ -3728,7 +3739,7 @@ msgstr ""
 "U staat op het punt om dit risico te verwijderen &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Beschrijving"
@@ -3758,7 +3769,7 @@ msgstr "Wilt u een persoonlijke kennisgeving voor deze OiRA-tool ?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Evaluatie"
 
@@ -3778,10 +3789,19 @@ msgid "label_evaluation_phase"
 msgstr "Evaluatiefase"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Maatregel is al toegepast"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3856,7 +3876,7 @@ msgstr "Uw risicoanalyse uitvoeren"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identificatie"
 
@@ -3864,6 +3884,11 @@ msgstr "Identificatie"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Afbeelding"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3886,7 +3911,7 @@ msgid "label_language"
 msgstr "Taal"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Wet- en beleidsreferenties"
@@ -3921,22 +3946,27 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Welk logo wilt u linksboven tonen?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Algemene aanpak (om het risico te verhelpen of te verlagen)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 "Specifieke actie(s) die voor de implementatie van deze aanpak nodig is (zijn)"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Niveau van expertise en/of vereisten nodig"
 
@@ -3993,25 +4023,25 @@ msgid "label_no"
 msgstr "Nee"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Geen risico"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Geen risico"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Geen risico"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Geen risico"
@@ -4051,15 +4081,10 @@ msgstr "Wachtwoord"
 msgid "label_password_confirm"
 msgstr "Wachtwoord opnieuw invoeren"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Voorinvullen"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Voorbereiding"
 
@@ -4070,7 +4095,7 @@ msgstr "Voorbeeld"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorige"
@@ -4133,15 +4158,15 @@ msgstr "U kunt een volledig verslag en een actieplan downloaden."
 msgid "label_register_first"
 msgstr "registreer"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Verwijder deze maatregel"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Rapport"
 
@@ -4153,12 +4178,12 @@ msgstr ""
 "noteren."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4178,49 +4203,49 @@ msgid "label_risk_type"
 msgstr "Risicotype"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Risico met maatregel(en)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Risico zonder maatregel"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Risico‘s met maatregel(en)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Risico‘s zonder maatregel"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Risico‘s zonder maatregel"
@@ -4233,7 +4258,7 @@ msgstr "Sla op en voeg nog een risico toe"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Opslaan en verdergaan"
 
@@ -4258,7 +4283,7 @@ msgid "label_sector_title"
 msgstr "Titel van de sector."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Selecteer één of meer van de bekende vaak voorkomende maatregelen."
 
@@ -4287,7 +4312,7 @@ msgid "label_show_less_hellip"
 msgstr "Toon minder"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} over dit risico."
 
@@ -4317,7 +4342,7 @@ msgid "label_start_identification"
 msgstr "Start risico-identificatie"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Start"
 
@@ -4362,29 +4387,29 @@ msgid "label_surveygroup_title"
 msgstr "Titel van geïmporteerd OiRA-instrument"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Hoog"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Laag"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titel"
 
@@ -4444,12 +4469,12 @@ msgid "label_user_title"
 msgstr "Naam"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 maatregelen)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(zonder maatregelen)"
 
@@ -4496,7 +4521,7 @@ msgid "limitations"
 msgstr "beperkingen"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Inloggen"
 
@@ -4589,7 +4614,7 @@ msgid "menu_import"
 msgstr "OiRA-instrument importeren"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4695,32 +4720,32 @@ msgid "nav_usermanagement"
 msgstr "Gebruikersbeheer"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Help"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Uitloggen"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Instellingen"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Bekijk uw voortgang"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Mijn beoordelingen"
 
@@ -4770,27 +4795,27 @@ msgid "notice_country_manager"
 msgstr "Landbeheerder voor ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Online interactive"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Risicobeoordeling"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4810,7 +4835,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4824,7 +4849,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "De officiële lancering van het instrument zal plaatsvinden in september "
@@ -4855,45 +4880,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Hoog"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Laag"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Groot"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Klein"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Voltooid"
 
@@ -4946,18 +4971,13 @@ msgstr "Hebt u nog geen account? ${register_link} u dan eerst."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4970,7 +4990,7 @@ msgstr ""
 "volgende voordelen:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4985,17 +5005,17 @@ msgstr ""
 "vullen."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Dit rapport is gebaseerd op het OiRA-instrument '${title}' van revisiedatum "
@@ -5027,35 +5047,35 @@ msgid "request_an_email_reminder"
 msgstr "vraag een e-mailherinnering aan"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Dit is een ${priority_value} prioriteitrisico."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "hoog"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "laag"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "gemiddeld"
 
@@ -5075,7 +5095,7 @@ msgid "risk_solution_header"
 msgstr "Maatregel ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Dit risico is nog niet beoordeeld."
@@ -5123,46 +5143,46 @@ msgid "select_add_existing_measure"
 msgstr "Selecteer of voeg maatregelen toe die al van kracht zijn."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Niet vrij ernstig"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Nodig om werk gedurende minder dan 3 dagen te onderbreken"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Ernstig"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Nodig om werk gedurende meer dan 3 dagen te onderbreken"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Zeer ernstig"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Onomkeerbaar letsel, ongeneeslijke ziekte, overlijden"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Zwak"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Niet nodig om werk te onderbreken"
 
@@ -5234,7 +5254,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Over"
 
@@ -5249,7 +5269,7 @@ msgid "title_account_settings"
 msgstr "Accountinstellingen"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Wachtwoord veranderen"
@@ -5260,7 +5280,7 @@ msgid "title_client_help"
 msgstr "Helptekst voor gebruikerssite"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Maatregel"
 
@@ -5295,7 +5315,7 @@ msgid "title_import_sector_survey"
 msgstr "Sector en OiRA-instrument importeren"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Bijkomende risico’s (door u toegevoegd)"
@@ -5322,8 +5342,8 @@ msgstr "Status van ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Online interactive Risk Assessment"
 
@@ -5348,19 +5368,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Status van ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Inhoud"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Dit risico is niet aanwezig in uw organisatie, maar aangezien de "
@@ -5368,7 +5388,7 @@ msgstr ""
 "worden opgenomen in dit rapport."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Dit risico is niet aanwezig in uw organisatie, maar aangezien de "
@@ -5376,7 +5396,7 @@ msgstr ""
 "worden opgenomen in dit rapport."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Dit risico werd nog niet beoordeeld, maar omdat het wordt aanzien als “hoge "
@@ -5406,7 +5426,7 @@ msgid "use_it_to_full_report"
 msgstr "Te gebruiken om"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Te gebruiken om"
 
@@ -5416,12 +5436,12 @@ msgid "use_it_to_measures_report"
 msgstr "Te gebruiken om"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Te gebruiken om"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Te gebruiken om"
 
@@ -5436,7 +5456,7 @@ msgid "warn_fix_errors"
 msgstr "Herstel de aangegeven fouten."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "U antwoordde negatief op de bovenstaande stelling."
@@ -5460,6 +5480,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Voeg een andere maatregel toe"
+
+#~ msgid "label_prefill"
+#~ msgstr "Voorinvullen"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr ""

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -282,7 +282,8 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
-"Door een risicoanalyse te klonen, zal u een nieuwe risicoanalyse creëren gebaseerd op de inhoud van deze risicoanalyse als startpunt."
+"Door een risicoanalyse te klonen, zal u een nieuwe risicoanalyse creëren "
+"gebaseerd op de inhoud van deze risicoanalyse als startpunt."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -588,7 +589,8 @@ msgstr "Informatie"
 
 #: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr "Verkeerd bestandsformaat voor afbeelding. Gebruik a.u.b. PNG, JPEG of GIF."
+msgstr ""
+"Verkeerd bestandsformaat voor afbeelding. Gebruik a.u.b. PNG, JPEG of GIF."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -673,7 +675,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -717,7 +719,7 @@ msgstr "Nee"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1570,10 +1572,6 @@ msgstr "Over"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Geproduceerd door ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "gebaseerd op"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4419,6 +4417,11 @@ msgstr "Gemiddeld"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "gebaseerd op ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4831,7 +4834,7 @@ msgid "optional"
 msgstr "Optioneel"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5486,6 +5489,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Ja"
+
+#~ msgid "based on"
+#~ msgstr "gebaseerd op"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Voeg een andere maatregel toe"

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0.2dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -236,7 +236,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -253,7 +253,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:26
 msgid "Are you sure you want to proceed?"
-msgstr ""
+msgstr "Bent u zeker dat u wil doorgaan?"
 
 #: euphorie/content/behaviour/configure.zcml:33
 msgid "Automatically generate unique ids for content"
@@ -282,6 +282,7 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
+"Door een risicoanalyse te klonen, zal u een nieuwe risicoanalyse creëren gebaseerd op de inhoud van deze risicoanalyse als startpunt."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -585,9 +586,9 @@ msgstr "Info"
 msgid "Information"
 msgstr "Informatie"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
+msgstr "Verkeerd bestandsformaat voor afbeelding. Gebruik a.u.b. PNG, JPEG of GIF."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -1046,7 +1047,7 @@ msgstr "Standaard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Standaard maatregelen"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1054,7 +1055,7 @@ msgstr "Standaardoplossing"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:83
 msgid "Started"
-msgstr ""
+msgstr "Gestart op"
 
 #: euphorie/client/browser/login.py:232
 #: euphorie/client/browser/templates/new-session-test.pt:89
@@ -1119,7 +1120,7 @@ msgid ""
 msgstr ""
 "De basisarchitectuur van een Online interactive Risk Assessment bestaat uit:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1260,7 +1261,7 @@ msgstr "Uploaden"
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:198
 msgid "Upload an image that illustrates this risk."
-msgstr "Invoegen afbeelding die het risico illustreert."
+msgstr "Upload een afbeelding die het risico illustreert."
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:217
 msgid "Upload image"
@@ -1313,7 +1314,7 @@ msgstr "Ja"
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:34
 msgid "Yes, clone risk assessment"
-msgstr ""
+msgstr "Ja, kloon risicoanalyse"
 
 #: euphorie/content/templates/library.pt:17
 msgid ""
@@ -1572,7 +1573,7 @@ msgstr "Geproduceerd door ${EU-OSHA}."
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:143
 msgid "based on"
-msgstr ""
+msgstr "gebaseerd op"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -2197,17 +2198,17 @@ msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2992,7 +2993,7 @@ msgstr ""
 "wilt aanvangen met een exemplaar van een bestaand OiRA-instrument.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -3004,14 +3005,14 @@ msgstr ""
 "Hij/zij kan de prioriteit later nog wel wijzigen."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Geef de ernst aan wanneer dit risico zich voordoet."
 
@@ -3292,7 +3293,7 @@ msgstr "Als u geen titel opgeeft, zal titel uit het bestand worden gehaald."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Dashboard"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3650,7 +3651,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3799,9 +3800,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Voeg een extra maatregel toe"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4095,7 +4096,7 @@ msgstr "Voorbeeld"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Vorige"
@@ -4258,7 +4259,7 @@ msgstr "Sla op en voeg nog een risico toe"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Opslaan en verdergaan"
 
@@ -4300,6 +4301,11 @@ msgstr "Kies uw sector in het uitrolmenu hieronder"
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Selecteer standaardmaatregelen"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4349,7 +4355,7 @@ msgstr "Start"
 #. Default: "Started"
 #: euphorie/client/browser/templates/status_info.pt:51
 msgid "label_started"
-msgstr "Gestart"
+msgstr "gestart op"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -5376,7 +5382,7 @@ msgstr "Inhoud"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Toon/verberg menu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1954,17 +1954,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2710,7 +2710,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2720,12 +2720,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3243,7 +3243,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3683,7 +3683,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3844,7 +3844,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3885,6 +3885,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -632,7 +632,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -676,7 +676,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1418,10 +1418,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -4004,6 +4000,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4396,7 +4397,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -63,7 +63,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -244,7 +244,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -272,7 +272,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -306,11 +306,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -347,15 +347,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -413,15 +413,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-post"
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -542,8 +542,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -552,7 +551,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -584,11 +583,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -600,7 +599,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -619,12 +618,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -741,12 +740,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -762,8 +763,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -788,9 +789,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -827,7 +828,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -856,8 +857,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -878,11 +879,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -957,7 +958,7 @@ msgstr "Del dette OiRA-verktøyet"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -972,6 +973,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1021,7 +1026,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1038,7 +1043,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1138,7 +1143,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Hele verden bør bli kjent med dette verktøyet! Del det med andre!"
 
@@ -1146,8 +1151,8 @@ msgstr "Hele verden bør bli kjent med dette verktøyet! Del det med andre!"
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1159,9 +1164,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1268,113 +1273,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1434,7 +1444,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1482,7 +1492,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1750,7 +1760,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1794,7 +1804,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1828,17 +1838,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1908,7 +1918,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1944,17 +1954,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2044,7 +2054,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2053,12 +2063,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -2078,7 +2088,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2088,57 +2098,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2159,12 +2169,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2179,12 +2189,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2220,18 +2230,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2241,13 +2251,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2258,12 +2268,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2289,12 +2299,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2329,7 +2339,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2349,7 +2359,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2365,7 +2375,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2386,23 +2396,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2414,7 +2424,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2474,12 +2484,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2494,17 +2504,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2525,142 +2535,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2680,7 +2690,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2700,7 +2710,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2710,12 +2720,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2805,6 +2815,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2816,7 +2831,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2937,7 +2952,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3002,7 +3017,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3154,13 +3169,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3170,26 +3185,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3233,8 +3243,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3319,7 +3329,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3349,7 +3359,7 @@ msgstr ""
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3369,9 +3379,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3447,13 +3466,18 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
 #. Default: "Image file"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3477,7 +3501,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3512,21 +3536,26 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3582,25 +3611,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3640,15 +3669,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3659,7 +3683,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3722,15 +3746,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3740,12 +3764,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3765,49 +3789,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3820,7 +3844,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3845,7 +3869,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3874,7 +3898,7 @@ msgid "label_show_less_hellip"
 msgstr "Vis mindre"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3904,7 +3928,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3949,29 +3973,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4031,12 +4055,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4081,7 +4105,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4162,7 +4186,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4262,32 +4286,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4337,27 +4361,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4377,7 +4401,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4389,7 +4413,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4415,45 +4439,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4502,18 +4526,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4523,7 +4542,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4533,17 +4552,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4573,35 +4592,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4621,7 +4640,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4669,46 +4688,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4768,7 +4787,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4783,7 +4802,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4794,7 +4813,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4829,7 +4848,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr ""
@@ -4856,8 +4875,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4882,29 +4901,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4929,7 +4948,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4939,12 +4958,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4959,7 +4978,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -64,7 +64,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -307,11 +307,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -348,15 +348,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -416,15 +416,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -545,8 +545,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -555,7 +554,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -587,11 +586,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -603,7 +602,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -622,12 +621,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -744,12 +743,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -765,8 +766,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -791,9 +792,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -830,7 +831,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -859,8 +860,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -881,11 +882,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -960,7 +961,7 @@ msgstr "Podziel się narzędziem OiRA"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -975,6 +976,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1024,7 +1029,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1041,7 +1046,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1141,7 +1146,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr ""
 "Narzędzie to powinno zostać rozpowszechnione na cały świat! Udostępnij!"
@@ -1150,8 +1155,8 @@ msgstr ""
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1163,9 +1168,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1272,113 +1277,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1438,7 +1448,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1486,7 +1496,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1754,7 +1764,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1801,7 +1811,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1835,17 +1845,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1915,7 +1925,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1951,17 +1961,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2051,7 +2061,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2060,12 +2070,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -2085,7 +2095,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2095,57 +2105,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2166,12 +2176,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2186,12 +2196,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2227,18 +2237,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2248,13 +2258,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2265,12 +2275,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2296,12 +2306,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2336,7 +2346,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2356,7 +2366,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2372,7 +2382,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2393,23 +2403,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2421,7 +2431,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2481,12 +2491,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2501,17 +2511,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2532,142 +2542,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2687,7 +2697,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2707,7 +2717,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2717,12 +2727,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2812,6 +2822,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2823,7 +2838,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2944,7 +2959,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3009,7 +3024,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3161,13 +3176,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3177,26 +3192,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3240,8 +3250,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3326,7 +3336,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3356,7 +3366,7 @@ msgstr "Czy pokazać zindywidualizowane powiadomienie dla tego narzędzia OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3376,9 +3386,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3454,13 +3473,18 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
 #. Default: "Image file"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3484,7 +3508,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3519,21 +3543,26 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3589,25 +3618,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3647,15 +3676,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3666,7 +3690,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3729,15 +3753,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3747,12 +3771,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3772,49 +3796,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3827,7 +3851,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3852,7 +3876,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3881,7 +3905,7 @@ msgid "label_show_less_hellip"
 msgstr "Pokaż mniej"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3911,7 +3935,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3956,29 +3980,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4038,12 +4062,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4088,7 +4112,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4169,7 +4193,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4269,32 +4293,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4344,27 +4368,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4384,7 +4408,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4396,7 +4420,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4422,45 +4446,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4509,18 +4533,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4530,7 +4549,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4540,17 +4559,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4580,35 +4599,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4628,7 +4647,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4676,46 +4695,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4775,7 +4794,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4790,7 +4809,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4801,7 +4820,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4836,7 +4855,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr ""
@@ -4863,8 +4882,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4889,29 +4908,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4936,7 +4955,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4946,12 +4965,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4966,7 +4985,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -554,7 +554,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1961,17 +1961,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2717,7 +2717,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2727,12 +2727,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3396,7 +3396,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3851,7 +3851,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3892,6 +3892,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -635,7 +635,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -679,7 +679,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1422,10 +1422,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -4011,6 +4007,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4403,7 +4404,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -253,7 +253,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:26
 msgid "Are you sure you want to proceed?"
-msgstr ""
+msgstr "Tem certeza de que deseja continuar?"
 
 #: euphorie/content/behaviour/configure.zcml:33
 msgid "Automatically generate unique ids for content"
@@ -282,6 +282,7 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
+"Ao duplicar uma avaliação de riscos, criará uma nova avaliação de riscos com base no conteúdo da avaliação de riscos inicial."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -357,7 +358,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/module_identification_custom.pt:39
 msgid "Continue to action plan"
-msgstr ""
+msgstr "Continue para o plano de ação"
 
 #: euphorie/content/profiles/default/types/euphorie.country.xml
 msgid "Country"
@@ -584,9 +585,9 @@ msgstr "Informação"
 msgid "Information"
 msgstr "Informação"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
-msgstr ""
+msgstr "Formato de ficheiro inválido. Por favor use PNG, JPEG ou GIF."
 
 #: euphorie/client/settings.py:106
 msgid "Invalid password"
@@ -1045,7 +1046,7 @@ msgstr "Standard"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Medidas sugeridas"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1119,7 +1120,7 @@ msgstr ""
 "A arquitetura de base de um instrumento interativo em linha de avaliação de "
 "risco consiste em:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1260,11 +1261,11 @@ msgstr "Carregar"
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:198
 msgid "Upload an image that illustrates this risk."
-msgstr ""
+msgstr "Adicione uma imagem que ilustre este risco."
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:217
 msgid "Upload image"
-msgstr ""
+msgstr "Adicione imagem"
 
 #: euphorie/content/behaviour/configure.zcml:19
 msgid "Use a rich text description for content types."
@@ -1313,7 +1314,7 @@ msgstr "Sim"
 
 #: euphorie/client/browser/templates/confirmation-clone-session.pt:34
 msgid "Yes, clone risk assessment"
-msgstr ""
+msgstr "Sim, duplicar a avaliação de riscos"
 
 #: euphorie/content/templates/library.pt:17
 msgid ""
@@ -1522,12 +1523,11 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Descreva: 3) o "
-"nível de competência necessário para implementar a medida, por exemplo "
-"\"senso comum (sem conhecimento necessário da SST)\", \"nenhuma competência "
-"da SST específica, mas conhecimento mínimo da SST ou formação e/ou consulta "
-"necessárias em SST \", ou \"competência SST\". Também é possível descrever "
-"aqui qualquer outro requisito adicional (se existente)."
+"Descreva: 3) o nível de competência necessário para implementar a medida, "
+"por exemplo \"senso comum (sem conhecimento necessário da SST)\", \"nenhuma "
+"competência da SST específica, mas conhecimento mínimo da SST ou formação e/"
+"ou consulta necessárias em SST \", ou \"competência SST\". Também é possível "
+"descrever aqui qualquer outro requisito adicional (se existente)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1564,7 +1564,7 @@ msgstr "Elaborada por ${EU-OSHA}."
 
 #: euphorie/client/browser/templates/session-browser-sidebar.pt:143
 msgid "based on"
-msgstr ""
+msgstr "baseada na"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -2186,17 +2186,17 @@ msgid "error_password_mismatch"
 msgstr "As palavras-passe não correspondem"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr "Esta data deve ser igual ou posterior à data inicial."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr "Esta data deve ser igual ou anterior à data final."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Este valor deve ser um número inteiro positivo."
 
@@ -2978,7 +2978,7 @@ msgstr ""
 "começar com uma cópia de uma Ferramenta OiRA existente.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Indica a frequência de ocorrência do risco numa situação normal."
 
@@ -2990,12 +2990,12 @@ msgstr ""
 "ainda pode alterar a prioridade."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Indica a probabilidade de ocorrência deste risco numa siutação normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indica a gravidade em caso de ocorrência do risco."
 
@@ -3265,7 +3265,7 @@ msgstr "Se não especificar um título, o mesmo será retirado da entrada."
 #. Default: "Dashboard"
 #: euphorie/client/templates/shell.pt:114
 msgid "home_link"
-msgstr ""
+msgstr "Painel de controlo"
 
 #. Default: "Your login name and/or password were entered incorrectly. Please check and try again or ${request_an_email_reminder}."
 #: euphorie/client/browser/templates/login_form.pt:29
@@ -3623,7 +3623,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3771,9 +3771,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Adicione outras medidas"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4065,7 +4065,7 @@ msgstr "Pré-visualização"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
@@ -4226,14 +4226,14 @@ msgstr "Guarde e adicione outro risco"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Guardar e continuar"
 
 #. Default: "Save and finish"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:256
 msgid "label_save_and_finish"
-msgstr ""
+msgstr "Guarde e termine"
 
 #. Default: "Section"
 #: euphorie/client/report.py:151
@@ -4270,6 +4270,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Selecione medidas sugeridas"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73
@@ -4319,7 +4324,7 @@ msgstr "Iniciar"
 #. Default: "Started"
 #: euphorie/client/browser/templates/status_info.pt:51
 msgid "label_started"
-msgstr ""
+msgstr "iniciada em"
 
 #. Default: "Affirmative statement"
 #: euphorie/content/risk.py:75
@@ -4431,7 +4436,7 @@ msgstr ""
 #. Default: "Used tool"
 #: euphorie/client/browser/templates/status_info.pt:36
 msgid "label_used_tool"
-msgstr ""
+msgstr "Ferramenta utilizada"
 
 #. Default: "Name"
 #: euphorie/content/user.py:81
@@ -4711,7 +4716,7 @@ msgstr "Definições"
 #: euphorie/client/browser/templates/webhelpers.pt:59
 #: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
-msgstr "Estado"
+msgstr "Ponto da situação"
 
 #. Default: "My Assessments"
 #: euphorie/client/browser/templates/webhelpers.pt:53
@@ -5340,7 +5345,7 @@ msgstr "Conteúdos"
 #. Default: "Show/hide menu"
 #: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
-msgstr ""
+msgstr "Mostrar/ocultar menu"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
 #: euphorie/client/browser/templates/risk_macros.pt:131

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -80,7 +80,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} às autoridades competentes (inspeção do trabalho)."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Adicione conteúdo da biblioteca"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -268,7 +268,7 @@ msgstr "Ferramentas OiRA disponíveis"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr "Países Candidatos"
 msgid "Candidate country"
 msgstr "Paísa candidato"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Alterar endereço de e-mail"
 
@@ -332,11 +332,11 @@ msgstr ""
 "Conteúdo: todas as informações e contributos que forneceu ao longo do "
 "processo de avaliação de riscos."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Contém: um quadro geral das medidas a implementar."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Contém: um quadro geral dos perigos identificados."
 
@@ -375,15 +375,15 @@ msgstr "Informação do país e  agrupamento para o cliente."
 msgid "Country manager"
 msgstr "Gestor de países"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Licença Genérica Creative Commons Atribuição -CompartilhaIgual 2.5"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licença Creative Commons "
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -441,15 +441,15 @@ msgstr "Descarregue o plano de ação"
 msgid "Download the full report"
 msgstr "Descarregue o relatório completo"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Descarregue o quadro geral das medidas"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Descarregue o quadro geral dos riscos"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "Correio eletrónico"
@@ -523,7 +523,7 @@ msgstr "Pasta"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formato: Excel (.xls);"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Formato: Portable Document Format (.pdf)"
 
@@ -531,7 +531,7 @@ msgstr "Formato: Portable Document Format (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Alemanha"
 
@@ -559,7 +559,7 @@ msgstr ""
 "Contudo, pode dedicar o seu tempo conforme as suas disponibilidades, podendo "
 "fazer interrupções e continuar a avaliação quando for mais conveniente."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Clique para seguir ligação"
 
@@ -575,8 +575,7 @@ msgstr ""
 msgid "Important"
 msgstr "Importante"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informação"
 
@@ -585,7 +584,7 @@ msgstr "Informação"
 msgid "Information"
 msgstr "Informação"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -620,11 +619,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "guardada"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Saiba mais sobre esta ferramenta…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -636,7 +635,7 @@ msgstr "Login"
 msgid "Manage"
 msgstr "A gestão"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Medida"
@@ -655,12 +654,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "acompanhar e avaliar se as medidas necessárias foram implementadas;"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Monitorizar as medidas a serem implementadas nos próximos 3 meses"
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Determinar se os riscos/as medidas são tratados devidamente."
 
@@ -787,12 +786,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Ajuda online"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Visão geral das medidas"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Visão geral dos riscos"
@@ -811,8 +812,8 @@ msgstr ""
 "técnicos de ST, …);"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Transmitir informações às pessoas interessadas."
 
@@ -843,9 +844,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Consulte os exemplos abaixo do formulário."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Adiado"
 
@@ -887,7 +888,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Saiba mais"
 
@@ -921,8 +922,8 @@ msgstr ""
 "já iniciada ou para realizar uma nova avaliação."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Remover"
 
@@ -943,11 +944,11 @@ msgstr "Risco"
 msgid "Risk assessments made with this tool"
 msgstr "Guarde e adicione outro risco"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Atenção"
 
@@ -1025,7 +1026,7 @@ msgstr "Partilhar este OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Mostrar biblioteca a partir de ${dropdown}"
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Iniciar sessão"
 
@@ -1041,6 +1042,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1095,7 +1100,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Países Baixos"
 
@@ -1114,7 +1119,7 @@ msgstr ""
 "A arquitetura de base de um instrumento interativo em linha de avaliação de "
 "risco consiste em:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1222,7 +1227,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Este instrumento merece ser conhecido em todo o mundo! Partilhe-o!"
 
@@ -1230,8 +1235,8 @@ msgstr "Este instrumento merece ser conhecido em todo o mundo! Partilhe-o!"
 msgid "Tip"
 msgstr "Dica"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Ativar a ajuda na tela"
 
@@ -1243,9 +1248,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Sem resposta"
 
@@ -1360,37 +1365,37 @@ msgid "Your password was successfully changed."
 msgstr "A palavra-passe foi alterada corretamente."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "O código fonte da aplicação OiRA está ${GPL} licenciada."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "O conteúdo das ferramentas sectoriais OiRA está licenciado sob uma ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 "As ferramentas sectoriais OiRA podem ser utilizadas gratuitamente por todos "
 "os utilizadores."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Mais informação sobre o projeto OiRA (em inglês)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Estratégia da Comunidade Europeia para a Sáude e Segurança no Trabalho "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "A experiência demonstra que ${key}. Por isso, EU-OSHA desenvolveu uma "
@@ -1401,50 +1406,50 @@ msgstr ""
 "termos de monitorização e ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "aplicação web gratuita e de fácil utilização"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "avaliação"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identificação"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "uma avaliação de riscos adequada é a chave para locais de trabalho saudáveis"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "ações preventivas"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "relatório"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "processo gradual de avaliação de riscos"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "A aplicação web OiRA permite acesso às ferramentas sectoriais de Avaliação "
 "de Riscos, criados e geridos pelas organizações sectoriais a nível nacional."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "A ${agency} evoca o desenvolvimento de ferramentas simples para facilitar a "
@@ -1457,7 +1462,7 @@ msgstr ""
 "por objetivo superar."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "O projeto OiRA e a respetiva aplicação web foi desenvolvido por ${eu-osha}, "
@@ -1469,14 +1474,14 @@ msgstr ""
 "FNV, CNV e MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Os seguintes parceiros técnicos contribuíram para o desenvolvimento do "
 "projeto OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "A agência recebeu igualmente aconselhamento estratégico e especializado por "
@@ -1485,12 +1490,12 @@ msgstr ""
 "nomeados pelos grupos de interesse no Conselho, pela Comissão e por EU-OSHA."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "as micro e pequenas empresas têm algumas limitações"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Apesar de algumas medidas serem gratuitas, a maioria não. As medidas devem "
@@ -1498,20 +1503,26 @@ msgstr ""
 "orçamental anual."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Designe alguém na sua empresa como responsável pela implementação desta "
 "medida. Esta pessoa terá autoridade para tomar os passos descritos no Plano "
 "e/ou responsabilidade para assegurar que os mesmos são executados."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descreva: 1) qual é a sua abordagem geral para eliminar ou (se o risco for "
 "inevitável) reduzir o risco; 2) a(s) ação(ões) específica(s) necessária(s) "
-"para implementar esta abordagem (para eliminar ou reduzir o risco); 3) o "
+"para implementar esta abordagem (para eliminar ou reduzir o risco)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Descreva: 3) o "
 "nível de competência necessário para implementar a medida, por exemplo "
 "\"senso comum (sem conhecimento necessário da SST)\", \"nenhuma competência "
 "da SST específica, mas conhecimento mínimo da SST ou formação e/ou consulta "
@@ -1577,7 +1588,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: declarações afirmativas, contidas em módulos."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Adicionar"
 
@@ -1625,7 +1636,7 @@ msgstr "Cancelar"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Fechar"
 
@@ -1957,7 +1968,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "A avaliação do risco foi efetuada automaticamente pela ferramenta. Poderá "
@@ -2011,7 +2022,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Após o desenvolvimento técnico da ferramenta em 2009, em 2010 (até ao "
@@ -2053,17 +2064,17 @@ msgid "effect_high"
 msgstr "Gravidade elevada (muito elevada)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Gravidade fraca"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Gravidade significativa"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Gravidade elevada (muito elevada)"
 
@@ -2138,7 +2149,7 @@ msgid "error_existing_login"
 msgstr "Este nome de login já existe."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Introduza o orçamento no seu todo em Euros."
 
@@ -2175,17 +2186,17 @@ msgid "error_password_mismatch"
 msgstr "As palavras-passe não correspondem"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr "Esta data deve ser igual ou posterior à data inicial."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr "Esta data deve ser igual ou anterior à data final."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Este valor deve ser um número inteiro positivo."
 
@@ -2296,7 +2307,7 @@ msgstr ""
 "continuar, é necessário atualizar estas alterações."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2305,12 +2316,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Plano de ação ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Relatório de identificação ${title}"
 
@@ -2330,7 +2341,7 @@ msgid "french"
 msgstr "Dois critérios simplificados"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Quase nunca"
 
@@ -2340,57 +2351,57 @@ msgid "frequency_almostnever"
 msgstr "Quase nunca"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Constantemente"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Não muito frequentemente"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Uma vez por mês"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Frequentemente"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Uma vez por semana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Rara"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Uma vez por ano"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Muito frequentemente ou regularmente"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "No mínimo uma vez por dia"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regularmente"
@@ -2417,12 +2428,12 @@ msgid "header_additional_content"
 msgstr "Conteúdo adicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Recursos adicionais para a avaliação do risco"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Recursos adicionais para este mòdulo"
 
@@ -2437,12 +2448,12 @@ msgid "header_country_managers"
 msgstr "Gestores de países"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Desenvolvimento e fase piloto – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Parceiros de desenvolvimento"
 
@@ -2479,18 +2490,18 @@ msgstr "Identificação"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informação"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Lançamento oficial do projeto – Setembro de 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Referências legais e normativas"
 
@@ -2500,13 +2511,13 @@ msgid "header_legend"
 msgstr "Legenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licenças"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Login"
@@ -2517,12 +2528,12 @@ msgid "header_main_image"
 msgstr "Imagem principal"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Medida ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Medida"
 
@@ -2548,12 +2559,12 @@ msgid "header_not_complicated"
 msgstr "A avaliação não é complicada"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2588,7 +2599,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2608,7 +2619,7 @@ msgid "header_profile_questions"
 msgstr "Perguntas de perfil"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Fases do projeto"
 
@@ -2624,7 +2635,7 @@ msgstr "Perguntas respondidas por módulo"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registe-se"
 
@@ -2645,23 +2656,23 @@ msgid "header_risk_aware"
 msgstr "Conhece todos os riscos?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Qual é a gravidade do dano?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Qual é a frequência de exposição a este risco?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Selecione a prioridade deste risco"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Qual é a probabilidade de ocorrência deste risco?"
 
@@ -2673,7 +2684,7 @@ msgid "header_risks"
 msgstr "Riscos"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2733,12 +2744,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2753,17 +2764,17 @@ msgid "header_welcome"
 msgstr "Bem-vindo"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "O que é o projeto OiRA (Online Interactive Risk Assessment)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Porquê o projeto OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Comentários"
 
@@ -2784,142 +2795,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Riscos de prioridade média"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} risco de prioridade alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} riscos de prioridade alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} riscos de prioridade alta"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} riscos de prioridade alta"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} risco de prioridade baixa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} riscos de prioridade baixa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} riscos de prioridade baixa"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} riscos de prioridade baixa"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} risco de prioridade média"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} riscos de prioridade média"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} riscos de prioridade média"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} riscos de prioridade média"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} riscos adiados"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} riscos adiados"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} riscos adiados"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} riscos adiados"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} riscos não respondidos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} riscos não respondidos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} riscos não respondidos"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} riscos não respondidos"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} Riscos Possíveis"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} Riscos Possíveis"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} Riscos Possíveis"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} Riscos Possíveis"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} Risco Presente"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} Riscos Presentes"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} Riscos Presentes"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} Riscos Presentes"
 
@@ -2939,7 +2950,7 @@ msgid "help_authentication"
 msgstr "Este texto deve explicar como efetuar o registo e o login."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Queira responder às perguntas que se seguem. Em função das suas respostas, o "
@@ -2967,7 +2978,7 @@ msgstr ""
 "começar com uma cópia de uma Ferramenta OiRA existente.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Indica a frequência de ocorrência do risco numa situação normal."
 
@@ -2979,12 +2990,12 @@ msgstr ""
 "ainda pode alterar a prioridade."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Indica a probabilidade de ocorrência deste risco numa siutação normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Indica a gravidade em caso de ocorrência do risco."
 
@@ -3076,6 +3087,11 @@ msgstr ""
 "Carregar uma imagem. Certifique-se de que a sua imagem está no formato png, "
 "jpg ou gif e que não contém carateres especiais."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3091,7 +3107,7 @@ msgstr ""
 "abordagem (para eliminar ou reduzir o risco)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Descreva o nível de competência necessário para implementar a medida, por "
@@ -3247,7 +3263,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Se não especificar um título, o mesmo será retirado da entrada."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3334,7 +3350,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "Sessão de teste"
 
@@ -3533,13 +3549,13 @@ msgstr "A conta está bloqueada"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Plano de Ação"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Orçamento"
 
@@ -3549,27 +3565,22 @@ msgid "label_action_plan_download"
 msgstr "Plano de Ação"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "A planear o fim"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Quem é o responsável?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "A planear o início"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Adicionar outra medida"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3612,8 +3623,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Queira por favor comentar a questão acima indicada. Estes comentários serão "
@@ -3700,7 +3711,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Descrição"
@@ -3730,7 +3741,7 @@ msgstr "Mostrar uma notificação personalizada para esta ferramenta OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Avaliação"
 
@@ -3750,10 +3761,19 @@ msgid "label_evaluation_phase"
 msgstr "Fase de avaliação"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Medida já executada"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3828,7 +3848,7 @@ msgstr "Realizar a sua avaliação de riscos"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identificação"
 
@@ -3836,6 +3856,11 @@ msgstr "Identificação"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Ficheiro de imagem"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3858,7 +3883,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Referências legais e políticas"
@@ -3893,21 +3918,26 @@ msgstr "Logótipo"
 msgid "label_logo_selection"
 msgstr "Qual é o logótipo que pretende mostrar no canto superior esquerdo?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Abordagem geral (para eliminar ou reduzir o risco)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Ação(ões) específica(s) necessária(s) para implementar esta abordagem"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Nível de competência e/ou requisitos necessários"
 
@@ -3963,25 +3993,25 @@ msgid "label_no"
 msgstr "Não"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Nenhum risco"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Nenhum risco"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Nenhum risco"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Nenhum risco"
@@ -4021,15 +4051,10 @@ msgstr "Palavra-passe"
 msgid "label_password_confirm"
 msgstr "Repetir a palavra-passe"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Sugestões"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Preparação"
 
@@ -4040,7 +4065,7 @@ msgstr "Pré-visualização"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Anterior"
@@ -4103,15 +4128,15 @@ msgstr "Pode descarregar um relatório completo e um plano de ação."
 msgid "label_register_first"
 msgstr "registe-se"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Apagar esta medida"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Relatório"
 
@@ -4121,12 +4146,12 @@ msgid "label_report_comment"
 msgstr "Queira por favor comentar a questão acima indicada."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4146,49 +4171,49 @@ msgid "label_risk_type"
 msgstr "Tipo de risco"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Risco com medida(s)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Risco sem medida"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Riscos com medida(s"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Riscos com medida(s"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Riscos com medida(s"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Riscos sem medida"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Riscos sem medida"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Riscos sem medida"
@@ -4201,7 +4226,7 @@ msgstr "Guarde e adicione outro risco"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Guardar e continuar"
 
@@ -4226,7 +4251,7 @@ msgid "label_sector_title"
 msgstr "Título do setor."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 "Selecione uma ou mais das medidas comuns conhecidas que foram fornecidas."
@@ -4257,7 +4282,7 @@ msgid "label_show_less_hellip"
 msgstr "Mostrar menos"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} sobre este risco."
 
@@ -4287,7 +4312,7 @@ msgid "label_start_identification"
 msgstr "Iniciar a identificação de perigos"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Iniciar"
 
@@ -4332,29 +4357,29 @@ msgid "label_surveygroup_title"
 msgstr "Título da Ferramenta OiRA importada"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Elevada"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Baixa"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Média"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Título"
 
@@ -4414,12 +4439,12 @@ msgid "label_user_title"
 msgstr "Nome"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 medidas)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(sem medidas)"
 
@@ -4466,7 +4491,7 @@ msgid "limitations"
 msgstr "limitações"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Login"
 
@@ -4556,7 +4581,7 @@ msgid "menu_import"
 msgstr "Importar a Ferramenta OiRA "
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4664,32 +4689,32 @@ msgid "nav_usermanagement"
 msgstr "Gestão de utilizadores"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Ajuda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Sair da sessão"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Definições"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Estado"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Minhas avaliações"
 
@@ -4739,27 +4764,27 @@ msgid "notice_country_manager"
 msgstr "Gestor de países para ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Avaliação de Riscos"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "interativa Online"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4779,7 +4804,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4791,7 +4816,7 @@ msgid "password_policy_conditions"
 msgstr "A sua palavra-passe para confirmação"
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "O lançamento oficial da ferramenta está marcado para Setembro de 2011, assim "
@@ -4822,45 +4847,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Elevada"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Baixa"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Média"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Elevada"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Média"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Pequena"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Completo"
 
@@ -4912,18 +4937,13 @@ msgstr "Não tem uma conta? Então ${register_link}, primeiro."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4935,7 +4955,7 @@ msgstr ""
 "Registe-se em apenas uma etapa e usufrua das seguintes vantagens:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4949,17 +4969,17 @@ msgstr ""
 "devem ser incluídos neste relatório no campo em baixo."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Este relatório teve por base a Ferramenta OiRA '${title}' da data de revisão "
@@ -4991,35 +5011,35 @@ msgid "request_an_email_reminder"
 msgstr "peça um lembrete de e-mail"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Este é um risco de prioridade ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "elevada"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "baixa"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "média"
 
@@ -5039,7 +5059,7 @@ msgid "risk_solution_header"
 msgstr "Medida ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Ainda é necessária a inventariação deste risco."
@@ -5087,46 +5107,46 @@ msgid "select_add_existing_measure"
 msgstr "Selecione ou adicione medidas já em vigor."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Não muito grave"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Necessidade de interromper o trabalho até 3 dias"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Grave"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Necessidade de interromper o trabalho mais de 3 dias"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Muito grave"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Lesões irreversíveis, doença incurável, morte"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Fraca"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Sem necessidade de interrupção do trabalho"
 
@@ -5198,7 +5218,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Sobre"
 
@@ -5213,7 +5233,7 @@ msgid "title_account_settings"
 msgstr "Definições de conta"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Mudar palavra-passe"
@@ -5224,7 +5244,7 @@ msgid "title_client_help"
 msgstr "Texto de ajuda para o cliente"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Medida"
 
@@ -5259,7 +5279,7 @@ msgid "title_import_sector_survey"
 msgstr "Importar setor e a Ferramenta OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Riscos adicionados (por si)"
@@ -5286,8 +5306,8 @@ msgstr "Estado do ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Online interactive Risk Assessment"
 
@@ -5312,19 +5332,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Estado do ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Conteúdos"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "O risco não está presente na sua organização, mas como a organização do "
@@ -5332,7 +5352,7 @@ msgstr ""
 "neste relatório."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "O risco não está presente na sua organização, mas como a organização do "
@@ -5340,7 +5360,7 @@ msgstr ""
 "neste relatório."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Este risco ainda não foi avaliado, mas como é considerado de “prioridade "
@@ -5369,7 +5389,7 @@ msgid "use_it_to_full_report"
 msgstr "Utilize-o para"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Utilize-o para"
 
@@ -5379,12 +5399,12 @@ msgid "use_it_to_measures_report"
 msgstr "Utilize-o para"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Utilize-o para"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Utilize-o para"
 
@@ -5399,7 +5419,7 @@ msgid "warn_fix_errors"
 msgstr "Elimine os erros indicados."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "A sua resposta foi negativa à declaração em cima."
@@ -5423,6 +5443,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sim"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Adicionar outra medida"
+
+#~ msgid "label_prefill"
+#~ msgstr "Sugestões"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "Nenhuma alteração foi feita ao seu plano de ação"

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 5.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -282,7 +282,8 @@ msgid ""
 "By cloning a risk assessment you will create a new risk assessment based on "
 "the contents of this risk assessment as a starting point."
 msgstr ""
-"Ao duplicar uma avaliação de riscos, criará uma nova avaliação de riscos com base no conteúdo da avaliação de riscos inicial."
+"Ao duplicar uma avaliação de riscos, criará uma nova avaliação de riscos com "
+"base no conteúdo da avaliação de riscos inicial."
 
 #: euphorie/client/browser/reset_password.py:185 euphorie/client/country.py:126
 #: euphorie/client/templates/account-delete.pt:29
@@ -669,7 +670,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -713,7 +714,7 @@ msgstr "Não"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1561,10 +1562,6 @@ msgstr "Sobre"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Elaborada por ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "baseada na"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4388,6 +4385,11 @@ msgstr "Média"
 msgid "label_title"
 msgstr "Título"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "baseada na ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4799,7 +4801,7 @@ msgid "optional"
 msgstr "Opcional"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5448,6 +5450,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Sim"
+
+#~ msgid "based on"
+#~ msgstr "baseada na"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Adicionar outra medida"

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -64,7 +64,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr ""
 
@@ -307,11 +307,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -348,15 +348,15 @@ msgstr ""
 msgid "Country manager"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -416,15 +416,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -545,8 +545,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -555,7 +554,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -587,11 +586,11 @@ msgstr ""
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Aflați mai multe despre acest instrument…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -603,7 +602,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -622,12 +621,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -744,12 +743,14 @@ msgstr ""
 msgid "Online help"
 msgstr ""
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -765,8 +766,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -791,9 +792,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr ""
 
@@ -830,7 +831,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -859,8 +860,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -881,11 +882,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr ""
 
@@ -960,7 +961,7 @@ msgstr "Distribuiți acest instrument OiRA"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -975,6 +976,10 @@ msgstr ""
 
 #: euphorie/content/upload.py:116
 msgid "Standard"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
 msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
@@ -1024,7 +1029,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr ""
 
@@ -1041,7 +1046,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1141,7 +1146,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Acest instrument merită să fie cunoscut în lume! Distribuiți-l!"
 
@@ -1149,8 +1154,8 @@ msgstr "Acest instrument merită să fie cunoscut în lume! Distribuiți-l!"
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1162,9 +1167,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1271,113 +1276,118 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr ""
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr ""
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr ""
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr ""
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr ""
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr ""
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr ""
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr ""
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr ""
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
+msgstr ""
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
 msgstr ""
 
 #. Default: "add a new OiRA Tool"
@@ -1437,7 +1447,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr ""
 
@@ -1485,7 +1495,7 @@ msgstr ""
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1753,7 +1763,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1800,7 +1810,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 
@@ -1834,17 +1844,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -1914,7 +1924,7 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr ""
 
@@ -1950,17 +1960,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2050,7 +2060,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2059,12 +2069,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr ""
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr ""
 
@@ -2084,7 +2094,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2094,57 +2104,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr ""
@@ -2165,12 +2175,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2185,12 +2195,12 @@ msgid "header_country_managers"
 msgstr ""
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr ""
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr ""
 
@@ -2226,18 +2236,18 @@ msgstr ""
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr ""
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr ""
 
@@ -2247,13 +2257,13 @@ msgid "header_legend"
 msgstr ""
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr ""
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr ""
@@ -2264,12 +2274,12 @@ msgid "header_main_image"
 msgstr ""
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr ""
 
@@ -2295,12 +2305,12 @@ msgid "header_not_complicated"
 msgstr ""
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2335,7 +2345,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2355,7 +2365,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr ""
 
@@ -2371,7 +2381,7 @@ msgstr ""
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr ""
 
@@ -2392,23 +2402,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2420,7 +2430,7 @@ msgid "header_risks"
 msgstr ""
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2480,12 +2490,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2500,17 +2510,17 @@ msgid "header_welcome"
 msgstr ""
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr ""
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2531,142 +2541,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2686,7 +2696,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2706,7 +2716,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2716,12 +2726,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -2811,6 +2821,11 @@ msgstr ""
 msgid "help_image_upload"
 msgstr ""
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2822,7 +2837,7 @@ msgid "help_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 
@@ -2944,7 +2959,7 @@ msgid "help_upload_surveygroup_title"
 msgstr ""
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3009,7 +3024,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3161,13 +3176,13 @@ msgstr ""
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr ""
 
@@ -3177,26 +3192,21 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
-msgstr ""
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
 msgstr ""
 
 #. Default: "Page content"
@@ -3240,8 +3250,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 
@@ -3326,7 +3336,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr ""
@@ -3356,7 +3366,7 @@ msgstr "Afișați o notificare personalizată în instrumentul OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr ""
 
@@ -3376,9 +3386,18 @@ msgid "label_evaluation_phase"
 msgstr ""
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3454,13 +3473,18 @@ msgstr ""
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr ""
 
 #. Default: "Image file"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
+msgstr ""
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
 msgstr ""
 
 #. Default: "Introduction text"
@@ -3484,7 +3508,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr ""
@@ -3519,21 +3543,26 @@ msgstr ""
 msgid "label_logo_selection"
 msgstr ""
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr ""
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr ""
 
@@ -3589,25 +3618,25 @@ msgid "label_no"
 msgstr ""
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3647,15 +3676,10 @@ msgstr ""
 msgid "label_password_confirm"
 msgstr ""
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr ""
 
@@ -3666,7 +3690,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3729,15 +3753,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr ""
 
@@ -3747,12 +3771,12 @@ msgid "label_report_comment"
 msgstr ""
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3772,49 +3796,49 @@ msgid "label_risk_type"
 msgstr ""
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -3827,7 +3851,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3852,7 +3876,7 @@ msgid "label_sector_title"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -3881,7 +3905,7 @@ msgid "label_show_less_hellip"
 msgstr "Mai puţine"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -3911,7 +3935,7 @@ msgid "label_start_identification"
 msgstr ""
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr ""
 
@@ -3956,29 +3980,29 @@ msgid "label_surveygroup_title"
 msgstr ""
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr ""
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr ""
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr ""
 
@@ -4038,12 +4062,12 @@ msgid "label_user_title"
 msgstr ""
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4088,7 +4112,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4169,7 +4193,7 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4269,32 +4293,32 @@ msgid "nav_usermanagement"
 msgstr ""
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr ""
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr ""
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr ""
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr ""
 
@@ -4344,27 +4368,27 @@ msgid "notice_country_manager"
 msgstr ""
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr ""
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr ""
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4384,7 +4408,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4396,7 +4420,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 
@@ -4422,45 +4446,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4509,18 +4533,13 @@ msgstr ""
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4530,7 +4549,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4540,17 +4559,17 @@ msgid "report_intro"
 msgstr ""
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 
@@ -4580,35 +4599,35 @@ msgid "request_an_email_reminder"
 msgstr ""
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr ""
 
@@ -4628,7 +4647,7 @@ msgid "risk_solution_header"
 msgstr ""
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr ""
@@ -4676,46 +4695,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4775,7 +4794,7 @@ msgid "titld_tool"
 msgstr ""
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr ""
 
@@ -4790,7 +4809,7 @@ msgid "title_account_settings"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -4801,7 +4820,7 @@ msgid "title_client_help"
 msgstr ""
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr ""
 
@@ -4836,7 +4855,7 @@ msgid "title_import_sector_survey"
 msgstr ""
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr ""
@@ -4863,8 +4882,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 
@@ -4889,29 +4908,29 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr ""
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 
@@ -4936,7 +4955,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -4946,12 +4965,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -4966,7 +4985,7 @@ msgid "warn_fix_errors"
 msgstr ""
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr ""

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -635,7 +635,7 @@ msgid "Montenegro"
 msgstr ""
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -679,7 +679,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1421,10 +1421,6 @@ msgstr ""
 #: euphorie/client/browser/templates/appendix.pt:16
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
-msgstr ""
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
 msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
@@ -4011,6 +4007,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4403,7 +4404,7 @@ msgid "optional"
 msgstr ""
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -554,7 +554,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1960,17 +1960,17 @@ msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2716,7 +2716,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr ""
 
@@ -2726,12 +2726,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3396,7 +3396,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr ""
@@ -3851,7 +3851,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -3892,6 +3892,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -576,7 +576,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informácie"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1103,7 +1103,7 @@ msgid ""
 msgstr ""
 "Základná architektúra Online interaktívneho hodnotenia rizika pozostáva z:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -2086,17 +2086,17 @@ msgid "error_password_mismatch"
 msgstr "Heslá sa nezhodujú"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 "existujúceho nástroja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Uveďte, ako často k tomuto riziku dochádza v normálnej situácii."
 
@@ -2880,14 +2880,14 @@ msgstr ""
 "môže zmeniť prioritu."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, aká je pravdepodobnosť vyskytnutia sa tohto rizika v normálnej "
 "situácii."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Uveďte závažnosť vyskytnutia sa tohto rizika."
 
@@ -3469,7 +3469,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3617,7 +3617,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr "Náhľad"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Predchádzajúci"
@@ -4076,7 +4076,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Uložiť a pokračovať"
 
@@ -4118,6 +4118,11 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} pre kontrolné orgány (inšpektorát práce)."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -264,7 +264,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr "Kandidátske krajiny"
 msgid "Candidate country"
 msgstr "Kandidátska krajina"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Zmeniť e-mailovú adresu"
 
@@ -328,11 +328,11 @@ msgstr ""
 "Obsahuje: všetky informácie a údaje, ktoré ste poskytli v procese hodnotenia "
 "rizika."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -369,15 +369,15 @@ msgstr "Informácie o krajine a zoskupenie pre klienta."
 msgid "Country manager"
 msgstr "Country manažér"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Licencia Creative Commons Attribution-ShareAlike 2.5 Generic"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licencia Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -435,15 +435,15 @@ msgstr "Stiahnite si plán činnosti"
 msgid "Download the full report"
 msgstr "Stiahnite si celú správu"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-mail"
@@ -517,7 +517,7 @@ msgstr "Priečinok"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Formát: Office Open XML Workbook (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Nemecko"
 
@@ -551,7 +551,7 @@ msgstr ""
 "sa môžete k hodnoteniu vrátiť, keď bude vhodné použiť rovnaké miesto, z "
 "ktorého ste odišli."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -567,8 +567,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -577,7 +576,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informácie"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -611,11 +610,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "uložené"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Prečítajte si viac informácií o tomto nástroji…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -627,7 +626,7 @@ msgstr "Prihlásiť"
 msgid "Manage"
 msgstr "Spravovať"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Opatrenie"
@@ -646,12 +645,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "Monitorujte a zhodnoťte, či boli zavedené potrebné opatrenia."
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -778,12 +777,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online pomoc"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -802,8 +803,8 @@ msgstr ""
 "práci, ...)"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -830,9 +831,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Pozrite si príklady pod formulárom."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Odložené"
 
@@ -873,7 +874,7 @@ msgstr "Poskytnutie dôkazov pre kontrolné orgány."
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -906,8 +907,8 @@ msgstr ""
 "predchádzajúcich hodnoteniach alebo začať nové hodnotenia."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Odstrániť"
 
@@ -928,11 +929,11 @@ msgstr "Riziko"
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Riziko nie je prítomné"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Riziko je prítomné"
 
@@ -1010,7 +1011,7 @@ msgstr "Zdieľajte tento OiRA-Tool"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -1026,6 +1027,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Štandardné"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1080,7 +1085,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Holandsko"
 
@@ -1098,7 +1103,7 @@ msgid ""
 msgstr ""
 "Základná architektúra Online interaktívneho hodnotenia rizika pozostáva z:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1205,7 +1210,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "O tomto nástroji by sa mal dozvedieť celý svet! Zdieľaj ho!"
 
@@ -1213,8 +1218,8 @@ msgstr "O tomto nástroji by sa mal dozvedieť celý svet! Zdieľaj ho!"
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1226,9 +1231,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Nenavštívené"
 
@@ -1342,35 +1347,35 @@ msgid "Your password was successfully changed."
 msgstr "Vaše heslo bolo úspešne zmenené."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Zdrojový kód aplikácie OiRA sa používa na základe licencie ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr ""
 "Obsah sektorových nástrojov OiRA sa používa na základe licencie ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "Sektorové nástroje OiRA môžu všetci používatelia používať bezplatne."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Ďalšie informácie o projekte OiRA (v angličtine)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr ""
 "Stratégia Európskeho spoločenstva pre bezpečnosť a ochranu zdravia pri práci "
 "2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Skúsenosť ukazuje ten ${key}. Preto agentúra EU-OSHA vyvinula ${easy} "
@@ -1378,98 +1383,103 @@ msgstr ""
 "rizík), ktorý"
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "ľahko použiteľná a bezplatná webová aplikácia"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "vyhodnotenie"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identifikácia"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "správne hodnotenie rizík je kľúčom k zdravým pracoviskám"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "preventívne akcie"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "spravodajstvo"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "proces hodnotenia rizík krok po kroku"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Webová aplikácia OiRA poskytuje prístup k sektorovým nástrojom na Hodnotenie "
 "rizík, vytvoreným a udržiavaným sektorovými organizáciami"
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} požaduje vývoj jednoduchých nástrojov, ktoré by uľahčili "
 "hodnotenie rizík. Od prijatia Európskeho rámca"
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Projekt OiRA a s ním súvisiacu webovú aplikáciu vyvinula agentúra ${eu-osha} "
 "na základe holandského RA-nástroja (nazývaného"
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "Nasledujúci technickí partneri prispeli k vývoju projektu OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Agentúra dostala aj  strategické a odborné rady od Riadiaceho výboru o "
 "vývoji a implementácii OiR"
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikro a malé podniky majú určité nedostatky"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Hoci niektoré opatrenia nestoja žiadne peniaze, väčšina stojí peniaze. Na "
 "opatrenia by sa mal preto pripraviť rozpočet; zaraďte ich do ročného"
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Určte niekoho vo vašej spoločnosti, kto bude zodpovedný za realizáciu tohto "
 "opatrenia. Táto osoba bude oprávnená"
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Opíšte: 1) aký je váš všeobecný prístup k odstráneniu alebo (ak sa riziku "
 "nedá vyhnúť) zníženiu rizika; 2)  konkrétnu akciu (akcie)"
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1530,7 +1540,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: pozitívne hodnotenia, ktoré sú uvedené v moduloch."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Uploadovať"
 
@@ -1578,7 +1588,7 @@ msgstr "Zrušiť"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1872,7 +1882,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1918,7 +1928,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Po technickom vývoji nástroja v r. 2009, v r. 2010 (až do prvej polovice "
@@ -1956,17 +1966,17 @@ msgid "effect_high"
 msgstr "Vysoká (veľmi vysoká) závažnosť"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Slabá závažnosť"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Významná závažnosť"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Vysoká (veľmi vysoká) závažnosť"
 
@@ -2040,7 +2050,7 @@ msgid "error_existing_login"
 msgstr "Toto prihlasovacie meno je už použité."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Uveďte prosím rozpočet v celých Eurách."
 
@@ -2076,17 +2086,17 @@ msgid "error_password_mismatch"
 msgstr "Heslá sa nezhodujú"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2194,7 +2204,7 @@ msgstr ""
 "stretnutia."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2203,12 +2213,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Akčný plán ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Správa o identifikácii ${title}"
 
@@ -2228,7 +2238,7 @@ msgid "french"
 msgstr "Zjednodušené dve kritériá"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Takmer nikdy"
 
@@ -2238,57 +2248,57 @@ msgid "frequency_almostnever"
 msgstr "Takmer nikdy"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Neustále"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Nie veľmi často"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Raz za mesiac"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Často"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Raz za týždeň"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Zriedka"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Raz za rok"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Veľmi často alebo pravidelne"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Minimálne raz za deň"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Pravidelne"
@@ -2311,12 +2321,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2331,12 +2341,12 @@ msgid "header_country_managers"
 msgstr "Country manažéri"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Vývojová a skúšobná fáza – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Vývojoví partneri"
 
@@ -2372,18 +2382,18 @@ msgstr "Identifikácia"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informácie"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Oficiálne spustenie projektu – september 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Právne a politické odkazy"
 
@@ -2393,13 +2403,13 @@ msgid "header_legend"
 msgstr "Legenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licencie"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prihlásenie"
@@ -2410,12 +2420,12 @@ msgid "header_main_image"
 msgstr "Hlavný obrázok"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Opatrenie ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Opatrenie"
 
@@ -2441,12 +2451,12 @@ msgid "header_not_complicated"
 msgstr "Posúdenie nie je komplikované"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2481,7 +2491,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2501,7 +2511,7 @@ msgid "header_profile_questions"
 msgstr "Otázky z profilu"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Fázy projektu"
 
@@ -2517,7 +2527,7 @@ msgstr "Zodpovedané otázky na jeden modul"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrácia"
 
@@ -2538,23 +2548,23 @@ msgid "header_risk_aware"
 msgstr "Ste si vedomí všetkých rizík?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Aká je závažnosť škody ?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Ako často sú ľudia vystavení tomuto riziku?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Zvoľte prioritu tohto rizika"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Aká je šanca vyskytnutia sa tohto rizika?"
 
@@ -2566,7 +2576,7 @@ msgid "header_risks"
 msgstr "Riziká"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2626,12 +2636,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2646,19 +2656,19 @@ msgid "header_welcome"
 msgstr "Vitajte"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr ""
 "Čo je projekt OiRA (Online Interactive Risk Assessment - Online interaktívne "
 "hodnotenie rizík)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Prečo projekt OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2679,142 +2689,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2834,7 +2844,7 @@ msgid "help_authentication"
 msgstr "Tento text by mal vysvetľovať, ako sa treba zaregistrovať a prihlásiť."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2858,7 +2868,7 @@ msgstr ""
 "existujúceho nástroja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Uveďte, ako často k tomuto riziku dochádza v normálnej situácii."
 
@@ -2870,14 +2880,14 @@ msgstr ""
 "môže zmeniť prioritu."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, aká je pravdepodobnosť vyskytnutia sa tohto rizika v normálnej "
 "situácii."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Uveďte závažnosť vyskytnutia sa tohto rizika."
 
@@ -2970,6 +2980,11 @@ msgstr ""
 "Uploadujte obrázok. Uistite sa, že obrázok je vo formáte png, jpg alebo gif "
 "a neobsahuje žiadne špeciálne znaky."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2985,7 +3000,7 @@ msgstr ""
 "(na odstránenie alebo zníženie rizika)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Opíšte: 1) aký je váš všeobecný prístup k odstráneniu alebo (ak sa riziku "
@@ -3132,7 +3147,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Ak neurčíte názov, prevezme sa zo vstupu."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3203,7 +3218,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3380,13 +3395,13 @@ msgstr "Konto je zablokované"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Akčný plán"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Rozpočet"
 
@@ -3396,27 +3411,22 @@ msgid "label_action_plan_download"
 msgstr "Akčný plán"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Plánovanie ukončenia"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Kto je zodpovedný?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Plánovanie spustenia"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Pridať ďalšie opatrenie"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3459,8 +3469,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Uveďte prosím prípadné komentáre k predchádzajúcej otázke v tomto poli. "
@@ -3547,7 +3557,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Popis"
@@ -3577,7 +3587,7 @@ msgstr "Zobraziť oznam pre používateľov tohto nástroja OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Vyhodnotenie"
 
@@ -3597,9 +3607,18 @@ msgid "label_evaluation_phase"
 msgstr "Fáza vyhodnotenia"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3675,7 +3694,7 @@ msgstr "Vykonanie hodnotenia rizika"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identifikácia"
 
@@ -3683,6 +3702,11 @@ msgstr "Identifikácia"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Súbor obrázka"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3705,7 +3729,7 @@ msgid "label_language"
 msgstr "Jazyk"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Právne a politické odkazy"
@@ -3740,21 +3764,26 @@ msgstr "Logo"
 msgid "label_logo_selection"
 msgstr "Ktoré logo by ste radi zobrazili v ľavom hornom rohu?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Všeobecný prístup (na odstránenie alebo zníženie rizika)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Konkrétna akcia (akcie) potrebná na realizáciu tohto prístupu"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Úroveň potrebnej odbornosti a/alebo požiadavky"
 
@@ -3812,25 +3841,25 @@ msgid "label_no"
 msgstr "Nie"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3870,15 +3899,10 @@ msgstr "Heslo"
 msgid "label_password_confirm"
 msgstr "Znovu heslo"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Príprava"
 
@@ -3889,7 +3913,7 @@ msgstr "Náhľad"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Predchádzajúci"
@@ -3952,15 +3976,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr "registrácia"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Vymazať toto opatrenie"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Správa"
 
@@ -3972,12 +3996,12 @@ msgstr ""
 "tomto poli."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3997,49 +4021,49 @@ msgid "label_risk_type"
 msgstr "Typ rizika"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -4052,7 +4076,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Uložiť a pokračovať"
 
@@ -4077,7 +4101,7 @@ msgid "label_sector_title"
 msgstr "Názov sektora."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Vyberte jedno alebo viac z uvedených známych spoločných opatrení."
 
@@ -4107,7 +4131,7 @@ msgid "label_show_less_hellip"
 msgstr "Zobraziť menej"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -4137,7 +4161,7 @@ msgid "label_start_identification"
 msgstr "Identifikácia počiatočného rizika"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Začať"
 
@@ -4182,29 +4206,29 @@ msgid "label_surveygroup_title"
 msgstr "Názov importovaného nástroja OiRA"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "vysoké"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "nízke"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "stredné"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Názov"
 
@@ -4264,12 +4288,12 @@ msgid "label_user_title"
 msgstr "Meno"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4316,7 +4340,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4399,7 +4423,7 @@ msgid "menu_import"
 msgstr "Importovať nástroj OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4506,32 +4530,32 @@ msgid "nav_usermanagement"
 msgstr "Riadenie používateľov"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Pomocník"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Odhlásenie"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Nastavenia"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Stav"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Stretnutia"
 
@@ -4581,27 +4605,27 @@ msgid "notice_country_manager"
 msgstr "Country manažér pre ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Online interaktívne"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Hodnotenie rizík"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4621,7 +4645,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4633,7 +4657,7 @@ msgid "password_policy_conditions"
 msgstr "Vaše heslo na potvrdenie"
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Oficiálne spustenie nástroja je plánované na september 2011, po dosiahnutí "
@@ -4661,45 +4685,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Vysoké"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Nízke"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Stredné"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Veľká"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Stredná"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Malá"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Dokončených"
 
@@ -4748,18 +4772,13 @@ msgstr "Nemáte konto? Tak sa prosím najprv ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4769,7 +4788,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4781,17 +4800,17 @@ msgstr ""
 "vytvorili akčný plán, môžete vytvoriť správu, ktorá"
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Táto správa bola založená na nástroji OiRA '${title}' s dátumom revízie "
@@ -4823,35 +4842,35 @@ msgid "request_an_email_reminder"
 msgstr "požiadajte o pripomienku e-mailom"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Toto je riziko s ${priority_value} prioritou."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "vysoké"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "nízke"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "stredné"
 
@@ -4871,7 +4890,7 @@ msgid "risk_solution_header"
 msgstr "Opatrenie ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Toto riziko je ešte potrebné katalogizovať."
@@ -4919,46 +4938,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Nie veľmi závažná"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Je potrebné zastaviť prácu na menej ako 3 dni"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Závažná"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Je potrebné zastaviť prácu na viac ako 3 dni"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Veľmi závažná"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "nevratné poranenie, nevyliečiteľná choroba, smrť"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Slabá"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Nie je potrebné zastaviť prácu"
 
@@ -5022,7 +5041,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Informácie"
 
@@ -5037,7 +5056,7 @@ msgid "title_account_settings"
 msgstr "Nastavenie konta"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -5048,7 +5067,7 @@ msgid "title_client_help"
 msgstr "Text nápovedy klienta"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Opatrenie"
 
@@ -5083,7 +5102,7 @@ msgid "title_import_sector_survey"
 msgstr "Importovať sektor a nástroj OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Chyba"
@@ -5110,8 +5129,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr ""
 "OiRA - Online interactive Risk Assessment (Online interaktívne hodnotenie "
@@ -5138,33 +5157,33 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Obsah"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Toto riziko sa nevyskytuje vo vašej organizácii, ale keďže sektorová "
 "organizácia ho považuje za jedno z prioritných rizík, musí byť"
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Toto riziko sa nevyskytuje vo vašej organizácii, ale keďže sektorová "
 "organizácia ho považuje za jedno z prioritných rizík, musí byť"
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Toto riziko sa nevyskytuje vo vašej organizácii, ale keďže sektorová "
@@ -5191,7 +5210,7 @@ msgid "use_it_to_full_report"
 msgstr "Použite ich na"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Použite ich na"
 
@@ -5201,12 +5220,12 @@ msgid "use_it_to_measures_report"
 msgstr "Použite ich na"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Použite ich na"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Použite ich na"
 
@@ -5221,7 +5240,7 @@ msgid "warn_fix_errors"
 msgstr "Napravte prosím uvedené chyby."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Na predchádzajúce vyhlásenie ste reagovali negatívne."
@@ -5244,6 +5263,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Áno"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Pridať ďalšie opatrenie"
 
 #~ msgid "Page ${number} of ${total}"
 #~ msgstr "Strana ${number} z ${total}"

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0syslab18\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -659,7 +659,7 @@ msgid "Montenegro"
 msgstr "Čierna Hora"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -703,7 +703,7 @@ msgstr "Nie"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1513,10 +1513,6 @@ msgstr "Informácie"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Vytvorila agentúra ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4237,6 +4233,11 @@ msgstr "stredné"
 msgid "label_title"
 msgstr "Názov"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4640,7 +4641,7 @@ msgid "optional"
 msgstr "Voliteľné"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr "${provide-evidence} nadzornim organom (inšpektoratu za delo)."
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Dodaj vsebino iz knjižnice"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -267,7 +267,7 @@ msgstr "Razpoložljiva OiRA orodja"
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr "Države kandidatke"
 msgid "Candidate country"
 msgstr "Država kandidatka"
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Spremeni e-poštni račun"
 
@@ -333,11 +333,11 @@ msgstr ""
 "Vsebuje vse vaše informacije in vnose, ki ste jih zagotovili med "
 "ocenjevanjem tveganja."
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr "Vključuje: pregled ukrepov, ki jih je treba izvesti."
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr "Vključuje: pregled opredeljenih tveganj."
 
@@ -376,15 +376,15 @@ msgstr "Informacije o državi in združevanje za odjemalca."
 msgid "Country manager"
 msgstr "Področni vodja"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Generična licenca Creative Commons Attribution-ShareAlike 2.5"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Licenca Creative Commons"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -444,15 +444,15 @@ msgstr "Prenos načrta ukrepov"
 msgid "Download the full report"
 msgstr "Prenos celotnega poročila"
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr "Prenesite pregled ukrepov"
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr "Prenesite pregled tveganj"
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-pošta"
@@ -526,7 +526,7 @@ msgstr "Mapa"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr "Format: Excel (.xlsx)"
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr "Oblika: dokument oblike PDF (.pdf)"
 
@@ -534,7 +534,7 @@ msgstr "Oblika: dokument oblike PDF (.pdf)"
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Nemčija"
 
@@ -561,7 +561,7 @@ msgstr ""
 "Vendar pa si lahko za oceno vzamete toliko časa kot ga imate na voljo in se "
 "kasneje vrnete in nadaljujete, kjer ste prekinili."
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr "Z vami želim deliti naslednje"
 
@@ -577,8 +577,7 @@ msgstr ""
 msgid "Important"
 msgstr "Pomembno"
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr "Informacije"
 
@@ -587,7 +586,7 @@ msgstr "Informacije"
 msgid "Information"
 msgstr "Informacije"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Napačen format slike. Prosim, uporabi PNG, JPEG ali GIF."
 
@@ -621,11 +620,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr "shranjeno"
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr "Preberite več o tem orodju…"
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -637,7 +636,7 @@ msgstr "Prijava"
 msgid "Manage"
 msgstr "Obvladovanje"
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Ukrep"
@@ -656,12 +655,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr "Spremljanje in ocenjevanje, ali so bili uvedeni potrebni ukrepi;"
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr "Spremljanje ukrepov, ki se bodo izvajali v naslednjih 3 mesecih"
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr "Spremljajte, ali se tveganja/ukrepi ustrezno obravnavajo."
 
@@ -790,12 +789,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Spletna pomoč"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr "Pregled ukrepov"
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr "Pregled tveganj"
@@ -814,8 +815,8 @@ msgstr ""
 "delu itd.);"
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr "Posredovanje informacij zadevnim osebam"
 
@@ -846,9 +847,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr "Oglejte si primere pod obrazcem."
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "Preloženo"
 
@@ -889,7 +890,7 @@ msgstr "Predložitev dokazil nadzornim organom;"
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr "Več informacij"
 
@@ -922,8 +923,8 @@ msgstr ""
 "s prejšnjo oceno ali začnete novo."
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr "Odstrani"
 
@@ -944,11 +945,11 @@ msgstr "Tveganje"
 msgid "Risk assessments made with this tool"
 msgstr "Ocene tveganja, opravljene s tem orodjem"
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr "Urejeno"
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Neurejeno"
 
@@ -1026,7 +1027,7 @@ msgstr "Seznanite druge s tem orodjem OiRA"
 msgid "Show library from ${dropdown}."
 msgstr "Pokaži knjižnico iz ${dropdown}."
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr "Vpišite se"
 
@@ -1042,6 +1043,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standardno"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1096,7 +1101,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nizozemska"
 
@@ -1113,7 +1118,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "V osnovi spletno interaktivno oceno tveganja sestavljajo:"
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1220,7 +1225,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "To orodje si zasluži vsesplošno prepoznavnost! Delite ga!"
 
@@ -1228,8 +1233,8 @@ msgstr "To orodje si zasluži vsesplošno prepoznavnost! Delite ga!"
 msgid "Tip"
 msgstr "Namig"
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr "Preklopi na pomoč na zaslonu"
 
@@ -1241,9 +1246,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr "Neodgovorjeno"
 
@@ -1361,32 +1366,32 @@ msgid "Your password was successfully changed."
 msgstr "Vaše geslo je bilo uspešno spremenjeno."
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "Izvorna koda aplikacije OiRA je licencirana pod ${GPL}."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "Vsebina orodij OiRA je licencirana pod ${license}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "Vsi uporabniki lahko brezplačno uporabljajo orodja OiRA."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Več informacij o projektu OiRA (v angleščini)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr "Strategija Evropske skupnosti o zdravju in varnosti pri delu 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Izkušnje so pokazale, da ${key}. Zato je EU-OSHA razvil ${easy} (“OiRA” - "
@@ -1396,42 +1401,42 @@ msgstr ""
 "${preventive_actions} in ukrepanjem, nadziranjem in ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "enostavna za uporabo in brezplačna spletna aplikacija"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "ocena"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identifikacija"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr "ustrezno ocenjevanje tveganja je ključnega za zdrava delovna mesta"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "preventivni ukrepi"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "poročanje"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "postopek ocenjevanja tveganja korak za korakom"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Spletna aplikacija OiRA omogoča dostop do sektorskih orodij za oceno "
@@ -1439,7 +1444,7 @@ msgstr ""
 "državni ravni."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${agency} poziva k razvoju enostavnih orodij za pomoč pri ocenjevanju "
@@ -1451,7 +1456,7 @@ msgstr ""
 "prizadeva doseči to, kar si projekt OiRA prizadeva premagati."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "Projekt OiRA in njegovo spletno aplikacijo je razvil ${eu-osha} na osnovi "
@@ -1462,12 +1467,12 @@ msgstr ""
 "prispevek in udeležba sindikatov FNV, CNV in MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr "Naslednji tehnični partnerji so prispevali k razvoju projekta OiRA:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Agencija, ki je prejela tudi strateške in strokovne nasvete od usmerjevalne "
@@ -1475,32 +1480,38 @@ msgstr ""
 "komisija in EU-OSHA so določili člane in namestnike usmerjevalne komisije."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikro in majhna podjetja imajo nekaj primanjkljajev"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Čeprav nekateri ukrepi nič ne stanejo, jih večina stane. Zato je treba imeti "
 "zanje zagotovljena sredstva; po potrebi jih vključite v letni proračun."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Določite nekoga v vašem podjetju, ki bo odgovoren za izvajanje tega ukrepa. "
 "Ta oseba bo imela pooblastila za izvajanje korakov, opisanih v Načrtu "
 "ukrepov in/ali bo odgovorna za njihovo izvajanje."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Opišite: 1) kakšen je vaš splošni pristop, da odpravite ali (če se tveganju "
 "ni mogoče izogniti) zmanjšate tveganje; 2) specifična dejanja, potrebna za "
-"izvajanje tega pristopa (da odpravite ali zmanjšate tveganje); 3) raven "
+"izvajanje tega pristopa (da odpravite ali zmanjšate tveganje)."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
+"Opišite: 3) raven "
 "strokovnosti, potrebna za izvajanje ukrepa, npr. \"zdrava pamet (znanje OSH "
 "ni potrebno)\", \"specifično strokovno znanje OSH ni potrebno, vendar je "
 "potrebno minimalno poznavanje OSH ali usposabljanje in/ali posvetovanje o "
@@ -1564,7 +1575,7 @@ msgid "bullet_risks"
 msgstr "${Tveganja}: pozitivne izjave, ki jih vsebujejo moduli."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Dodaj"
 
@@ -1612,7 +1623,7 @@ msgstr "Prekliči"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr "Zapri"
 
@@ -1933,7 +1944,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 "Orodje je samodejno izvedlo oceno tveganja. Prednostno razvrstitev za to "
@@ -1986,7 +1997,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Po tehničnem razvoju orodja v letih 2009 in 2010 (do prve polovice 2011) "
@@ -2027,17 +2038,17 @@ msgid "effect_high"
 msgstr "Velika (zelo velika) resnost"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Nizka"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Znatna"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Visoka (zelo visoka)"
 
@@ -2112,7 +2123,7 @@ msgid "error_existing_login"
 msgstr "To uporabniško ime je že zasedeno."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Vnesite proračun v evrih brez decimalk."
 
@@ -2148,20 +2159,20 @@ msgid "error_password_mismatch"
 msgstr "Gesli se ne ujemata"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 "Ta datum mora biti enak začetnemu datumu oziroma mora biti poznejši od njega."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 "Ta datum mora biti enak končnemu datumu oziroma ne sme biti poznejši od "
 "njega."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr "Ta vrednost mora biti pozitivno celo število."
 
@@ -2270,7 +2281,7 @@ msgstr ""
 "spremembe, narejene v orodju OiRA, združene v vašo sejo."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2279,12 +2290,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Identifikacijsko poročilo ${title}"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Identifikacijsko poročilo ${title}"
 
@@ -2304,7 +2315,7 @@ msgid "french"
 msgstr "Poenostavljena dva kriterija"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Skoraj nikoli"
 
@@ -2314,57 +2325,57 @@ msgid "frequency_almostnever"
 msgstr "Skoraj nikoli"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Nenehno"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr "Ne zelo pogosto"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr "Enkrat mesečno"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr "Pogosto"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Enkrat tedensko"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr "Redko"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Enkrat letno"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr "Zelo pogosto ali redno"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Najmanj enkrat dnevno"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Redno"
@@ -2391,12 +2402,12 @@ msgid "header_additional_content"
 msgstr "Dodatna vsebina"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr "Dodatni viri za ocenjevanje tveganja"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr "Dodatni viri za ta modul"
 
@@ -2411,12 +2422,12 @@ msgid "header_country_managers"
 msgstr "Področni vodje"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Razvojna in preizkusna faza – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Partnerji za razvoj"
 
@@ -2453,18 +2464,18 @@ msgstr "Identifikacija"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Informacije"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Uradno lansiranje projekta – september 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Zakonodaja in drugi viri"
 
@@ -2474,13 +2485,13 @@ msgid "header_legend"
 msgstr "Legenda"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licence"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Prijava"
@@ -2491,12 +2502,12 @@ msgid "header_main_image"
 msgstr "Glavna slika"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Ukrep ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Ukrep"
 
@@ -2522,12 +2533,12 @@ msgid "header_not_complicated"
 msgstr "Ocenjevanje tveganja ni zapleteno"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2562,7 +2573,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2582,7 +2593,7 @@ msgid "header_profile_questions"
 msgstr "vprašanja o profilu"
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Faze projekta"
 
@@ -2598,7 +2609,7 @@ msgstr "Odgovorjena vprašanja na modul"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registriraj se"
 
@@ -2619,23 +2630,23 @@ msgid "header_risk_aware"
 msgstr "Ali se zavedate vseh tveganj?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Resnost"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Pogostost"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Prioriteta"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Verjetnost"
 
@@ -2647,7 +2658,7 @@ msgid "header_risks"
 msgstr "Tveganja"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2707,12 +2718,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2727,17 +2738,17 @@ msgid "header_welcome"
 msgstr "Dobrodošli"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Kaj je projekt OiRA (spletno interaktivno orodje za oceno tveganja)"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Zakaj projekt OiRA"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr "Opombe"
 
@@ -2758,142 +2769,142 @@ msgid "heading_medium_prio_risks"
 msgstr "Tveganja srednje prioritete"
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr "${num_high_risks} tveganje visoke prioritete"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr "${num_high_risks} tveganji visoke prioritete"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr "${num_high_risks} tveganja visoke prioritete"
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr "${num_high_risks} tveganj visoke prioritete"
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr "${num_low_risks} tveganje nizke prioritete"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr "${num_low_risks} tveganji nizke prioritete"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr "${num_low_risks} tveganja nizke prioritete"
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr "${num_low_risks} tveganj nizke prioritete"
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr "${num_medium_risks} tveganje srednje prioritete"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr "${num_medium_risks} tveganji srednje prioritete"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr "${num_medium_risks} tveganja srednje prioritete"
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr "${num_medium_risks} tveganj srednje prioritete"
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr "${num_postponed_risks} preloženo tveganje"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr "${num_postponed_risks} preloženi tveganji"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr "${num_postponed_risks} preložena tveganja"
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr "${num_postponed_risks} preloženih tveganj"
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr "${num_todo_risks} neodgovorjeno tveganje"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr "${num_todo_risks} neodgovorjeni tveganji"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr "${num_todo_risks} neodgovorjena tveganja"
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr "${num_todo_risks} neodgovorjenih tveganj"
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr "${num_possible_risks} možno tveganje"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr "${num_possible_risks} možni tveganji"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr "${num_possible_risks} možna tveganja"
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr "${num_possible_risks} možnih tveganj"
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr "${num_present_risks} prisotno tveganje"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr "${num_present_risks} prisotnih tveganji"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr "${num_present_risks} prisotnih tveganja"
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr "${num_present_risks} prisotnih tveganj"
 
@@ -2913,7 +2924,7 @@ msgid "help_authentication"
 msgstr "To besedilo mora pojasniti, kako se registrirati in prijaviti."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 "Odgovorite na naslednja vprašanja. Sistem bo na podlagi vaših odgovorov "
@@ -2940,7 +2951,7 @@ msgstr ""
 "obstoječega orodja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Označite, kako pogosto se to tveganje pojavi v običajni situaciji."
 
@@ -2952,13 +2963,13 @@ msgstr ""
 "Svojo prioriteto bo še vedno lahko spremenil/a."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Označite verjetnost, da bi se to tveganje pojavilo v običajni situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Označite stopnjo resnosti, če se to tveganje pojavi."
 
@@ -3050,6 +3061,11 @@ msgstr ""
 "Naložite sliko. Zagotovite, da je formata png, jpg ali gif in da ne vsebuje "
 "posebnih znakov."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -3065,7 +3081,7 @@ msgstr ""
 "preprečite ali zmanjšate tveganje)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Opišite raven strokovnosti, potrebna za izvajanje ukrepa, npr. \"zdrava "
@@ -3215,7 +3231,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Če ne specificirate naslova, bo uporabljen iz vnosa."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3296,7 +3312,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr "To je poskusna seja"
 
@@ -3487,13 +3503,13 @@ msgstr "Račun je zaklenjen"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Načrt ukrepov"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Potrebna sredstva"
 
@@ -3503,27 +3519,22 @@ msgid "label_action_plan_download"
 msgstr "Načrt ukrepov"
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Načrtovani zaključek"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Kdo je odgovoren?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Načrtovani začetek"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr "Dodaj nov ukrep"
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3566,8 +3577,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "V to polje vnesite vse morebitne opombe glede zgoraj navedenega, "
@@ -3654,7 +3665,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Opis"
@@ -3684,7 +3695,7 @@ msgstr "Prikažem obvestilo po meri za to orodje OiRA?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Ocena"
 
@@ -3704,10 +3715,19 @@ msgid "label_evaluation_phase"
 msgstr "Faza ocenjevanja"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
 msgstr "Že izveden ukrep"
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
+msgstr ""
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -3782,7 +3802,7 @@ msgstr "Izvajanje ocene tveganja"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identifikacija"
 
@@ -3790,6 +3810,11 @@ msgstr "Identifikacija"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Slikovna datoteka"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3812,7 +3837,7 @@ msgid "label_language"
 msgstr "Jezik"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Zakonodaja in drugi viri"
@@ -3847,21 +3872,26 @@ msgstr "Logotip"
 msgid "label_logo_selection"
 msgstr "Kater logotip želite, da je prikazan v zgornjem levem kotu?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Splošni pristop (za odpravo ali zmanjšanje tveganja)"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Specifični ukrepi, potrebni za izvajanje tega pristopa"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Raven potrebne strokovnosti in/ali zahteve"
 
@@ -3919,25 +3949,25 @@ msgid "label_no"
 msgstr "Ne"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr "Tveganje ni"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr "Tveganji ni"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr "Tveganja ni"
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr "Tveganj ni"
@@ -3977,15 +4007,10 @@ msgstr "Prijava"
 msgid "label_password_confirm"
 msgstr "Ponovno geslo"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr "Izberite ukrep"
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Priprava"
 
@@ -3996,7 +4021,7 @@ msgstr "Predogled"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Nazaj"
@@ -4059,15 +4084,15 @@ msgstr "Prenesete lahko celotno poročilo in akcijski načrt."
 msgid "label_register_first"
 msgstr "registrirajte"
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr "Izbrišite ta ukrep"
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Poročilo"
 
@@ -4079,12 +4104,12 @@ msgstr ""
 "identificiranega tveganja."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -4104,49 +4129,49 @@ msgid "label_risk_type"
 msgstr "Vrsta tveganja"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr "Tveganje z ukrepom(-i)"
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr "Tveganje brez ukrepa"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr "Tveganji z ukrepom(-i)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr "Tveganja z ukrepom(-i)"
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr "Tveganj z ukrepom(-i)"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr "Tveganji brez ukrepa"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr "Tveganja brez ukrepa"
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr "Tveganj brez ukrepa"
@@ -4159,7 +4184,7 @@ msgstr "Shrani in dodaj drugo tveganje"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr "Shrani in nadaljuj"
 
@@ -4184,7 +4209,7 @@ msgid "label_sector_title"
 msgstr "Naslov sektorja."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr "Izberite enega ali več znanih splošnih ukrepov."
 
@@ -4214,7 +4239,7 @@ msgid "label_show_less_hellip"
 msgstr "Prikaži manj"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr "${read_more} o tem tveganju."
 
@@ -4244,7 +4269,7 @@ msgid "label_start_identification"
 msgstr "Začni z identifikacijo tveganj"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Začni"
 
@@ -4289,29 +4314,29 @@ msgid "label_surveygroup_title"
 msgstr "Naslov uvoženega orodja OiRA"
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "visoka"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "nizka"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "srednja"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Naslov"
 
@@ -4371,12 +4396,12 @@ msgid "label_user_title"
 msgstr "Ime"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr "(≥1 ukrep)"
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr "(brez ukrepov)"
 
@@ -4423,7 +4448,7 @@ msgid "limitations"
 msgstr "omejitve"
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr "Prijava"
 
@@ -4513,7 +4538,7 @@ msgid "menu_import"
 msgstr "Uvozi orodje OiRA"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4617,32 +4642,32 @@ msgid "nav_usermanagement"
 msgstr "Upravljanje uporabnikov"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Pomoč"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Odjava"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Nastavitve"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Status"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Moje ocene"
 
@@ -4692,27 +4717,27 @@ msgid "notice_country_manager"
 msgstr "Področni vodja za ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Spletno interaktivno"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "orodje"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4732,7 +4757,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4746,7 +4771,7 @@ msgstr ""
 "capital letter, one number and one special character (e.g. $, # or @)."
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Uradno lansiranje orodja je bilo načrtovano za september 2011, ko bodo "
@@ -4775,45 +4800,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Visoka"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Nizka"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Srednja"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Velika"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Srednja"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Majhna"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Dokončano"
 
@@ -4865,18 +4890,13 @@ msgstr "Nimate računa? Potem se najprej ${register_link}."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4888,7 +4908,7 @@ msgstr ""
 "uporabljati. Registrirajte se v enem koraku in pridobite naslednje koristi:"
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4901,17 +4921,17 @@ msgstr ""
 "rezultate in predloge."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "To poročilo je bilo zasnovano na orodju OiRA '${title}' z datumom revizije "
@@ -4943,35 +4963,35 @@ msgid "request_an_email_reminder"
 msgstr "zahtevaj e-poštni opomnik"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "To je tveganje s prioriteto ${priority_value}."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "visoka"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "nizka"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "srednja"
 
@@ -4991,7 +5011,7 @@ msgid "risk_solution_header"
 msgstr "Ukrep ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Tveganje je še vedno treba inventarizirati."
@@ -5039,46 +5059,46 @@ msgid "select_add_existing_measure"
 msgstr "Izberi ali dodaj ukrepe, ki so že vzpostavljeni."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr "Ni zelo resna"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr "Ne more delati manj kot 3 dni"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr "Resna"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr "Dlje kot 3 dni ne more delati"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr "Zelo resna"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr "Nepopravljive poškodbe, neozdravljiva bolezen, smrt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr "Nizka"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr "Ne rabi prenehati z delom"
 
@@ -5150,7 +5170,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Vizitka"
 
@@ -5165,7 +5185,7 @@ msgid "title_account_settings"
 msgstr "Nastavitve računa"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr "Spremeni geslo"
@@ -5176,7 +5196,7 @@ msgid "title_client_help"
 msgstr "Besedilo za pomoč odjemalca"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Ukrep"
 
@@ -5211,7 +5231,7 @@ msgid "title_import_sector_survey"
 msgstr "Uvozi sektor in orodje OiRA"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Vaša dodana tveganja"
@@ -5238,8 +5258,8 @@ msgstr "Stanje ${survey_title}"
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA - Spletno interaktivno orodje za oceno tveganja"
 
@@ -5264,19 +5284,19 @@ msgid "title_with_vowel_status_of"
 msgstr "Stanje ${survey_title}"
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Vsebina"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "To tveganje je prisotno v vaši ogranizaciji, ker pa sektorska organizacija "
@@ -5284,7 +5304,7 @@ msgstr ""
 "to poročilo."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "To tveganje je prisotno v vaši ogranizaciji, ker pa sektorska organizacija "
@@ -5292,7 +5312,7 @@ msgstr ""
 "to poročilo."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "To tveganje še ni bilo ocenjeno, ker pa ga razvijalci orodij OiRA ocenjujejo "
@@ -5320,7 +5340,7 @@ msgid "use_it_to_full_report"
 msgstr "Uporabite ga za"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr "Uporabite ga za"
 
@@ -5330,12 +5350,12 @@ msgid "use_it_to_measures_report"
 msgstr "Uporabite ga za"
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr "Uporabite ga za"
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr "Uporabite ga za"
 
@@ -5350,7 +5370,7 @@ msgid "warn_fix_errors"
 msgstr "Popravite označene napake."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Na zgornjo izjavo ste odgovorili negativno."
@@ -5374,6 +5394,12 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Da"
+
+#~ msgid "label_add_measure"
+#~ msgstr "Dodaj nov ukrep"
+
+#~ msgid "label_prefill"
+#~ msgstr "Izberite ukrep"
 
 #~ msgid "No changes were made to measures in your action plan."
 #~ msgstr "V vaš načrt ukrepov ni bila vnešena nobena sprememba."

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -669,7 +669,7 @@ msgid "Montenegro"
 msgstr "Črna Gora"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -713,7 +713,7 @@ msgstr "Ne"
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1549,10 +1549,6 @@ msgstr "Vizitka"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Izdelal ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr "na podlagi"
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4344,6 +4340,11 @@ msgstr "srednja"
 msgid "label_title"
 msgstr "Naslov"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr "na podlagi ${tool_title}"
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4751,7 +4752,7 @@ msgid "optional"
 msgstr "Poljubno"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 
@@ -5398,6 +5399,9 @@ msgstr ""
 #: euphorie/content/templates/risk_view.pt:44
 msgid "yes"
 msgstr "Da"
+
+#~ msgid "based on"
+#~ msgstr "na podlagi"
 
 #~ msgid "label_add_measure"
 #~ msgstr "Dodaj nov ukrep"

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 3.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -358,7 +358,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/module_identification_custom.pt:39
 msgid "Continue to action plan"
-msgstr "Nadaljuj na akcijski načrt"
+msgstr "Nadaljuj na načrt ukrepov"
 
 #: euphorie/content/profiles/default/types/euphorie.country.xml
 msgid "Country"
@@ -586,7 +586,7 @@ msgstr "Informacije"
 msgid "Information"
 msgstr "Informacije"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Napačen format slike. Prosim, uporabi PNG, JPEG ali GIF."
 
@@ -1046,7 +1046,7 @@ msgstr "Standardno"
 
 #: euphorie/client/browser/templates/risk_actionplan.pt:126
 msgid "Standard measures"
-msgstr ""
+msgstr "Predlagani ukrepi"
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1118,7 +1118,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "V osnovi spletno interaktivno oceno tveganja sestavljajo:"
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1511,12 +1511,11 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_actionplan.pt:349
 msgid "actionplan_requirements_tooltip"
 msgstr ""
-"Opišite: 3) raven "
-"strokovnosti, potrebna za izvajanje ukrepa, npr. \"zdrava pamet (znanje OSH "
-"ni potrebno)\", \"specifično strokovno znanje OSH ni potrebno, vendar je "
-"potrebno minimalno poznavanje OSH ali usposabljanje in/ali posvetovanje o "
-"smernicah OSH\" ali \"strokovnjak za OSH\". Tukaj lahko opišete tudi "
-"morebitne druge dodatne zahteve (če obstajajo)."
+"Opišite: 3) raven strokovnosti, potrebna za izvajanje ukrepa, npr. \"zdrava "
+"pamet (znanje OSH ni potrebno)\", \"specifično strokovno znanje OSH ni "
+"potrebno, vendar je potrebno minimalno poznavanje OSH ali usposabljanje in/"
+"ali posvetovanje o smernicah OSH\" ali \"strokovnjak za OSH\". Tukaj lahko "
+"opišete tudi morebitne druge dodatne zahteve (če obstajajo)."
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -2159,20 +2158,20 @@ msgid "error_password_mismatch"
 msgstr "Gesli se ne ujemata"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 "Ta datum mora biti enak začetnemu datumu oziroma mora biti poznejši od njega."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 "Ta datum mora biti enak končnemu datumu oziroma ne sme biti poznejši od "
 "njega."
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr "Ta vrednost mora biti pozitivno celo število."
 
@@ -2951,7 +2950,7 @@ msgstr ""
 "obstoječega orodja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Označite, kako pogosto se to tveganje pojavi v običajni situaciji."
 
@@ -2963,13 +2962,13 @@ msgstr ""
 "Svojo prioriteto bo še vedno lahko spremenil/a."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr ""
 "Označite verjetnost, da bi se to tveganje pojavilo v običajni situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Označite stopnjo resnosti, če se to tveganje pojavi."
 
@@ -3577,7 +3576,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3725,9 +3724,9 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
-msgstr ""
+msgstr "Vaš dodan ukrep"
 
 #. Default: "Content file"
 #: euphorie/content/module.py:110 euphorie/content/risk.py:286
@@ -4021,7 +4020,7 @@ msgstr "Predogled"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Nazaj"
@@ -4184,7 +4183,7 @@ msgstr "Shrani in dodaj drugo tveganje"
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr "Shrani in nadaljuj"
 
@@ -4227,6 +4226,11 @@ msgstr ""
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
 msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
+msgstr "Izberite ukrep(e)"
 
 #. Default: "Enter a title for your Risk Assessment"
 #: euphorie/client/browser/session.py:73

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-12 09:41+0000\n"
+"POT-Creation-Date: 2020-05-12 10:50+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -636,7 +636,7 @@ msgid "Montenegro"
 msgstr "Montenegro"
 
 #: euphorie/client/browser/templates/portlet-my-ras.pt:92
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:151
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:152
 #: euphorie/client/browser/templates/tool_sessions.pt:62
 msgid "More"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 msgid "No information about the last editor is available."
 msgstr ""
 
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:160
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:161
 msgid "No risk assessments are available for this selection."
 msgstr ""
 
@@ -1470,10 +1470,6 @@ msgstr "Om"
 #: euphorie/content/templates/colour-preview.pt:62
 msgid "appendix_produced_by"
 msgstr "Producerad av ${EU-OSHA}."
-
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:143
-msgid "based on"
-msgstr ""
 
 #: euphorie/client/browser/templates/new-session-test.pt:72
 msgid "benefits"
@@ -4201,6 +4197,11 @@ msgstr "Medium"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "based on ${tool_title}"
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:144
+msgid "label_tool_based_on"
+msgstr ""
+
 #. Default: "Tool notification message"
 #: euphorie/content/survey.py:140
 msgid "label_tool_notification"
@@ -4599,7 +4600,7 @@ msgid "optional"
 msgstr "Tillval"
 
 #. Default: "No risk assessments were found for this selection."
-#: euphorie/client/browser/templates/session-browser-sidebar.pt:166
+#: euphorie/client/browser/templates/session-browser-sidebar.pt:167
 msgid "osc_search_no_results_for_search"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 12:21+0000\n"
+"POT-Creation-Date: 2020-04-28 07:30+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -63,7 +63,7 @@ msgstr ""
 msgid "${provide-evidence} for supervisory authorities (labour inspectorate)."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:476
+#: euphorie/client/browser/templates/webhelpers.pt:305
 msgid "${view/description_probability}"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:144
+#: euphorie/client/browser/templates/risk_actionplan.pt:311
 msgid "Additional Measure"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:863
+#: euphorie/client/browser/risk.py:906
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:21
 msgid "Browse risk assessments"
 msgstr ""
 
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Candidate country"
 msgstr ""
 
-#: euphorie/client/browser/templates/user-menu.pt:44
+#: euphorie/client/browser/templates/user-menu.pt:46
 msgid "Change email address"
 msgstr "Okänd e-postadress"
 
@@ -310,11 +310,11 @@ msgid ""
 "assessment process."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:177
+#: euphorie/client/templates/report_landing.pt:175
 msgid "Contains: an overview of the measures to be implemented."
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:148
+#: euphorie/client/templates/report_landing.pt:147
 msgid "Contains: an overview of the risks identified"
 msgstr ""
 
@@ -351,15 +351,15 @@ msgstr "Landinformation och gruppering för klienten."
 msgid "Country manager"
 msgstr "Landschef"
 
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 msgstr "Creative Commons Attribution-ShareAlike 2.5 Generic License"
 
-#: euphorie/client/templates/about.pt:180
+#: euphorie/client/templates/about.pt:181
 msgid "Creative Commons License"
 msgstr "Creative Commons-license"
 
-#: euphorie/client/browser/templates/user-menu.pt:47
+#: euphorie/client/browser/templates/user-menu.pt:49
 #: euphorie/client/settings.py:140
 #: euphorie/client/templates/account-delete.pt:28
 msgid "Delete account"
@@ -417,15 +417,15 @@ msgstr ""
 msgid "Download the full report"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:170
+#: euphorie/client/templates/report_landing.pt:168
 msgid "Download the measures overview"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:141
+#: euphorie/client/templates/report_landing.pt:140
 msgid "Download the risks overview"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:153
+#: euphorie/client/browser/templates/start.pt:163
 #: euphorie/client/templates/report_landing.pt:40
 msgid "E-mail"
 msgstr "E-post"
@@ -499,7 +499,7 @@ msgstr "Mapp"
 msgid "Format: Office Open XML Workbook (.xlsx)"
 msgstr ""
 
-#: euphorie/client/templates/report_landing.pt:147
+#: euphorie/client/templates/report_landing.pt:146
 msgid "Format: Portable Document Format (.pdf)"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Generated unique ids are only unique within this context"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:161
+#: euphorie/client/templates/about.pt:162
 msgid "Germany"
 msgstr "Tyskland"
 
@@ -530,7 +530,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:706
+#: euphorie/client/browser/webhelpers.py:739
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -546,8 +546,7 @@ msgstr ""
 msgid "Important"
 msgstr ""
 
-#: euphorie/client/templates/plain.pt:195
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/plain.pt:181 euphorie/client/templates/shell.pt:96
 msgid "Info"
 msgstr ""
 
@@ -556,7 +555,7 @@ msgstr ""
 msgid "Information"
 msgstr "Information"
 
-#: euphorie/client/browser/risk.py:530
+#: euphorie/client/browser/risk.py:571
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -588,11 +587,11 @@ msgstr "Kosovo"
 msgid "Last saved"
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:61
+#: euphorie/client/browser/templates/start.pt:71
 msgid "Learn more about this tool&hellip;"
 msgstr ""
 
-#: euphorie/client/templates/shell.pt:314
+#: euphorie/client/templates/shell.pt:303
 msgid "Loading Risk Assessments&hellip;"
 msgstr ""
 
@@ -604,7 +603,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:143
+#: euphorie/client/browser/templates/risk_actionplan.pt:308
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -623,12 +622,12 @@ msgid "Monitor and assess whether necessary measures have been introduced."
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:66
-#: euphorie/client/templates/report_landing.pt:183
+#: euphorie/client/templates/report_landing.pt:181
 msgid "Monitor the measures to be implemented in the forthcoming 3 months."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:155
-#: euphorie/client/templates/report_landing.pt:154
+#: euphorie/client/browser/templates/risks_overview.pt:156
+#: euphorie/client/templates/report_landing.pt:153
 msgid "Monitor whether risks / measures are properly dealt with."
 msgstr ""
 
@@ -747,12 +746,14 @@ msgstr ""
 msgid "Online help"
 msgstr "Online-hjälp"
 
+#: euphorie/client/browser/session.py:968
 #: euphorie/client/browser/templates/measures_overview.pt:61
-#: euphorie/client/templates/report_landing.pt:162
+#: euphorie/client/templates/report_landing.pt:161
 msgid "Overview of measures"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:151
+#: euphorie/client/browser/session.py:958
+#: euphorie/client/browser/templates/risks_overview.pt:152
 #: euphorie/client/templates/report_landing.pt:133
 msgid "Overview of risks"
 msgstr ""
@@ -768,8 +769,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/measures_overview.pt:65
-#: euphorie/client/browser/templates/risks_overview.pt:154
-#: euphorie/client/templates/report_landing.pt:153
+#: euphorie/client/browser/templates/risks_overview.pt:155
+#: euphorie/client/templates/report_landing.pt:152
 msgid "Pass information to the people concerned."
 msgstr ""
 
@@ -794,9 +795,9 @@ msgstr ""
 msgid "Please refer to the examples below the form."
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:322
+#: euphorie/client/browser/templates/risks_overview.pt:323
 #: euphorie/client/browser/templates/status_info.pt:259
-#: euphorie/client/browser/templates/webhelpers.pt:180
+#: euphorie/client/browser/templates/webhelpers.pt:142
 msgid "Postponed"
 msgstr "${count} frågorna har skjutits upp"
 
@@ -833,7 +834,7 @@ msgstr ""
 msgid "Publish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "Read more"
 msgstr ""
 
@@ -862,8 +863,8 @@ msgid ""
 msgstr ""
 
 #: euphorie/client/browser/templates/profile.pt:69
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/updated.pt:52
 msgid "Remove"
 msgstr ""
 
@@ -884,14 +885,14 @@ msgstr "Risk"
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:183
+#: euphorie/client/browser/templates/webhelpers.pt:145
 msgid "Risk not present"
 msgstr ""
 "Denna risk är inte närvarande inom din organisation, men eftersom "
 "branschorganisationen anser att detta är en av de fem mest kritiska riskerna "
 "måste den ingå i denna rapport."
 
-#: euphorie/client/browser/templates/webhelpers.pt:186
+#: euphorie/client/browser/templates/webhelpers.pt:148
 msgid "Risk present"
 msgstr "Du svarade nekande till ovanstående redovisning."
 
@@ -966,7 +967,7 @@ msgstr "Dela detta OiRA-verktyg"
 msgid "Show library from ${dropdown}."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:68
+#: euphorie/client/browser/templates/webhelpers.pt:65
 msgid "Sign in"
 msgstr ""
 
@@ -982,6 +983,10 @@ msgstr ""
 #: euphorie/content/upload.py:116
 msgid "Standard"
 msgstr "Standard"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:126
+msgid "Standard measures"
+msgstr ""
 
 #: euphorie/content/templates/solution_view.pt:12
 msgid "Standard solution"
@@ -1030,7 +1035,7 @@ msgstr ""
 msgid "Survey versions"
 msgstr ""
 
-#: euphorie/client/templates/about.pt:140
+#: euphorie/client/templates/about.pt:141
 msgid "The Netherlands"
 msgstr "Nederländerna"
 
@@ -1047,7 +1052,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:867
+#: euphorie/client/browser/risk.py:912
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1147,7 +1152,7 @@ msgstr ""
 msgid "This request could not be processed."
 msgstr ""
 
-#: euphorie/client/browser/templates/start.pt:131
+#: euphorie/client/browser/templates/start.pt:141
 msgid "This tool deserves to be known by the world! Share it!"
 msgstr "Detta verktyg förtjänar att bli känt i världen! Dela det!"
 
@@ -1155,8 +1160,8 @@ msgstr "Detta verktyg förtjänar att bli känt i världen! Dela det!"
 msgid "Tip"
 msgstr ""
 
-#: euphorie/client/browser/templates/help-menu.pt:18
-#: euphorie/client/browser/templates/user-menu.pt:28
+#: euphorie/client/browser/templates/help-menu.pt:19
+#: euphorie/client/browser/templates/user-menu.pt:30
 msgid "Toggle on screen help"
 msgstr ""
 
@@ -1168,9 +1173,9 @@ msgstr ""
 msgid "Unpublish Risk Assessment"
 msgstr ""
 
-#: euphorie/client/browser/templates/risks_overview.pt:330
+#: euphorie/client/browser/templates/risks_overview.pt:331
 #: euphorie/client/browser/templates/status_info.pt:267
-#: euphorie/client/browser/templates/webhelpers.pt:177
+#: euphorie/client/browser/templates/webhelpers.pt:139
 msgid "Unvisited"
 msgstr ""
 
@@ -1277,32 +1282,32 @@ msgid "Your password was successfully changed."
 msgstr ""
 
 #. Default: "The source code of the OiRA application is ${GPL} licensed."
-#: euphorie/client/templates/about.pt:172
+#: euphorie/client/templates/about.pt:173
 msgid "about_licenses_1"
 msgstr "OiRA-progammets källkod omfattas av en ${GPL}-licens."
 
 #. Default: "The content of OiRA sectoral tools is licensed under a ${license}"
-#: euphorie/client/templates/about.pt:186
+#: euphorie/client/templates/about.pt:187
 msgid "about_licenses_2"
 msgstr "Innehållet i de branschanpassade OIRA-verktygen omfattas av ${-licens}"
 
 #. Default: "The OiRA sectoral tools can be used for free by all users."
-#: euphorie/client/templates/about.pt:192
+#: euphorie/client/templates/about.pt:193
 msgid "about_licenses_3"
 msgstr "De branschanpassade OiRA-verktygen får användas kostnadsfritt av alla."
 
 #. Default: "More information about the OiRA project (in English)"
-#: euphorie/client/templates/about.pt:95
+#: euphorie/client/templates/about.pt:96
 msgid "about_oiraproject"
 msgstr "Mer information om OiRA-projektet (på engelska)"
 
 #. Default: "European Community Strategy on Health and Safety at Work 2007-2012"
-#: euphorie/client/templates/about.pt:85
+#: euphorie/client/templates/about.pt:86
 msgid "about_paragraph3_agency"
 msgstr "EU:s arbetsmiljöstrategi för 2007-2012"
 
 #. Default: "Experience shows that ${key}. This is why EU-OSHA developed an ${easy} (the &ldquo;OiRA&rdquo; - Online interactive Risk Assessment) that can help micro and small organisations to put in place a ${step} &ndash; starting with the ${identification} and ${evaluation} of workplace risks, through decision making on ${preventive_actions} and the taking of action, to monitoring and ${reporting}."
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1"
 msgstr ""
 "Erfarenheten visar att ${key}. Därför har Europeiska arbetsmiljöbyrån "
@@ -1313,50 +1318,50 @@ msgstr ""
 "och ${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
-#: euphorie/client/templates/about.pt:40
+#: euphorie/client/templates/about.pt:41
 msgid "about_paragraph_1_easy"
 msgstr "användarvänligt och kostnadsfritt webbverktyg"
 
 #. Default: "evaluation"
-#: euphorie/client/templates/about.pt:57
+#: euphorie/client/templates/about.pt:58
 msgid "about_paragraph_1_evaluation"
 msgstr "värdering"
 
 #. Default: "identification"
-#: euphorie/client/templates/about.pt:53
+#: euphorie/client/templates/about.pt:54
 msgid "about_paragraph_1_identification"
 msgstr "identifiering"
 
 #. Default: "proper risk assessment is the key to healthy workplaces"
-#: euphorie/client/templates/about.pt:34
+#: euphorie/client/templates/about.pt:35
 msgid "about_paragraph_1_key"
 msgstr ""
 "bra riskbedömningar är en viktig förutsättning för hälsosamma arbetsplatser"
 
 #. Default: "preventive actions"
-#: euphorie/client/templates/about.pt:62
+#: euphorie/client/templates/about.pt:63
 msgid "about_paragraph_1_preventive_actions"
 msgstr "förebyggande åtgärder"
 
 #. Default: "reporting"
-#: euphorie/client/templates/about.pt:68
+#: euphorie/client/templates/about.pt:69
 msgid "about_paragraph_1_reporting"
 msgstr "rapportering"
 
 #. Default: "step-by-step risk assessment process"
-#: euphorie/client/templates/about.pt:47
+#: euphorie/client/templates/about.pt:48
 msgid "about_paragraph_1_step"
 msgstr "riskbedömning steg för steg"
 
 #. Default: "The OiRA web application gives access to the sectoral Risk Assessment tools created and maintained by sectoral organisations at national level."
-#: euphorie/client/templates/about.pt:74
+#: euphorie/client/templates/about.pt:75
 msgid "about_paragraph_2"
 msgstr ""
 "Webbverktyget OiRA ger tillgång till branschanpassade riskbedömningsverktyg "
 "som branschorganisationer i olika länder har skapat och administrerat."
 
 #. Default: "The ${agency} calls for the development of simple tools to facilitate risk assessment. Since the adoption of the European Framework directive in 1989, risk assessment has become a familiar concept for organising prevention in the workplace, and hundreds of thousands of companies all over Europe assess their risks regularly. Nevertheless, there is sufficient evidence to conclude that ${smb} when it comes to risk assessment and the adoption of a preventive policy in general which the OiRA project aims to overcome."
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_paragraph_3"
 msgstr ""
 "${byrån} efterlyser utveckling av enkla verktyg som kan underlätta arbetet "
@@ -1369,7 +1374,7 @@ msgstr ""
 "OiRA-projektet är att rätta till detta."
 
 #. Default: "The OiRA project and its related web application has been developed by the ${eu-osha} based on the Dutch RA-instrument (called ${RIE}), which, financed by the Dutch government, was initially developed by TNO in collaboration with the employers organisation for small and medium-sized enterprises MKB-Nederland and the Dutch Ministry for Employment. Further development of the application was realised with input and participation of trade unions FNV, CNV and MHP."
-#: euphorie/client/templates/about.pt:126
+#: euphorie/client/templates/about.pt:127
 msgid "about_partners_1"
 msgstr ""
 "OIRA-projektet och webbverktyget har utvecklats av ${eu-osha} på grundval av "
@@ -1380,14 +1385,14 @@ msgstr ""
 "tillsammans med arbetstagarorganisationerna FNV, CNV och MHP."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
-#: euphorie/client/templates/about.pt:131
+#: euphorie/client/templates/about.pt:132
 msgid "about_partners_2"
 msgstr ""
 "Följande tekniska sarmarbetspartners har bidragit till att utveckla OIRA-"
 "projektet:"
 
 #. Default: "The Agency was also given strategic and expert advice by a Steering Committee in the development and implementation of the OiRA project. Members and alternates of the Steering Committee were appointed by the interest groups at the Board, by the Commission and by EU-OSHA."
-#: euphorie/client/templates/about.pt:164
+#: euphorie/client/templates/about.pt:165
 msgid "about_partners_3"
 msgstr ""
 "Den Europeiska arbetsmiljöbyrån har också fått strategiska expertråd om "
@@ -1396,27 +1401,27 @@ msgstr ""
 "styrelsen, av kommissionen och av den Europeiska arbetsmiljöbyrån själv."
 
 #. Default: "micro and small enterprises have some shortcomings"
-#: euphorie/client/templates/about.pt:89
+#: euphorie/client/templates/about.pt:90
 msgid "about_partners_3_smb"
 msgstr "mikroföretag och små företag har vissa brister"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/risk_actionplan.pt:245
+#: euphorie/client/browser/templates/risk_actionplan.pt:254
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Även fast inte alla åtgärder kostar pengar, gör de flesta det. Åtgärderna "
 "bör därför budgeteras, inkludera dem i den årliga budgeten om nödvändigt."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/risk_actionplan.pt:228
+#: euphorie/client/browser/templates/risk_actionplan.pt:236
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Utse någon i ditt företag som ansvarar för genomförandet av denna åtgärd. "
 "Denna person kommer att ha befogenhet att vidta de åtgärder som beskrivs i "
 "planen och/eller ansvaret för att se till att de genomförs."
 
-#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk); 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/risk_actionplan.pt:186
+#. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
+#: euphorie/client/browser/templates/risk_actionplan.pt:334
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Skriv ner i planen vilken åtgärd du kommer att utföra med anledning av "
@@ -1427,6 +1432,11 @@ msgstr ""
 "krav). I de flesta fall kommer den som är ansvarig för förberedelserna att "
 "bidra till genomförandet av planen: Dock måste han/hon vara kapabel till, "
 "eller haft relevant utbildning för att göra detta.."
+
+#. Default: "Describe: 3) the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
+#: euphorie/client/browser/templates/risk_actionplan.pt:349
+msgid "actionplan_requirements_tooltip"
+msgstr ""
 
 #. Default: "add a new OiRA Tool"
 #: euphorie/content/templates/sector_view.pt:18
@@ -1485,7 +1495,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/risk_actionplan.pt:174
+#: euphorie/client/browser/templates/risk_actionplan.pt:146
 msgid "button_add"
 msgstr "Ladda upp"
 
@@ -1533,7 +1543,7 @@ msgstr "Avbryt"
 
 #. Default: "Close"
 #: euphorie/client/browser/templates/new-session-test.pt:93
-#: euphorie/client/browser/webhelpers.py:703
+#: euphorie/client/browser/webhelpers.py:736
 msgid "button_close"
 msgstr ""
 
@@ -1811,7 +1821,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:713
+#: euphorie/client/browser/templates/webhelpers.pt:542
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -1869,7 +1879,7 @@ msgid "description_use_location_question"
 msgstr ""
 
 #. Default: "After the technical development of the tool in 2009, in 2010 (until the first half of 2011) the Agency is piloting the development and diffusion model at both EU level (working with the Sectoral Social Dialogue Committees) and at Member State level (with several Member States) as part of the testing of the tool and the development of appropriate support and guidance services."
-#: euphorie/client/templates/about.pt:108
+#: euphorie/client/templates/about.pt:109
 msgid "devel_phase"
 msgstr ""
 "Den tekniska utvecklingen av verktyget ägde rum 2009. Under 2010 (och första "
@@ -1910,17 +1920,17 @@ msgid "effect_high"
 msgstr "Hög (mycket hög) allvarlighetsgrad"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:546
+#: euphorie/client/browser/templates/webhelpers.pt:375
 msgid "effect_injury_no_absence"
 msgstr "Svag allvarlighetsgrad"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:552
+#: euphorie/client/browser/templates/webhelpers.pt:381
 msgid "effect_injury_with_absence"
 msgstr "Stark allvarlighetsgrad"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:558
+#: euphorie/client/browser/templates/webhelpers.pt:387
 msgid "effect_permanent_damage"
 msgstr "Hög (mycket hög) allvarlighetsgrad"
 
@@ -1990,7 +2000,7 @@ msgid "error_existing_login"
 msgstr "Detta inloggningsnamn är redan taget."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/risk_actionplan.pt:241
+#: euphorie/client/browser/templates/risk_actionplan.pt:250
 msgid "error_invalid_budget"
 msgstr "Ange budget i euro (ental)."
 
@@ -2026,17 +2036,17 @@ msgid "error_password_mismatch"
 msgstr "Lösenorden stämmer inte överens"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:876
+#: euphorie/client/browser/risk.py:925
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:872
+#: euphorie/client/browser/risk.py:919
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:880
+#: euphorie/client/browser/risk.py:931
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2143,7 +2153,7 @@ msgstr ""
 "utförda ändringar måste undersökningen slås ihop med din session."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:245
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2152,12 +2162,12 @@ msgid "extra_text_identification"
 msgstr ""
 
 #. Default: "Action plan ${title}"
-#: euphorie/client/docx/views.py:299
+#: euphorie/client/docx/views.py:271
 msgid "filename_report_actionplan"
 msgstr "Handlingsplan ${title}.doc"
 
 #. Default: "Identification report ${title}"
-#: euphorie/client/docx/views.py:342
+#: euphorie/client/docx/views.py:314
 msgid "filename_report_identification"
 msgstr "Identifiering ${title}.doc"
 
@@ -2177,7 +2187,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:516
+#: euphorie/client/browser/templates/webhelpers.pt:345
 msgid "frequency_almost_never"
 msgstr "Nästan aldrig"
 
@@ -2187,57 +2197,57 @@ msgid "frequency_almostnever"
 msgstr "Nästan aldrig"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:528
+#: euphorie/client/browser/templates/webhelpers.pt:357
 #: euphorie/content/risk.py:419
 msgid "frequency_constantly"
 msgstr "Konstant"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:649
+#: euphorie/client/browser/templates/webhelpers.pt:478
 #: euphorie/content/risk.py:370
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:650
+#: euphorie/client/browser/templates/webhelpers.pt:479
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:661
+#: euphorie/client/browser/templates/webhelpers.pt:490
 #: euphorie/content/risk.py:373
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:491
 msgid "frequency_french_often_help"
 msgstr "Konstant"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:637
+#: euphorie/client/browser/templates/webhelpers.pt:466
 #: euphorie/content/risk.py:368
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:638
+#: euphorie/client/browser/templates/webhelpers.pt:467
 msgid "frequency_french_rare_help"
 msgstr "Regelbunden"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:673
+#: euphorie/client/browser/templates/webhelpers.pt:502
 #: euphorie/content/risk.py:375
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:674
+#: euphorie/client/browser/templates/webhelpers.pt:503
 msgid "frequency_french_regularly_help"
 msgstr "Regelbunden"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:522
+#: euphorie/client/browser/templates/webhelpers.pt:351
 #: euphorie/content/risk.py:417
 msgid "frequency_regularly"
 msgstr "Regelbunden"
@@ -2258,12 +2268,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:813
+#: euphorie/client/browser/templates/webhelpers.pt:563
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:816
+#: euphorie/client/browser/templates/webhelpers.pt:566
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2278,12 +2288,12 @@ msgid "header_country_managers"
 msgstr "Landschefer"
 
 #. Default: "Development and pilot phase &ndash; 2009-2011"
-#: euphorie/client/templates/about.pt:101
+#: euphorie/client/templates/about.pt:102
 msgid "header_devel_phase"
 msgstr "Utveckling och pilotfas – 2009-2011"
 
 #. Default: "Development partners"
-#: euphorie/client/templates/about.pt:115
+#: euphorie/client/templates/about.pt:116
 msgid "header_development_partners"
 msgstr "Utvecklingspartners"
 
@@ -2319,18 +2329,18 @@ msgstr "Identifiering"
 
 #. Default: "Information"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:192
-#: euphorie/client/browser/templates/webhelpers.pt:722
+#: euphorie/client/browser/templates/risk_macros.pt:178
 #: euphorie/content/templates/module_view.pt:22
 msgid "header_information"
 msgstr "Information"
 
 #. Default: "Official launch of the project &ndash; September 2011"
-#: euphorie/client/templates/about.pt:111
+#: euphorie/client/templates/about.pt:112
 msgid "header_launch"
 msgstr "Officiell lansering av projektet – september 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:330
+#: euphorie/client/docx/compiler.py:327
 msgid "header_legal_references"
 msgstr "Rättsliga och politiska referenser"
 
@@ -2340,13 +2350,13 @@ msgid "header_legend"
 msgstr "Teckenförklaring"
 
 #. Default: "Licenses"
-#: euphorie/client/templates/about.pt:168
+#: euphorie/client/templates/about.pt:169
 msgid "header_licenses"
 msgstr "Licenser"
 
 #. Default: "Login"
 #: euphorie/client/browser/templates/login_form.pt:17
-#: euphorie/client/templates/shell.pt:115
+#: euphorie/client/templates/shell.pt:104
 #: euphorie/client/templates/tooltips.pt:8
 msgid "header_login"
 msgstr "Logga in"
@@ -2357,12 +2367,12 @@ msgid "header_main_image"
 msgstr "Huvudbild"
 
 #. Default: "Measure ${index}"
-#: euphorie/client/docx/compiler.py:405
+#: euphorie/client/docx/compiler.py:365
 msgid "header_measure"
 msgstr "Åtgärd ${index}"
 
 #. Default: "Measure"
-#: euphorie/client/docx/compiler.py:402
+#: euphorie/client/docx/compiler.py:362
 msgid "header_measure_single"
 msgstr "Åtgärd ${index}"
 
@@ -2388,12 +2398,12 @@ msgid "header_not_complicated"
 msgstr "En riskbedömning är inte komplicerad"
 
 #. Default: "Consultation of workers"
-#: euphorie/client/docx/compiler.py:470
+#: euphorie/client/docx/compiler.py:425
 msgid "header_oira_report_consultation"
 msgstr ""
 
 #. Default: "OiRA Report: “${title}”"
-#: euphorie/client/docx/views.py:227
+#: euphorie/client/docx/views.py:199
 msgid "header_oira_report_download"
 msgstr ""
 
@@ -2428,7 +2438,7 @@ msgid "header_osh_tool_navigation"
 msgstr ""
 
 #. Default: "Risks that have been identified, evaluated and have an Action Plan"
-#: euphorie/client/docx/views.py:237
+#: euphorie/client/docx/views.py:209
 msgid "header_present_risks"
 msgstr ""
 
@@ -2448,7 +2458,7 @@ msgid "header_profile_questions"
 msgstr ""
 
 #. Default: "Project Phases"
-#: euphorie/client/templates/about.pt:100
+#: euphorie/client/templates/about.pt:101
 msgid "header_project_phases"
 msgstr "Projektfas"
 
@@ -2464,7 +2474,7 @@ msgstr "Besvarade frågor per modul"
 
 #. Default: "Register"
 #: euphorie/client/browser/templates/register.pt:75
-#: euphorie/client/templates/shell.pt:116
+#: euphorie/client/templates/shell.pt:105
 msgid "header_register"
 msgstr "Registrera"
 
@@ -2485,23 +2495,23 @@ msgid "header_risk_aware"
 msgstr "Är du medveten om alla risker?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:536
+#: euphorie/client/browser/templates/webhelpers.pt:365
 msgid "header_risk_effect"
 msgstr "Vad för slags allvarighetsgrad har skadan?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:506
+#: euphorie/client/browser/templates/webhelpers.pt:335
 msgid "header_risk_frequency"
 msgstr "Hur ofta är personer utsatta för denna risk?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:167
-#: euphorie/client/browser/templates/webhelpers.pt:690
+#: euphorie/client/browser/templates/webhelpers.pt:519
 msgid "header_risk_priority"
 msgstr "Välj prioritet för denna risk"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:475
+#: euphorie/client/browser/templates/webhelpers.pt:304
 msgid "header_risk_probability"
 msgstr "Vad är chansen att denna risk uppstår?"
 
@@ -2513,7 +2523,7 @@ msgid "header_risks"
 msgstr "Risker"
 
 #. Default: "Hazards/problems that have been managed or are not present in your organisation"
-#: euphorie/client/docx/views.py:249
+#: euphorie/client/docx/views.py:221
 msgid "header_risks_not_present"
 msgstr ""
 
@@ -2573,12 +2583,12 @@ msgid "header_training"
 msgstr ""
 
 #. Default: "Hazards/problems that have been \"parked\" and are still to be dealt with"
-#: euphorie/client/docx/views.py:245
+#: euphorie/client/docx/views.py:217
 msgid "header_unanswered_risks"
 msgstr ""
 
 #. Default: "Risks that have been identified but do NOT have an Action Plan"
-#: euphorie/client/docx/views.py:241
+#: euphorie/client/docx/views.py:213
 msgid "header_unevaluated_risks"
 msgstr ""
 
@@ -2593,17 +2603,17 @@ msgid "header_welcome"
 msgstr "Välkommen"
 
 #. Default: "What is the OiRA (Online Interactive Risk Assessment) project"
-#: euphorie/client/templates/about.pt:24
+#: euphorie/client/templates/about.pt:25
 msgid "header_what_is_oira"
 msgstr "Vad är OiRA (interaktivt webbverktyg för riskbedömning)?"
 
 #. Default: "Why the OiRA project"
-#: euphorie/client/templates/about.pt:79
+#: euphorie/client/templates/about.pt:80
 msgid "header_why_oira"
 msgstr "Varför OiRA-projektet?"
 
 #. Default: "Comments"
-#: euphorie/client/browser/templates/webhelpers.pt:846
+#: euphorie/client/browser/templates/webhelpers.pt:596
 msgid "heading_comments"
 msgstr ""
 
@@ -2624,142 +2634,142 @@ msgid "heading_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:372
+#: euphorie/client/browser/templates/risks_overview.pt:373
 msgid "heading_num_high_prio_risks"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:376
+#: euphorie/client/browser/templates/risks_overview.pt:377
 msgid "heading_num_high_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:380
+#: euphorie/client/browser/templates/risks_overview.pt:381
 msgid "heading_num_high_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_high_risks} High priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:384
+#: euphorie/client/browser/templates/risks_overview.pt:385
 msgid "heading_num_high_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:406
+#: euphorie/client/browser/templates/risks_overview.pt:407
 msgid "heading_num_low_prio_risks"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:410
+#: euphorie/client/browser/templates/risks_overview.pt:411
 msgid "heading_num_low_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:414
+#: euphorie/client/browser/templates/risks_overview.pt:415
 msgid "heading_num_low_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_low_risks} Low priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:418
+#: euphorie/client/browser/templates/risks_overview.pt:419
 msgid "heading_num_low_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risk"
-#: euphorie/client/browser/templates/risks_overview.pt:389
+#: euphorie/client/browser/templates/risks_overview.pt:390
 msgid "heading_num_medium_prio_risks"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:393
+#: euphorie/client/browser/templates/risks_overview.pt:394
 msgid "heading_num_medium_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:397
+#: euphorie/client/browser/templates/risks_overview.pt:398
 msgid "heading_num_medium_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_medium_risks} Medium priority risks"
-#: euphorie/client/browser/templates/risks_overview.pt:401
+#: euphorie/client/browser/templates/risks_overview.pt:402
 msgid "heading_num_medium_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risk postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:462
+#: euphorie/client/browser/templates/risks_overview.pt:463
 msgid "heading_num_postponed_prio_risks"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:466
+#: euphorie/client/browser/templates/risks_overview.pt:467
 msgid "heading_num_postponed_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:470
+#: euphorie/client/browser/templates/risks_overview.pt:471
 msgid "heading_num_postponed_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_postponed_risks} Risks postponed"
-#: euphorie/client/browser/templates/risks_overview.pt:474
+#: euphorie/client/browser/templates/risks_overview.pt:475
 msgid "heading_num_postponed_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risk not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:479
+#: euphorie/client/browser/templates/risks_overview.pt:480
 msgid "heading_num_todo_prio_risks"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:483
+#: euphorie/client/browser/templates/risks_overview.pt:484
 msgid "heading_num_todo_prio_risks_2"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:487
+#: euphorie/client/browser/templates/risks_overview.pt:488
 msgid "heading_num_todo_prio_risks_3_4"
 msgstr ""
 
 #. Default: "${num_todo_risks} Risks not answered"
-#: euphorie/client/browser/templates/risks_overview.pt:491
+#: euphorie/client/browser/templates/risks_overview.pt:492
 msgid "heading_num_todo_prio_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:438
+#: euphorie/client/browser/templates/risks_overview.pt:439
 msgid "heading_possible_risks"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:442
+#: euphorie/client/browser/templates/risks_overview.pt:443
 msgid "heading_possible_risks_2"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:446
+#: euphorie/client/browser/templates/risks_overview.pt:447
 msgid "heading_possible_risks_3_4"
 msgstr ""
 
 #. Default: "${num_possible_risks} Possible Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:450
+#: euphorie/client/browser/templates/risks_overview.pt:451
 msgid "heading_possible_risks_5_or_more"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risk"
-#: euphorie/client/browser/templates/risks_overview.pt:349
+#: euphorie/client/browser/templates/risks_overview.pt:350
 msgid "heading_present_risks"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:353
+#: euphorie/client/browser/templates/risks_overview.pt:354
 msgid "heading_present_risks_2"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:357
+#: euphorie/client/browser/templates/risks_overview.pt:358
 msgid "heading_present_risks_3_4"
 msgstr ""
 
 #. Default: "${num_present_risks} Present Risks"
-#: euphorie/client/browser/templates/risks_overview.pt:361
+#: euphorie/client/browser/templates/risks_overview.pt:362
 msgid "heading_present_risks_5_or_more"
 msgstr ""
 
@@ -2783,7 +2793,7 @@ msgstr ""
 "lösenordspåminnelse och registrering av sidor."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:462
+#: euphorie/client/browser/templates/webhelpers.pt:291
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -2807,7 +2817,7 @@ msgstr ""
 "starta med en kopia av en befintlig undersökning."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:321 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Ange hur ofta denna risk inträffar i en normal situation."
 
@@ -2819,12 +2829,12 @@ msgstr ""
 "fortfarande ändra prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:316 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Ange hur trolig förekomsten av denna risk är i en normal situation."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:325 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Ange allvarighetsgraden av att hantera denna risk om den inträffar."
 
@@ -2924,6 +2934,11 @@ msgstr ""
 "Ladda upp en bild. Se till att din bild är i formatet png, jpg eller gif och "
 "inte innehåller några specialtecken."
 
+#. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk. + Describe the specific action(s) required to implement this approach (to eliminate or to reduce the risk)."
+#: euphorie/content/solution.py:79
+msgid "help_measure_action"
+msgstr ""
+
 #. Default: "Describe your general approach to eliminate or (if the risk is not avoidable) reduce the risk."
 #: euphorie/content/solution.py:50
 msgid "help_measure_action_plan"
@@ -2939,7 +2954,7 @@ msgstr ""
 "(igen). Denna information kopieras till åtgärden."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance \"common sense (no OSH knowledge required)\", \"no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required\", or \"OSH expert\". You can also describe here any other additional requirement (if any)."
-#: euphorie/content/solution.py:77
+#: euphorie/content/solution.py:94
 msgid "help_measure_requirements"
 msgstr ""
 "Beskriv standardkraven hos handlingsplanen och planen för förebyggande. "
@@ -3096,7 +3111,7 @@ msgid "help_upload_surveygroup_title"
 msgstr "Om du inte specificerar en titel den kommer att tas från indatan."
 
 #. Default: "Dashboard"
-#: euphorie/client/templates/shell.pt:125
+#: euphorie/client/templates/shell.pt:114
 msgid "home_link"
 msgstr ""
 
@@ -3164,7 +3179,7 @@ msgid "info_select_session"
 msgstr ""
 
 #. Default: "This is a test session. ${link_sign_in} to save your data."
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "info_testsession"
 msgstr ""
 
@@ -3349,13 +3364,13 @@ msgstr "Kontot är låst"
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:110
 #: euphorie/client/templates/report_identification.pt:145
-#: euphorie/client/templates/shell.pt:201
+#: euphorie/client/templates/shell.pt:190
 msgid "label_action_plan"
 msgstr "Handlingsplan"
 
 #. Default: "Budget"
-#: euphorie/client/browser/templates/risk_actionplan.pt:240
-#: euphorie/client/docx/compiler.py:430 euphorie/client/report.py:150
+#: euphorie/client/browser/templates/risk_actionplan.pt:249
+#: euphorie/client/docx/compiler.py:386 euphorie/client/report.py:150
 msgid "label_action_plan_budget"
 msgstr "Budget (i euro)"
 
@@ -3365,27 +3380,22 @@ msgid "label_action_plan_download"
 msgstr ""
 
 #. Default: "Planning end"
-#: euphorie/client/browser/templates/risk_actionplan.pt:280
-#: euphorie/client/docx/compiler.py:434 euphorie/client/report.py:119
+#: euphorie/client/browser/templates/risk_actionplan.pt:289
+#: euphorie/client/docx/compiler.py:390 euphorie/client/report.py:127
 msgid "label_action_plan_end"
 msgstr "Planerat slut"
 
 #. Default: "Who is responsible?"
-#: euphorie/client/browser/templates/risk_actionplan.pt:227
-#: euphorie/client/docx/compiler.py:427 euphorie/client/report.py:148
+#: euphorie/client/browser/templates/risk_actionplan.pt:235
+#: euphorie/client/docx/compiler.py:383 euphorie/client/report.py:148
 msgid "label_action_plan_responsible"
 msgstr "Vem är ansvarig?"
 
 #. Default: "Planning start"
-#: euphorie/client/browser/templates/risk_actionplan.pt:264
-#: euphorie/client/docx/compiler.py:432 euphorie/client/report.py:114
+#: euphorie/client/browser/templates/risk_actionplan.pt:273
+#: euphorie/client/docx/compiler.py:388 euphorie/client/report.py:122
 msgid "label_action_plan_start"
 msgstr "Planerad start"
-
-#. Default: "Add another measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:296
-msgid "label_add_measure"
-msgstr ""
 
 #. Default: "Page content"
 #: euphorie/content/page.py:28
@@ -3428,8 +3438,8 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:434
-#: euphorie/client/browser/templates/webhelpers.pt:853
+#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
 "Lämna gärna synpunkter du kan ha om ovanstående fråga inom detta område. "
@@ -3516,7 +3526,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/risk_actionplan.pt:128
+#: euphorie/client/browser/templates/risk_actionplan.pt:173
 #: euphorie/content/risk.py:94
 msgid "label_description"
 msgstr "Beskrivning"
@@ -3546,7 +3556,7 @@ msgstr "Vill du skapa ett anpassat meddelande för detta OiRA-verktyg?"
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:108
 #: euphorie/client/templates/report_identification.pt:135
-#: euphorie/client/templates/shell.pt:181
+#: euphorie/client/templates/shell.pt:170
 msgid "label_evaluation"
 msgstr "Utvärdering"
 
@@ -3566,9 +3576,18 @@ msgid "label_evaluation_phase"
 msgstr "Utvärderingsfas"
 
 #. Default: "Measure already implemented"
-#: euphorie/client/browser/templates/risk_actionplan.pt:126
-#: euphorie/client/docx/compiler.py:385
+#: euphorie/client/docx/compiler.py:346
 msgid "label_existing_measure"
+msgstr ""
+
+#. Default: "Expertise"
+#: euphorie/client/browser/templates/risk_actionplan.pt:221
+msgid "label_expertise"
+msgstr ""
+
+#. Default: "Add an extra measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:450
+msgid "label_extra_add_measure"
 msgstr ""
 
 #. Default: "Content file"
@@ -3644,7 +3663,7 @@ msgstr "Sessioner"
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:106
 #: euphorie/client/templates/report_identification.pt:125
-#: euphorie/client/templates/shell.pt:179
+#: euphorie/client/templates/shell.pt:168
 msgid "label_identification"
 msgstr "Identifiering"
 
@@ -3652,6 +3671,11 @@ msgstr "Identifiering"
 #: euphorie/content/module.py:78 euphorie/content/risk.py:226
 msgid "label_image"
 msgstr "Bildfil"
+
+#. Default: "Implemented measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:170
+msgid "label_implemented_measure"
+msgstr ""
 
 #. Default: "Introduction text"
 #: euphorie/content/survey.py:73 euphorie/content/templates/survey_view.pt:32
@@ -3674,7 +3698,7 @@ msgid "label_language"
 msgstr "Språk"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/browser/templates/webhelpers.pt:801
+#: euphorie/client/browser/templates/webhelpers.pt:551
 #: euphorie/content/risk.py:120 euphorie/content/templates/risk_view.pt:76
 msgid "label_legal_reference"
 msgstr "Rättsliga och politiska referenser"
@@ -3709,21 +3733,26 @@ msgstr "Logotyp"
 msgid "label_logo_selection"
 msgstr "Vilken logotyp vill du visa i det övre vänstra hörnet?"
 
+#. Default: "General approach (to eliminate or reduce the risk) + Specific action(s) required to implement this approach"
+#: euphorie/content/solution.py:74
+msgid "label_measure_action"
+msgstr ""
+
 #. Default: "General approach (to eliminate or reduce the risk)"
-#: euphorie/client/browser/templates/risk_actionplan.pt:190
-#: euphorie/client/docx/compiler.py:413 euphorie/client/report.py:124
+#: euphorie/client/browser/templates/risk_actionplan.pt:338
+#: euphorie/client/docx/compiler.py:373 euphorie/client/report.py:132
 msgid "label_measure_action_plan"
 msgstr "Handlingsplan"
 
 #. Default: "Specific action(s) required to implement this approach"
-#: euphorie/client/browser/templates/risk_actionplan.pt:200
-#: euphorie/client/docx/compiler.py:420 euphorie/client/report.py:132
+#: euphorie/content/solution.py:59
+#: euphorie/content/templates/solution_view.pt:24
 msgid "label_measure_prevention_plan"
 msgstr "Förebyggande plan"
 
 #. Default: "Level of expertise and/or requirements needed"
-#: euphorie/client/browser/templates/risk_actionplan.pt:210
-#: euphorie/client/docx/compiler.py:424 euphorie/client/report.py:140
+#: euphorie/client/browser/templates/risk_actionplan.pt:354
+#: euphorie/client/docx/compiler.py:380 euphorie/client/report.py:140
 msgid "label_measure_requirements"
 msgstr "Krav"
 
@@ -3779,25 +3808,25 @@ msgid "label_no"
 msgstr "Nej"
 
 #. Default: "No risk"
-#: euphorie/client/browser/templates/risks_overview.pt:259
+#: euphorie/client/browser/templates/risks_overview.pt:260
 #: euphorie/client/browser/templates/status_info.pt:196
 msgid "label_no_risk"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:263
+#: euphorie/client/browser/templates/risks_overview.pt:264
 #: euphorie/client/browser/templates/status_info.pt:200
 msgid "label_no_risks_2"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:267
+#: euphorie/client/browser/templates/risks_overview.pt:268
 #: euphorie/client/browser/templates/status_info.pt:204
 msgid "label_no_risks_3_4"
 msgstr ""
 
 #. Default: "No risks"
-#: euphorie/client/browser/templates/risks_overview.pt:271
+#: euphorie/client/browser/templates/risks_overview.pt:272
 #: euphorie/client/browser/templates/status_info.pt:208
 msgid "label_no_risks_5_or_more"
 msgstr ""
@@ -3837,15 +3866,10 @@ msgstr "Lösenord"
 msgid "label_password_confirm"
 msgstr "Bekräfta lösenord"
 
-#. Default: "Pre-fill"
-#: euphorie/client/browser/templates/risk_actionplan.pt:154
-msgid "label_prefill"
-msgstr ""
-
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:104
 #: euphorie/client/templates/report_identification.pt:113
-#: euphorie/client/templates/shell.pt:155
+#: euphorie/client/templates/shell.pt:144
 msgid "label_preparation"
 msgstr "Förberedelse"
 
@@ -3856,7 +3880,7 @@ msgstr "Förhandsgranskning"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:448
+#: euphorie/client/browser/templates/risk_actionplan.pt:576
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Föregående"
@@ -3919,15 +3943,15 @@ msgstr ""
 msgid "label_register_first"
 msgstr ""
 
-#. Default: "Delete this measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:151
+#. Default: "Remove this measure"
+#: euphorie/client/browser/templates/risk_actionplan.pt:189
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/templates/report_identification.pt:155
 #: euphorie/client/templates/report_landing.pt:77
-#: euphorie/client/templates/shell.pt:226
+#: euphorie/client/templates/shell.pt:215
 msgid "label_report"
 msgstr "Rapport"
 
@@ -3937,12 +3961,12 @@ msgid "label_report_comment"
 msgstr "Lämna gärna extra kommentarer som bör ingå i denna områdesrapport."
 
 #. Default: "Date of editing"
-#: euphorie/client/docx/compiler.py:562
+#: euphorie/client/docx/compiler.py:517
 msgid "label_report_date"
 msgstr ""
 
 #. Default: "Staff who participated in the risk assessment"
-#: euphorie/client/docx/compiler.py:561
+#: euphorie/client/docx/compiler.py:516
 msgid "label_report_staff"
 msgstr ""
 
@@ -3962,49 +3986,49 @@ msgid "label_risk_type"
 msgstr "Risktyp"
 
 #. Default: "Risk with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:280
+#: euphorie/client/browser/templates/risks_overview.pt:281
 #: euphorie/client/browser/templates/status_info.pt:217
 msgid "label_risk_with_measure"
 msgstr ""
 
 #. Default: "Risk without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:301
+#: euphorie/client/browser/templates/risks_overview.pt:302
 #: euphorie/client/browser/templates/status_info.pt:238
 msgid "label_risk_without_measure"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:284
+#: euphorie/client/browser/templates/risks_overview.pt:285
 #: euphorie/client/browser/templates/status_info.pt:221
 msgid "label_risks_with_measure_2"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:288
+#: euphorie/client/browser/templates/risks_overview.pt:289
 #: euphorie/client/browser/templates/status_info.pt:225
 msgid "label_risks_with_measure_3_4"
 msgstr ""
 
 #. Default: "Risks with measure(s)"
-#: euphorie/client/browser/templates/risks_overview.pt:292
+#: euphorie/client/browser/templates/risks_overview.pt:293
 #: euphorie/client/browser/templates/status_info.pt:229
 msgid "label_risks_with_measure_5_or_more"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:305
+#: euphorie/client/browser/templates/risks_overview.pt:306
 #: euphorie/client/browser/templates/status_info.pt:242
 msgid "label_risks_without_measure_2"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:309
+#: euphorie/client/browser/templates/risks_overview.pt:310
 #: euphorie/client/browser/templates/status_info.pt:246
 msgid "label_risks_without_measure_3_4"
 msgstr ""
 
 #. Default: "Risks without measure"
-#: euphorie/client/browser/templates/risks_overview.pt:313
+#: euphorie/client/browser/templates/risks_overview.pt:314
 #: euphorie/client/browser/templates/status_info.pt:250
 msgid "label_risks_without_measure_5_or_more"
 msgstr ""
@@ -4017,7 +4041,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:454
+#: euphorie/client/browser/templates/risk_actionplan.pt:582
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -4042,7 +4066,7 @@ msgid "label_sector_title"
 msgstr "Bransch titel."
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/risk_actionplan.pt:165
+#: euphorie/client/browser/templates/risk_actionplan.pt:132
 msgid "label_select_measure"
 msgstr ""
 
@@ -4071,7 +4095,7 @@ msgid "label_show_less_hellip"
 msgstr "Visa mindre"
 
 #. Default: "${read_more} about this risk."
-#: euphorie/client/browser/templates/webhelpers.pt:335
+#: euphorie/client/browser/templates/risk_macros.pt:161
 msgid "label_show_more"
 msgstr ""
 
@@ -4101,7 +4125,7 @@ msgid "label_start_identification"
 msgstr "Starta riskidentifiering"
 
 #. Default: "Start"
-#: euphorie/client/browser/templates/start.pt:117
+#: euphorie/client/browser/templates/start.pt:127
 msgid "label_start_survey"
 msgstr "Starta"
 
@@ -4146,29 +4170,29 @@ msgid "label_surveygroup_title"
 msgstr "Titel på importerad undersökning."
 
 #. Default: "Test session"
-#: euphorie/client/templates/shell.pt:107
+#: euphorie/client/templates/shell.pt:96
 msgid "label_testsession"
 msgstr ""
 
 #. Default: "High"
-#: euphorie/client/report.py:107
+#: euphorie/client/report.py:115
 msgid "label_timeline_priority_high"
 msgstr "Hög"
 
 #. Default: "Low"
-#: euphorie/client/report.py:105
+#: euphorie/client/report.py:113
 msgid "label_timeline_priority_low"
 msgstr "Låg"
 
 #. Default: "Medium"
-#: euphorie/client/report.py:106
+#: euphorie/client/report.py:114
 msgid "label_timeline_priority_medium"
 msgstr "Medium"
 
 #. Default: "Title"
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:24
 #: euphorie/client/browser/templates/confirmation-delete-session.pt:24
-#: euphorie/client/docx/compiler.py:560
+#: euphorie/client/docx/compiler.py:515
 msgid "label_title"
 msgstr "Titel"
 
@@ -4228,12 +4252,12 @@ msgid "label_user_title"
 msgstr "Namn"
 
 #. Default: "(&ge;1 measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:424
+#: euphorie/client/browser/templates/risks_overview.pt:425
 msgid "label_with_measures"
 msgstr ""
 
 #. Default: "(without measures)"
-#: euphorie/client/browser/templates/risks_overview.pt:426
+#: euphorie/client/browser/templates/risks_overview.pt:427
 msgid "label_without_measures"
 msgstr ""
 
@@ -4280,7 +4304,7 @@ msgid "limitations"
 msgstr ""
 
 #. Default: "Sign in"
-#: euphorie/client/templates/plain.pt:195
+#: euphorie/client/templates/plain.pt:181
 msgid "link_sign_in"
 msgstr ""
 
@@ -4364,7 +4388,7 @@ msgid "menu_import"
 msgstr "Importera undersökning"
 
 #. Default: "Training"
-#: euphorie/client/templates/shell.pt:247
+#: euphorie/client/templates/shell.pt:236
 msgid "menu_training"
 msgstr ""
 
@@ -4465,32 +4489,32 @@ msgid "nav_usermanagement"
 msgstr "Användarhantering"
 
 #. Default: "Help"
-#: euphorie/client/browser/templates/help-menu.pt:24
-#: euphorie/client/browser/templates/user-menu.pt:34
-#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/browser/templates/help-menu.pt:25
+#: euphorie/client/browser/templates/user-menu.pt:36
+#: euphorie/client/browser/templates/webhelpers.pt:56
 msgid "navigation_help"
 msgstr "Hjälp"
 
 #. Default: "Logout"
-#: euphorie/client/browser/templates/user-menu.pt:50
-#: euphorie/client/browser/templates/webhelpers.pt:53
+#: euphorie/client/browser/templates/user-menu.pt:52
+#: euphorie/client/browser/templates/webhelpers.pt:50
 msgid "navigation_logout"
 msgstr "Logga ut"
 
 #. Default: "Settings"
-#: euphorie/client/browser/templates/webhelpers.pt:65
+#: euphorie/client/browser/templates/webhelpers.pt:62
 msgid "navigation_settings"
 msgstr "Status"
 
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:46
-#: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/templates/shell.pt:273
+#: euphorie/client/browser/templates/webhelpers.pt:59
+#: euphorie/client/templates/shell.pt:262
 msgid "navigation_status"
 msgstr "Status"
 
 #. Default: "My Assessments"
-#: euphorie/client/browser/templates/webhelpers.pt:56
+#: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_surveys"
 msgstr "Undersökningar"
 
@@ -4540,27 +4564,27 @@ msgid "notice_country_manager"
 msgstr "Landschef för ${country}."
 
 #. Default: "On behalf of the employer:"
-#: euphorie/client/docx/compiler.py:482
+#: euphorie/client/docx/compiler.py:437
 msgid "oira_consultation_employer"
 msgstr ""
 
 #. Default: "On behalf of the workers:"
-#: euphorie/client/docx/compiler.py:485
+#: euphorie/client/docx/compiler.py:440
 msgid "oira_consultation_workers"
 msgstr ""
 
 #. Default: "Online interactive"
-#: euphorie/client/browser/templates/webhelpers.pt:41
+#: euphorie/client/browser/templates/webhelpers.pt:38
 msgid "oira_name_line_1"
 msgstr "Interaktiv"
 
 #. Default: "Risk Assessment"
-#: euphorie/client/browser/templates/webhelpers.pt:44
+#: euphorie/client/browser/templates/webhelpers.pt:41
 msgid "oira_name_line_2"
 msgstr "Riskbedömning"
 
 #. Default: "Date:"
-#: euphorie/client/docx/compiler.py:493
+#: euphorie/client/docx/compiler.py:448
 msgid "oira_survey_date"
 msgstr ""
 
@@ -4580,7 +4604,7 @@ msgid "osc_search_placeholder"
 msgstr ""
 
 #. Default: "The undersigned hereby declare that the workers have been consulted on the content of this document."
-#: euphorie/client/docx/compiler.py:475
+#: euphorie/client/docx/compiler.py:430
 msgid "paragraph_oira_consultation_of_workers"
 msgstr ""
 
@@ -4592,7 +4616,7 @@ msgid "password_policy_conditions"
 msgstr ""
 
 #. Default: "The official launch of the tool is planned for September 2011, once the objectives of the testing phase have been reached and once the OiRA website, the OiRA training scheme and OiRA help desk will be ready."
-#: euphorie/client/templates/about.pt:112
+#: euphorie/client/templates/about.pt:113
 msgid "phase_launch"
 msgstr ""
 "Den officiella lanseringen av verktyget planeras ske i september 2011, när "
@@ -4621,45 +4645,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:185
-#: euphorie/client/browser/templates/webhelpers.pt:708
+#: euphorie/client/browser/templates/webhelpers.pt:537
 #: euphorie/content/risk.py:195
 msgid "priority_high"
 msgstr "Hög"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:173
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:525
 #: euphorie/content/risk.py:192
 msgid "priority_low"
 msgstr "Låg"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:179
-#: euphorie/client/browser/templates/webhelpers.pt:702
+#: euphorie/client/browser/templates/webhelpers.pt:531
 #: euphorie/content/risk.py:194
 msgid "priority_medium"
 msgstr "Medium"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:498
+#: euphorie/client/browser/templates/webhelpers.pt:327
 #: euphorie/content/risk.py:399
 msgid "probability_large"
 msgstr "Stor"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:492
+#: euphorie/client/browser/templates/webhelpers.pt:321
 #: euphorie/content/risk.py:397
 msgid "probability_medium"
 msgstr "Medium"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:486
+#: euphorie/client/browser/templates/webhelpers.pt:315
 #: euphorie/content/risk.py:395
 msgid "probability_small"
 msgstr "Liten"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:251
+#: euphorie/client/browser/webhelpers.py:266
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -4708,18 +4732,13 @@ msgstr "Saknar du ett konto? Vänligen ${register_link} först."
 msgid "reminder_email_footer"
 msgstr ""
 
-#. Default: "Actions:"
-#: euphorie/client/docx/compiler.py:657
-msgid "report_actions"
-msgstr ""
-
 #. Default: "Required expertise:"
-#: euphorie/client/docx/compiler.py:668
+#: euphorie/client/docx/compiler.py:612
 msgid "report_competences"
 msgstr ""
 
 #. Default: "To be done by: ${date}"
-#: euphorie/client/docx/compiler.py:691
+#: euphorie/client/docx/compiler.py:635
 msgid "report_end_date"
 msgstr ""
 
@@ -4729,7 +4748,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:894
+#: euphorie/client/docx/compiler.py:838
 msgid "report_identification_revision"
 msgstr ""
 
@@ -4743,17 +4762,17 @@ msgstr ""
 "denna rapport i fältet nedan."
 
 #. Default: "Measures already in place:"
-#: euphorie/client/docx/compiler.py:636
+#: euphorie/client/docx/compiler.py:591
 msgid "report_measures_in_place"
 msgstr ""
 
 #. Default: "Responsible: ${responsible_name}"
-#: euphorie/client/docx/compiler.py:679
+#: euphorie/client/docx/compiler.py:623
 msgid "report_responsible"
 msgstr ""
 
 #. Default: "This document was based on the OiRA Tool '${title}' of revision date ${date}."
-#: euphorie/client/docx/compiler.py:207
+#: euphorie/client/docx/compiler.py:204
 msgid "report_survey_revision"
 msgstr ""
 "Denna rapport är baserad på undersökingen '${title}' från revideringsdatum "
@@ -4785,35 +4804,35 @@ msgid "request_an_email_reminder"
 msgstr "begär en påminnelse via e-post"
 
 #. Default: "Risk is present."
-#: euphorie/client/docx/compiler.py:255
+#: euphorie/client/docx/compiler.py:252
 msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
-#: euphorie/client/docx/compiler.py:295
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/docx/compiler.py:292
 msgid "risk_priority"
 msgstr "Detta är en ${priority} ."
 
-#: euphorie/client/browser/templates/risk_actionplan.pt:102
+#: euphorie/client/browser/templates/risk_actionplan.pt:110
 msgid "risk_priority_${value}"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:95
-#: euphorie/client/docx/compiler.py:293
+#: euphorie/client/browser/templates/risk_actionplan.pt:99
+#: euphorie/client/docx/compiler.py:290
 msgid "risk_priority_high"
 msgstr "högt prioriterad risk"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:87
-#: euphorie/client/docx/compiler.py:289
+#: euphorie/client/browser/templates/risk_actionplan.pt:91
+#: euphorie/client/docx/compiler.py:286
 msgid "risk_priority_low"
 msgstr "lågt prioriterad risk"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:91
-#: euphorie/client/docx/compiler.py:291
+#: euphorie/client/browser/templates/risk_actionplan.pt:95
+#: euphorie/client/docx/compiler.py:288
 msgid "risk_priority_medium"
 msgstr "medium prioriterad risk"
 
@@ -4833,7 +4852,7 @@ msgid "risk_solution_header"
 msgstr "Lösning ${number}"
 
 #. Default: "This risk still needs to be inventorised."
-#: euphorie/client/docx/compiler.py:261
+#: euphorie/client/docx/compiler.py:258
 #: euphorie/client/templates/report_identification.pt:84
 msgid "risk_unanswered"
 msgstr "Denna risk måste fortfarande kartläggas"
@@ -4881,46 +4900,46 @@ msgid "select_add_existing_measure"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:590
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:347
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:591
+#: euphorie/client/browser/templates/webhelpers.pt:420
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:601
+#: euphorie/client/browser/templates/webhelpers.pt:430
 #: euphorie/content/risk.py:350
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:602
+#: euphorie/client/browser/templates/webhelpers.pt:431
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:613
+#: euphorie/client/browser/templates/webhelpers.pt:442
 #: euphorie/content/risk.py:352
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:614
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:579
+#: euphorie/client/browser/templates/webhelpers.pt:408
 #: euphorie/content/risk.py:345
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:580
+#: euphorie/client/browser/templates/webhelpers.pt:409
 msgid "severity_weak_help"
 msgstr ""
 
@@ -4983,7 +5002,7 @@ msgid "titld_tool"
 msgstr "OiRA"
 
 #. Default: "About"
-#: euphorie/client/templates/about.pt:22
+#: euphorie/client/templates/about.pt:23
 msgid "title_about"
 msgstr "Om"
 
@@ -4998,7 +5017,7 @@ msgid "title_account_settings"
 msgstr "Dokumentation"
 
 #. Default: "Change password"
-#: euphorie/client/browser/templates/user-menu.pt:41
+#: euphorie/client/browser/templates/user-menu.pt:43
 #: euphorie/client/settings.py:86
 msgid "title_change_password"
 msgstr ""
@@ -5009,7 +5028,7 @@ msgid "title_client_help"
 msgstr "Klient hjälptext"
 
 #. Default: "Measure"
-#: euphorie/content/solution.py:106
+#: euphorie/content/solution.py:123
 msgid "title_common_solution"
 msgstr "Vanlig lösning"
 
@@ -5044,7 +5063,7 @@ msgid "title_import_sector_survey"
 msgstr "Importera bransch och undersökning"
 
 #. Default: "Added risks (by you)"
-#: euphorie/client/docx/compiler.py:98 euphorie/client/publish.py:141
+#: euphorie/client/docx/compiler.py:95 euphorie/client/publish.py:141
 #: euphorie/client/utils.py:68
 msgid "title_other_risks"
 msgstr "Lista över alla risker."
@@ -5071,8 +5090,8 @@ msgstr ""
 
 #. Default: "OiRA - Online interactive Risk Assessment"
 #: euphorie/client/browser/country.py:263
-#: euphorie/client/browser/templates/modal-template.pt:23
-#: euphorie/client/browser/templates/webhelpers.pt:40
+#: euphorie/client/browser/templates/modal-template.pt:19
+#: euphorie/client/browser/templates/webhelpers.pt:37
 msgid "title_tool"
 msgstr "OiRA"
 
@@ -5097,19 +5116,19 @@ msgid "title_with_vowel_status_of"
 msgstr ""
 
 #. Default: "Contents"
-#: euphorie/client/browser/templates/risks_overview.pt:167
-#: euphorie/client/docx/compiler.py:189
+#: euphorie/client/browser/templates/risks_overview.pt:168
+#: euphorie/client/docx/compiler.py:186
 msgid "toc_header"
 msgstr "Innehåll"
 
 #. Default: "Show/hide menu"
-#: euphorie/client/templates/shell.pt:98
+#: euphorie/client/templates/shell.pt:87
 msgid "tooltip_menu_toggle"
 msgstr ""
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/browser/templates/webhelpers.pt:311
-#: euphorie/client/docx/compiler.py:266
+#: euphorie/client/browser/templates/risk_macros.pt:131
+#: euphorie/client/docx/compiler.py:263
 msgid "top5_risk_not_present"
 msgstr ""
 "Denna risk är inte närvarande inom din organisation, men eftersom "
@@ -5117,7 +5136,7 @@ msgstr ""
 "måste den ingå i denna rapport."
 
 #. Default: "This risk is not present in your organisation, but since the sector organisation considers this one of the priority risks it must be included in this report."
-#: euphorie/client/docx/compiler.py:274
+#: euphorie/client/docx/compiler.py:271
 msgid "top5_risk_not_present_answer_yes"
 msgstr ""
 "Denna risk är inte närvarande inom din organisation, men eftersom "
@@ -5125,7 +5144,7 @@ msgstr ""
 "måste den ingå i denna rapport."
 
 #. Default: "This risk has not yet been assessed, but since it is considered \"high priority\" by the OiRA tool developers, it will always be included in the action plan. Please go to the identification and answer the statement."
-#: euphorie/client/browser/templates/webhelpers.pt:314
+#: euphorie/client/browser/templates/risk_macros.pt:136
 msgid "top5_risk_not_present_postponed"
 msgstr ""
 "Denna risk är inte närvarande inom din organisation, men eftersom "
@@ -5156,7 +5175,7 @@ msgid "use_it_to_full_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:180
+#: euphorie/client/templates/report_landing.pt:178
 msgid "use_it_to_measures_overview"
 msgstr ""
 
@@ -5166,12 +5185,12 @@ msgid "use_it_to_measures_report"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/templates/report_landing.pt:151
+#: euphorie/client/templates/report_landing.pt:150
 msgid "use_it_to_risks_overview"
 msgstr ""
 
 #. Default: "Use it to"
-#: euphorie/client/browser/templates/risks_overview.pt:152
+#: euphorie/client/browser/templates/risks_overview.pt:153
 msgid "use_it_to_risks_report"
 msgstr ""
 
@@ -5186,7 +5205,7 @@ msgid "warn_fix_errors"
 msgstr "Korrigera angivna fel."
 
 #. Default: "You responded negative to the above statement."
-#: euphorie/client/browser/templates/webhelpers.pt:324
+#: euphorie/client/browser/templates/risk_macros.pt:149
 #: euphorie/client/templates/report_identification.pt:83
 msgid "warn_risk_present"
 msgstr "Du svarade nekande till ovanstående redovisning."

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 2.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-28 07:30+0000\n"
+"POT-Creation-Date: 2020-05-12 09:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:906
+#: euphorie/client/browser/risk.py:915
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Information"
 msgstr "Information"
 
-#: euphorie/client/browser/risk.py:571
+#: euphorie/client/browser/risk.py:577
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
@@ -1052,7 +1052,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:912
+#: euphorie/client/browser/risk.py:921
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -2036,17 +2036,17 @@ msgid "error_password_mismatch"
 msgstr "Lösenorden stämmer inte överens"
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:925
+#: euphorie/client/browser/risk.py:934
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:919
+#: euphorie/client/browser/risk.py:928
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:931
+#: euphorie/client/browser/risk.py:940
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2817,7 +2817,7 @@ msgstr ""
 "starta med en kopia av en befintlig undersökning."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:334 euphorie/content/risk.py:361
+#: euphorie/client/browser/risk.py:336 euphorie/content/risk.py:361
 msgid "help_default_frequency"
 msgstr "Ange hur ofta denna risk inträffar i en normal situation."
 
@@ -2829,12 +2829,12 @@ msgstr ""
 "fortfarande ändra prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:329 euphorie/content/risk.py:388
+#: euphorie/client/browser/risk.py:331 euphorie/content/risk.py:388
 msgid "help_default_probability"
 msgstr "Ange hur trolig förekomsten av denna risk är i en normal situation."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:338 euphorie/content/risk.py:339
+#: euphorie/client/browser/risk.py:340 euphorie/content/risk.py:339
 msgid "help_default_severity"
 msgstr "Ange allvarighetsgraden av att hantera denna risk om den inträffar."
 
@@ -3438,7 +3438,7 @@ msgid "label_clone"
 msgstr ""
 
 #. Default: "Please leave any comments you may have on the question above in this field. These comments will be used in the action plan."
-#: euphorie/client/browser/templates/risk_actionplan.pt:562
+#: euphorie/client/browser/templates/risk_actionplan.pt:563
 #: euphorie/client/browser/templates/webhelpers.pt:603
 msgid "label_comment"
 msgstr ""
@@ -3586,7 +3586,7 @@ msgid "label_expertise"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/risk_actionplan.pt:450
+#: euphorie/client/browser/templates/risk_actionplan.pt:451
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr "Förhandsgranskning"
 
 #. Default: "Previous"
 #: euphorie/client/browser/templates/module_identification.pt:74
-#: euphorie/client/browser/templates/risk_actionplan.pt:576
+#: euphorie/client/browser/templates/risk_actionplan.pt:577
 #: euphorie/client/browser/templates/risk_identification.pt:66
 msgid "label_previous"
 msgstr "Föregående"
@@ -4041,7 +4041,7 @@ msgstr ""
 #. Default: "Save and continue"
 #: euphorie/client/browser/templates/profile.pt:106
 #: euphorie/client/browser/templates/report.pt:41
-#: euphorie/client/browser/templates/risk_actionplan.pt:582
+#: euphorie/client/browser/templates/risk_actionplan.pt:583
 msgid "label_save_and_continue"
 msgstr ""
 
@@ -4082,6 +4082,11 @@ msgstr "Starta en ny session genom att välja en av följande branschverktyg"
 #: euphorie/client/browser/templates/new-session.pt:54
 #: euphorie/client/browser/templates/portlet-available-tools.pt:71
 msgid "label_select_oira_tool"
+msgstr ""
+
+#. Default: "Select standard measures"
+#: euphorie/client/browser/templates/risk_actionplan.pt:443
+msgid "label_select_standard_measures"
 msgstr ""
 
 #. Default: "Enter a title for your Risk Assessment"

--- a/src/euphorie/deployment/profiles/default/metadata.xml
+++ b/src/euphorie/deployment/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>26</version>
+  <version>27</version>
   <dependencies>
     <dependency>profile-plone.app.imagecropping:default</dependency>
     <dependency>profile-plonetheme.nuplone:default</dependency>

--- a/src/euphorie/deployment/upgrade/alembic/versions/27_.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/27_.py
@@ -22,7 +22,11 @@ def upgrade():
     op.add_column("session", sa.Column("migrated", sa.DateTime(), nullable=True))
     op.create_index(op.f('ix_action_plan_plan_type'), 'action_plan', ['plan_type'], unique=False)
     op.execute("UPDATE action_plan SET plan_type = 'measure_custom'")
-    op.execute("""UPDATE action_plan ap SET "action" = ap.action_plan || E'\n' || ap.prevention_plan """)
+    op.execute("""
+UPDATE action_plan ap
+    SET "action" = CASE
+    WHEN ap.prevention_plan is not NULL THEN ap.action_plan || E'\n' || ap.prevention_plan
+    ELSE ap.action_plan END""")
     op.alter_column('action_plan', 'plan_type', nullable=False)
 
 

--- a/src/euphorie/deployment/upgrade/alembic/versions/27_.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/27_.py
@@ -7,7 +7,6 @@ Create Date: 2020-03-04 10:51:17.559416
 """
 from alembic import op
 import sqlalchemy as sa
-from euphorie.client.enum import Enum
 
 # revision identifiers, used by Alembic.
 revision = '27'
@@ -17,10 +16,12 @@ depends_on = None
 
 
 def upgrade():
+    op.add_column("action_plan", sa.Column("action", sa.UnicodeText(), nullable=True))
     op.add_column('action_plan', sa.Column('solution_id', sa.Integer(), nullable=True))
     op.add_column('action_plan', sa.Column('plan_type', sa.String(length=20), nullable=True))
     op.create_index(op.f('ix_action_plan_plan_type'), 'action_plan', ['plan_type'], unique=False)
     op.execute("UPDATE action_plan SET plan_type = 'measure_custom'")
+    op.execute("""UPDATE action_plan ap SET "action" = ap.action_plan || E'\n' || ap.prevention_plan """)
     op.alter_column('action_plan', 'plan_type', nullable=False)
 
 

--- a/src/euphorie/deployment/upgrade/alembic/versions/27_.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/27_.py
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade():
     op.add_column("action_plan", sa.Column("action", sa.UnicodeText(), nullable=True))
-    op.add_column('action_plan', sa.Column('solution_id', sa.Integer(), nullable=True))
+    op.add_column('action_plan', sa.Column('solution_id', sa.String(length=20), nullable=True))
     op.add_column('action_plan', sa.Column('plan_type', sa.String(length=20), nullable=True))
     op.add_column("session", sa.Column("migrated", sa.DateTime(), nullable=True))
     op.create_index(op.f('ix_action_plan_plan_type'), 'action_plan', ['plan_type'], unique=False)
@@ -30,3 +30,5 @@ def downgrade():
     op.drop_index(op.f('ix_action_plan_plan_type'), table_name='action_plan')
     op.drop_column('action_plan', 'solution_id')
     op.drop_column('action_plan', 'plan_type')
+    op.drop_column('action_plan', 'action')
+    op.drop_column('session', 'migrated')

--- a/src/euphorie/deployment/upgrade/alembic/versions/27_.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/27_.py
@@ -1,0 +1,30 @@
+"""empty message
+
+Revision ID: 27
+Revises: 26
+Create Date: 2020-03-04 10:51:17.559416
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from euphorie.client.enum import Enum
+
+# revision identifiers, used by Alembic.
+revision = '27'
+down_revision = '26'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('action_plan', sa.Column('solution_id', sa.Integer(), nullable=True))
+    op.add_column('action_plan', sa.Column('plan_type', sa.String(length=20), nullable=True))
+    op.create_index(op.f('ix_action_plan_plan_type'), 'action_plan', ['plan_type'], unique=False)
+    op.execute("UPDATE action_plan SET plan_type = 'measure_custom'")
+    op.alter_column('action_plan', 'plan_type', nullable=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_action_plan_plan_type'), table_name='action_plan')
+    op.drop_column('action_plan', 'solution_id')
+    op.drop_column('action_plan', 'plan_type')

--- a/src/euphorie/deployment/upgrade/alembic/versions/27_.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/27_.py
@@ -19,6 +19,7 @@ def upgrade():
     op.add_column("action_plan", sa.Column("action", sa.UnicodeText(), nullable=True))
     op.add_column('action_plan', sa.Column('solution_id', sa.Integer(), nullable=True))
     op.add_column('action_plan', sa.Column('plan_type', sa.String(length=20), nullable=True))
+    op.add_column("session", sa.Column("migrated", sa.DateTime(), nullable=True))
     op.create_index(op.f('ix_action_plan_plan_type'), 'action_plan', ['plan_type'], unique=False)
     op.execute("UPDATE action_plan SET plan_type = 'measure_custom'")
     op.execute("""UPDATE action_plan ap SET "action" = ap.action_plan || E'\n' || ap.prevention_plan """)

--- a/src/euphorie/deployment/upgrade/configure.zcml
+++ b/src/euphorie/deployment/upgrade/configure.zcml
@@ -422,6 +422,9 @@
       title="Unify action fields in solutions"
       handler=".v27.unify_action_fields_in_solution"/>
     <genericsetup:upgradeStep
+      title="Unify action fields in solutions (in Client)"
+      handler=".v27.unify_action_fields_in_solution_client"/>
+    <genericsetup:upgradeStep
       title="Migrate action plans"
       handler=".v27.migrate_actgion_plans"/>
 

--- a/src/euphorie/deployment/upgrade/configure.zcml
+++ b/src/euphorie/deployment/upgrade/configure.zcml
@@ -421,6 +421,10 @@
     <genericsetup:upgradeStep
       title="Unify action fields in solutions"
       handler=".v27.unify_action_fields_in_solution"/>
+    <genericsetup:upgradeStep
+      title="Migrate action plans"
+      handler=".v27.migrate_actgion_plans"/>
+
     </genericsetup:upgradeSteps>
 
 </configure>

--- a/src/euphorie/deployment/upgrade/configure.zcml
+++ b/src/euphorie/deployment/upgrade/configure.zcml
@@ -408,4 +408,16 @@
 
     </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      destination="27"
+      profile="euphorie.deployment:default"
+      source="26"
+      >
+    <genericsetup:upgradeStep
+        title="Run Alembic migration: extend action plan with plan_type column"
+        description="Check the logs! You might want to adapt the migration to your DB"
+        handler=".v27.alembic_upgrade"
+        />
+    </genericsetup:upgradeSteps>
+
 </configure>

--- a/src/euphorie/deployment/upgrade/configure.zcml
+++ b/src/euphorie/deployment/upgrade/configure.zcml
@@ -418,6 +418,9 @@
         description="Check the logs! You might want to adapt the migration to your DB"
         handler=".v27.alembic_upgrade"
         />
+    <genericsetup:upgradeStep
+      title="Unify action fields in solutions"
+      handler=".v27.unify_action_fields_in_solution"/>
     </genericsetup:upgradeSteps>
 
 </configure>

--- a/src/euphorie/deployment/upgrade/v27.py
+++ b/src/euphorie/deployment/upgrade/v27.py
@@ -139,6 +139,28 @@ def migrate_actgion_plans(context):
 
                 else:
                     zodb_risk = risks_by_path[risk_path]
+
+                # convert ActionPlan items that are clearly based on solutions to "standard" type
+                if not is_custom:
+                    for ap in risk.action_plans:
+                        for solution in solutions_by_path[risk_path]:
+                            if solution.action_plan.startswith(
+                                (ap.action_plan or "").strip()
+                            ):
+                                if (
+                                    (
+                                        getattr(solution, "prevention_plan", "") or ""
+                                    ).strip()
+                                    == ap.prevention_plan
+                                    and (
+                                        getattr(solution, "requirements", "") or ""
+                                    ).strip()
+                                    == ap.requirements
+                                ):
+                                    ap.plan_type = "measure_standard"
+                                    ap.solution_id = solution.id
+
+                # Convert the measures-in-place to their respective ActionPlan items
                 try:
                     saved_existing_measures = (
                         risk.existing_measures and loads(risk.existing_measures) or []

--- a/src/euphorie/deployment/upgrade/v27.py
+++ b/src/euphorie/deployment/upgrade/v27.py
@@ -1,0 +1,6 @@
+# -*- coding: UTF-8 -*-
+from euphorie.deployment.upgrade.utils import alembic_upgrade_to
+
+
+def alembic_upgrade(context):
+    alembic_upgrade_to("27")

--- a/src/euphorie/deployment/upgrade/v27.py
+++ b/src/euphorie/deployment/upgrade/v27.py
@@ -3,6 +3,14 @@ from euphorie.content.solution import ISolution
 from euphorie.deployment.upgrade.utils import alembic_upgrade_to
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
+from z3c.saconfig import Session
+from euphorie.client import model
+from sqlalchemy import and_
+from datetime import date
+from zope.interface import alsoProvides
+from euphorie.client.interfaces import IClientSkinLayer
+from json import loads
+from euphorie.content.risk import IRisk
 
 import logging
 
@@ -41,3 +49,133 @@ def unify_action_fields_in_solution(context):
         walker = walk(getattr(site, section))
         log.info('Iterating over section "{}"'.format(section))
         unifiy_fields(walker)
+
+
+def get_pre_defined_measures(solutions, country):
+    """ Iterate over the Solution items on this risk.
+    """
+    measures = {}
+
+    for item in solutions:
+        description = item.description and item.description.strip() or ""
+        prevention_plan = item.prevention_plan and item.prevention_plan.strip() or ""
+        measure = description
+        if country in ("it",):
+            if prevention_plan:
+                measure = u"%s: %s" % (measure, prevention_plan)
+        measures[measure] = item.id
+
+    return measures
+
+
+def migrate_actgion_plans(context):
+    max_tools = -1
+    site = api.portal.get()
+    client = getattr(site, "client")
+    today = date.today()
+    request = context.REQUEST.clone()
+    alsoProvides(request, IClientSkinLayer)
+    tool_paths = Session.query(model.SurveySession.zodb_path).distinct()
+    # .filter(model.SurveySession.zodb_path=="lv/latvia-test/darbs-biroja").distinct()
+    tool_count = 0
+    for result in tool_paths:
+        tool_path = str(result[0])
+        try:
+            tool = client.restrictedTraverse(tool_path)
+        except KeyError:
+            log.warning("No tool in client found for {}".format(tool_path))
+            continue
+        log.info("\n\nHandle tool {}".format(tool_path))
+        country = tool_path.split("/")[0]
+        sessions = (
+            Session.query(model.SurveySession)
+            .filter(
+                and_(
+                    model.Account.id == model.SurveySession.account_id,
+                    model.Account.account_type != "guest",
+                    model.SurveySession.zodb_path == tool_path,
+                    model.SurveySession.migrated == None,
+                )
+            )
+            .order_by(model.SurveySession.zodb_path)
+        )
+        if not sessions.count():
+            continue
+        risks_by_path = {}
+        solutions_by_path = {}
+        measures_by_path = {}
+        for session in sessions:
+            log.info("Session {}".format(session.id))
+            risks = (
+                Session.query(model.Risk)
+                .filter(model.Risk.session_id == session.id)
+                .order_by(model.Risk.path)
+            )
+            for risk in risks:
+                risk_path = str(risk.zodb_path)
+                is_custom = "custom" in risk_path
+                if is_custom:
+                    zodb_risk = None
+                elif risk_path not in risks_by_path:
+                    try:
+                        zodb_risk = tool.restrictedTraverse(risk_path)
+                    except:
+                        log.warning(
+                            "Risk {} not found in tool {}".format(risk_path, tool_path)
+                        )
+                        continue
+                    else:
+                        if not IRisk.providedBy(zodb_risk):
+                            zodb_risk = None
+                            solutions_by_path[risk_path] = []
+                            measures_by_path[risk_path] = []
+                        else:
+                            solutions = zodb_risk._solutions
+                            solutions_by_path[risk_path] = solutions
+                            measures_by_path[risk_path] = get_pre_defined_measures(
+                                solutions, country
+                            )
+                        risks_by_path[risk_path] = zodb_risk
+
+                else:
+                    zodb_risk = risks_by_path[risk_path]
+                try:
+                    saved_existing_measures = (
+                        risk.existing_measures and loads(risk.existing_measures) or []
+                    )
+                except ValueError:
+                    saved_existing_measures = []
+                # Backwards compat. We used to save dicts before we
+                # switched to list of tuples.
+                if isinstance(saved_existing_measures, dict):
+                    saved_existing_measures = [
+                        (k, v) for (k, v) in saved_existing_measures.items()
+                    ]
+                new_action_plans = []
+                if saved_existing_measures:
+                    custom = []
+                    while saved_existing_measures:
+                        text, active = saved_existing_measures.pop()
+                        if not active:
+                            continue
+                        if not is_custom and text in measures_by_path[risk_path]:
+                            new_action_plans.append(
+                                model.ActionPlan(
+                                    action=text,
+                                    plan_type="in_place_standard",
+                                    solution_id=measures_by_path[risk_path][text],
+                                )
+                            )
+                        else:
+                            custom.append(text)
+                    for text in custom:
+                        new_action_plans.append(
+                            model.ActionPlan(action=text, plan_type="in_place_custom")
+                        )
+                if new_action_plans:
+                    risk.action_plans.extend(new_action_plans)
+            session.migrated = today
+        tool_count += 1
+        if max_tools > 0 and tool_count >= max_tools:
+            log.info("Broke off after %d tools" % tool_count)
+            return

--- a/src/euphorie/deployment/upgrade/v27.py
+++ b/src/euphorie/deployment/upgrade/v27.py
@@ -1,6 +1,33 @@
 # -*- coding: UTF-8 -*-
 from euphorie.deployment.upgrade.utils import alembic_upgrade_to
+from plone import api
+
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def alembic_upgrade(context):
     alembic_upgrade_to("27")
+
+
+def unify_action_fields_in_solution(context):
+    pc = api.portal.get_tool("portal_catalog")
+    solutions = pc(portal_type="euphorie.solution")
+    count = 0
+    for brain in solutions:
+        log.debug("Updating description for %s", brain.getPath())
+        try:
+            solution = brain.getObject()
+        except KeyError:
+            log.error('Could not get object for %s', brain.getPath())
+        action = solution.action_plan.strip()
+        prevention_plan = solution.prevention_plan
+        prevention_plan = prevention_plan and prevention_plan.strip() or ""
+        if prevention_plan:
+            action = u"{0}\n{1}".format(action, prevention_plan)
+        solution.action = action
+        count += 1
+        if count % 100 == 0:
+            log.info("Handled %d items" % count)
+    log.info("Finished. Updated %d solutions" % count)


### PR DESCRIPTION
This PR does severval things:

1) Integrate the re-design of action plan regarding standard measures: instead of a pre-fill per measure, we have a single modal where many standard measured can be picked at once

2) The fields "action_plan" and "prevention_plan" get merged into a single new field "action". Both in the class content.Solution and in the table "action_plan". The old values, now redundant, are kept, in case we need them for refining the upgrade step per country. Cleaning up the old values will happen later

3) The "measures in place", formerly saved in a JSON structure, also get converted to action_plan items, so that we are better able to handle them together with the other measures. Again, the old values are kept (for now).