### PR TITLE
Bugfix: make sure that when the user submits the profile, the session…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,8 +4,8 @@ Changelog
 11.3.12 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Bugfix: make sure that when the user submits the profile, the session always get
+  refreshed. This prevents a potential infinite loop of "The tool has been updated"
 
 11.3.11 (2020-07-01)
 --------------------

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -309,7 +309,9 @@ class Profile(SessionMixin, AutoExtensibleForm, EditForm):
             # At this stage, we actually do not need to touch the session.
             # It is enough that it gets touched when a Risk is edited, or if the
             # tree gets rebuilt due to changes.
-            # survey_session.touch()
+            # Touch means: the modification timestamp is set.
+            # But we need to make sure the refreshed marker is up to date!
+            survey_session.refresh_survey()
             return survey_session
 
         params = {}


### PR DESCRIPTION
… always get

refreshed. This prevents a potential infinite loop of "The tool has been updated"