### PR TITLE
Propage title changes on risks/modules

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Changelog
 --------------------
 
 - New Hungarian translations (provided by client)
+- Make sure that an update to the title of a module or risk gets propagated
+  to existing sessions.
 
 11.3.13 (2020-07-17)
 --------------------

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -311,7 +311,7 @@ class Profile(SessionMixin, AutoExtensibleForm, EditForm):
             # tree gets rebuilt due to changes.
             # Touch means: the modification timestamp is set.
             # But we need to make sure the refreshed marker is up to date!
-            survey_session.refresh_survey()
+            survey_session.refresh_survey(survey)
             return survey_session
 
         params = {}

--- a/src/euphorie/client/update.py
+++ b/src/euphorie/client/update.py
@@ -156,7 +156,7 @@ def wasSurveyUpdated(session, survey):
 
     changes = treeChanges(session, survey)
     if not changes:
-        session.refresh_survey()
+        session.refresh_survey(survey)
         return False
 
     return True


### PR DESCRIPTION
Make sure that an update to the title of a module or risk gets propagated to existing sessions.