### PR TITLE
Omega risks: fix order

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Don't pre-fill a session's title with the Survey name. Let the user choose their
   own name
+- Omega risks: when a risk as added or deleted, make sure that the original order is
+  correct, and that gaps in numbering are closed
 
 11.6.4 (2021-01-19)
 -------------------

--- a/src/euphorie/client/browser/module.py
+++ b/src/euphorie/client/browser/module.py
@@ -172,7 +172,9 @@ class IdentificationView(BrowserView):
         else:
             if ICustomRisksModule.providedBy(module):
                 if reply["next"] == "add_custom_risk":
-                    risk_id = self.add_custom_risk()
+                    self.add_custom_risk()
+                    notify(CustomRisksModifiedEvent(self.context))
+                    risk_id = self.context.children().count()
                     url = "{parent_url}/{risk_id}/@@identification".format(
                         parent_url=self.context.absolute_url(),
                         risk_id=risk_id,
@@ -211,15 +213,10 @@ class IdentificationView(BrowserView):
         risk.postponed = False
         risk.has_description = None
         risk.zodb_path = "/".join(
-            [self.context.zodb_path]
-            +
-            # There's a constraint for unique zodb_path per session
-            ["%d" % counter_id]
-        )
+            [self.context.zodb_path] + ["%d" % counter_id]
+        )  # There's a constraint for unique zodb_path per session
         risk.profile_index = 0  # XXX: not sure what this is for
         self.context.addChild(risk)
-        notify(CustomRisksModifiedEvent(self.context))
-        return counter_id
 
 
 class ActionPlanView(BrowserView):

--- a/src/euphorie/client/browser/module.py
+++ b/src/euphorie/client/browser/module.py
@@ -2,6 +2,7 @@
 from Acquisition import aq_inner
 from euphorie.client import model
 from euphorie.client import utils
+from euphorie.client.interfaces import CustomRisksModifiedEvent
 from euphorie.client.navigation import FindNextQuestion
 from euphorie.client.navigation import FindPreviousQuestion
 from euphorie.client.navigation import getTreeData
@@ -12,6 +13,7 @@ from plone import api
 from plone.memoize.view import memoize
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.event import notify
 
 
 logger = getLogger(__name__)
@@ -216,6 +218,7 @@ class IdentificationView(BrowserView):
         )
         risk.profile_index = 0  # XXX: not sure what this is for
         self.context.addChild(risk)
+        notify(CustomRisksModifiedEvent(self.context))
         return counter_id
 
 

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -794,7 +794,9 @@ class IdentificationView(RiskBase):
                 return self.request.response.redirect(url)
 
             view = api.content.get_view("identification", sql_module, self.request)
-            risk_id = view.add_custom_risk()
+            view.add_custom_risk()
+            notify(CustomRisksModifiedEvent(self.context.aq_parent))
+            risk_id = self.context.aq_parent.children().count()
             # Construct the path to the newly added risk: We know that there
             # is only one custom module, so we can take its id directly. And
             # to that we can append the risk id.

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -11,6 +11,7 @@ from Acquisition import aq_parent
 from euphorie import MessageFactory as _
 from euphorie.client import model
 from euphorie.client import utils
+from euphorie.client.interfaces import CustomRisksModifiedEvent
 from euphorie.client.navigation import FindNextQuestion
 from euphorie.client.navigation import FindPreviousQuestion
 from euphorie.client.navigation import getTreeData
@@ -34,6 +35,7 @@ from z3c.appconfig.interfaces import IAppConfig
 from z3c.appconfig.utils import asBool
 from z3c.saconfig import Session
 from zope.component import getUtility
+from zope.event import notify
 from zope.publisher.interfaces import NotFound
 
 import datetime
@@ -1174,7 +1176,7 @@ class ConfirmationDeleteRisk(BrowserView):
 
 
 class DeleteRisk(BrowserView):
-    """View name: @@delete-session"""
+    """View name: @@delete-risk"""
 
     def __call__(self):
         risk_id = self.request.form.get("risk_id", None)
@@ -1190,6 +1192,7 @@ class DeleteRisk(BrowserView):
                     if risk.id != risk_id
                 ]
                 self.context.removeChildren(excluded=keep_ids)
+                notify(CustomRisksModifiedEvent(self.context))
 
         self.request.response.redirect(
             "{session_url}/@@identification".format(

--- a/src/euphorie/client/interfaces.py
+++ b/src/euphorie/client/interfaces.py
@@ -1,6 +1,18 @@
 from plonetheme.nuplone.z3cform.interfaces import INuPloneFormLayer
+from zope.component.interfaces import ObjectEvent
+from zope.interface import implements
+from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
 class IClientSkinLayer(IDefaultBrowserLayer, INuPloneFormLayer):
     """Zope skin layer for the online client."""
+
+
+class ICustomRisksModifiedEvent(Interface):
+    """Custom risks were modified"""
+
+
+class CustomRisksModifiedEvent(ObjectEvent):
+
+    implements(ICustomRisksModifiedEvent)

--- a/src/euphorie/client/subscribers/configure.zcml
+++ b/src/euphorie/client/subscribers/configure.zcml
@@ -11,4 +11,10 @@
 		     zope.lifecycleevent.interfaces.IObjectModifiedEvent"
 		handler=".imagecropping.crop_on_image_edit" />
 
+  	<subscriber
+      	for="euphorie.client.model.Module
+      		 euphorie.client.interfaces.CustomRisksModifiedEvent"
+      	handler=".module.handle_custom_risks_order"
+ 	/>
+
 </configure>

--- a/src/euphorie/client/subscribers/module.py
+++ b/src/euphorie/client/subscribers/module.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+from euphorie.client.model import SurveyTreeItem
+from sqlalchemy import and_
+from sqlalchemy.sql import func
+from z3c.saconfig import Session
+
+
+def handle_custom_risks_order(context, event):
+    session = Session()
+
+    custom_risks = session.query(SurveyTreeItem).filter(
+        and_(
+            SurveyTreeItem.session_id == context.session_id,
+            SurveyTreeItem.path.like(context.path + "%"),
+            SurveyTreeItem.type == "risk",
+        )
+    )
+
+    # First, set all zodb_paths to bogus "XXX" values, to avoid constraint errors
+    custom_risks.update(
+        {
+            SurveyTreeItem.path: context.path
+            + func.lpad(func.split_part(SurveyTreeItem.zodb_path, "/", 2), 3, "0")
+            + "xxx"
+        },
+        synchronize_session=False,
+    )
+
+    # Now, set the zodb_path according to the path (= natural order)
+    custom_risks.update(
+        {
+            SurveyTreeItem.path: context.path
+            + func.lpad(func.split_part(SurveyTreeItem.zodb_path, "/", 2), 3, "0")
+        },
+        synchronize_session=False,
+    )

--- a/src/euphorie/client/subscribers/module.py
+++ b/src/euphorie/client/subscribers/module.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from euphorie.client.model import SurveyTreeItem
 from sqlalchemy import and_
+from sqlalchemy import Integer
 from sqlalchemy.sql import func
+from sqlalchemy.sql.expression import cast
 from z3c.saconfig import Session
 
 
@@ -16,21 +18,28 @@ def handle_custom_risks_order(context, event):
         )
     )
 
-    # First, set all zodb_paths to bogus "XXX" values, to avoid constraint errors
-    custom_risks.update(
-        {
-            SurveyTreeItem.path: context.path
-            + func.lpad(func.split_part(SurveyTreeItem.zodb_path, "/", 2), 3, "0")
-            + "xxx"
-        },
-        synchronize_session=False,
+    # First, set all paths and zodb_paths to bogus values (extra zeros)
+    # to avoid constraint errors
+    for risk in custom_risks:
+        risk.path = risk.path + "000"
+        risk.zodb_path = risk.zodb_path + u"000"
+
+    ordered_custom_risks = (
+        session.query(SurveyTreeItem)
+        .filter(
+            and_(
+                SurveyTreeItem.session_id == context.session_id,
+                SurveyTreeItem.path.like(context.path + "%"),
+                SurveyTreeItem.type == "risk",
+            )
+        )
+        .order_by(cast(func.split_part(SurveyTreeItem.zodb_path, "/", 2), Integer))
     )
 
-    # Now, set the zodb_path according to the path (= natural order)
-    custom_risks.update(
-        {
-            SurveyTreeItem.path: context.path
-            + func.lpad(func.split_part(SurveyTreeItem.zodb_path, "/", 2), 3, "0")
-        },
-        synchronize_session=False,
-    )
+    # Iterate over the risks in their natural order. Close any gaps in numbering
+    for count, risk in enumerate(ordered_custom_risks):
+        risk.zodb_path = u"custom-risks/{}".format(count + 1)
+
+    # Now, set the path according to the zodb_path (= natural order)
+    for risk in custom_risks:
+        risk.path = "%s%03d" % (context.path, int(risk.zodb_path.split("/")[-1]))


### PR DESCRIPTION
In the wild it sometimes happens that the order of omega risks gets jumbled. The reason has not been found (heisenbug).

With an event handler we can make sure that after adding or removing an omega risk the original order is restored. Additionally we close any gaps in numbering that might arise if a risk gets deleted.