### PR TITLE
Add a new view @@get-resources-timestamp

### DIFF
--- a/src/euphorie/deployment/browser/configure.zcml
+++ b/src/euphorie/deployment/browser/configure.zcml
@@ -24,6 +24,13 @@
       />
 
   <browser:page
+      name="get-resources-timestamp"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      class=".site.GetEuphorieResourcesTimestamp"
+      permission="zope2.Public"
+      />
+
+  <browser:page
       name="manage-ensure-interface"
       for="*"
       permission="cmf.ManagePortal"

--- a/src/euphorie/deployment/browser/site.py
+++ b/src/euphorie/deployment/browser/site.py
@@ -82,6 +82,12 @@ class EuphorieRefreshResourcesTimestamp(BrowserView):
         return "OK"
 
 
+class GetEuphorieResourcesTimestamp(EuphorieRefreshResourcesTimestamp):
+    def __call__(self):
+        """Get the resource timestamp"""
+        return self.resources_timestamp
+
+
 class ManageEnsureInterface(BrowserView):
     def set_evaluation_method_interfaces(self):
         def walk(node):

--- a/src/euphorie/deployment/tests/test_setup.py
+++ b/src/euphorie/deployment/tests/test_setup.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 from euphorie.testing import EuphorieIntegrationTestCase
+from plone import api
+from time import time
 
 
 class SetupTests(EuphorieIntegrationTestCase):
@@ -34,3 +36,18 @@ class SetupTests(EuphorieIntegrationTestCase):
     def testNuPloneEnabled(self):
         st = self.portal.portal_skins
         self.assertEqual(st.getDefaultSkin(), "NuPlone")
+
+    def test_get_resource_timestamp(self):
+        self.logout()
+        self.assertEqual(
+            self.portal.restrictedTraverse("@@get-resources-timestamp")(), None
+        )
+
+        with api.env.adopt_user("admin"):
+            self.portal.restrictedTraverse("@@refresh-resources-timestamp")()
+
+        self.request.__annotations__.clear()
+        self.assertEqual(
+            int(self.portal.restrictedTraverse("@@get-resources-timestamp")()) // 10,
+            int(time()) // 10,
+        )


### PR DESCRIPTION
A new view ``@@get-resources-timestamp`` has been introduced to not use
the protected view ``@@refresh-resources-timestamp`` which will be
forbidden by the latest security hotfix

Edit: this is not strictly needed anymore after with version 1.2 of the hotfix but it seems a good idea to merge this anyway.