### PR TITLE
scr-1198 - portal renewal: main template website border

### DIFF
--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -531,6 +531,14 @@
       />
 
   <browser:page
+      name="help-menu.html"
+      for="*"
+      permission="zope2.View"
+      template="templates/help-menu.pt"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
+  <browser:page
       name="update-completion-percentage"
       for="euphorie.client.adapters.session_traversal.ITraversedSurveySession"
       permission="zope2.View"

--- a/src/euphorie/client/browser/templates/help-menu.pt
+++ b/src/euphorie/client/browser/templates/help-menu.pt
@@ -5,36 +5,33 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       meta:interpolation="true"
-      tal:define="
-        webhelpers nocall:context/@@webhelpers;
-        base_url webhelpers/base_url;
-      "
+      metal:use-macro="context/@@modal-template/macros/shell"
       i18n:domain="euphorie"
 >
 
-  <metal:help-menu define-macro="help-menu"
-                   meta:interpolation="true"
-                   i18n:domain="euphorie"
-  >
-    <div id="help-menu"
-         hidden="hidden"
+  <body i18n:domain="euphorie">
+    <metal:slot fill-slot="content"
+                tal:define="webhelpers nocall:context/@@webhelpers"
     >
-      <ul class="menu">
-        <li>
-          <button class="icon-circles osh-toggle pat-toggle close-panel"
-                  id="osh-toggle"
-                  data-pat-toggle="selector: body; value: osh-on osh-off; store: local"
-                  i18n:translate=""
-          >Toggle on screen help</button>
-        </li>
-        <li>
-          <a class="icon-help-circle close-panel"
-             href="${base_url}/help#content"
-             target="Help"
-             i18n:translate="navigation_help"
-          >Help</a>
-        </li>
-      </ul>
-    </div>
-  </metal:help-menu>
+      <section id="menu-content">
+        <ul class="menu">
+          <li class="menu-item-on-screen-help">
+            <button class="icon-circles osh-toggle pat-toggle close-panel"
+                    id="osh-toggle"
+                    data-pat-toggle="selector: body; value: osh-on osh-off; store: local"
+                    i18n:translate=""
+            >Toggle on screen help</button>
+          </li>
+          <li class="menu-item-help">
+            <a class="pat-inject icon-help-circle close-panel"
+               href="${webhelpers/base_url}/++resource++euphorie.resources/oira/help/${webhelpers/help_language}/index.html"
+               target="Help"
+               data-pat-inject="history: record"
+               i18n:translate="navigation_help"
+            >Help</a>
+          </li>
+        </ul>
+      </section>
+    </metal:slot>
+  </body>
 </html>

--- a/src/euphorie/client/browser/templates/shell-for-iframe.pt
+++ b/src/euphorie/client/browser/templates/shell-for-iframe.pt
@@ -27,10 +27,6 @@
           rel="stylesheet"
           type="text/css"
     />
-    <script>window.__patternslib_public_path__ = "${webhelpers/client_url}/${webhelpers/script_path}/";</script>
-    <script src="${webhelpers/client_url}/${webhelpers/script_path}/polyfills-loader.js"
-            type="text/javascript"
-    ></script>
     <script src="${webhelpers/js_url}"
             type="text/javascript"
     ></script>

--- a/src/euphorie/client/browser/templates/shell.pt
+++ b/src/euphorie/client/browser/templates/shell.pt
@@ -167,12 +167,21 @@
 
         <tal:if_not_anon condition="python: not is_anonymous and not webhelpers.is_guest_account">
           <a class="iconified pat-tooltip pat-switch"
-             id="more-menu"
+             id="user-menu"
              href="${webhelpers/session_overview_url}/user-menu.html#menu-content"
              data-pat-switch="selector: body; remove: osc-s-on; add: osc-s-off;"
              data-pat-tooltip="source: ajax;"
-          >More&hellip;</a>
+             i18n:translate="more_link"
+          >More</a>
         </tal:if_not_anon>
+        <a
+            id="help-menu"
+            href="${webhelpers/session_overview_url}/help-menu.html#menu-content"
+            class="iconified pat-tooltip pat-switch"
+            data-pat-switch="selector: body; remove: osc-s-on; add: osc-s-off;"
+            data-pat-tooltip="source: ajax"
+            i18n:translate="help_link"
+        >Help</a>
         <a class="home pat-inject iconified icon-home pat-switch"
            href="${webhelpers/country_or_client_url}"
            title="Dashboard"

--- a/src/euphorie/client/browser/templates/shell.pt
+++ b/src/euphorie/client/browser/templates/shell.pt
@@ -165,17 +165,6 @@
                        "
         />
 
-        <tal:if_anon condition="python:is_anonymous or webhelpers.is_guest_account">
-          <a class="pat-modal login"
-             href="${webhelpers/country_or_client_url}/login_form?${came_from_param}#document-content"
-             data-pat-modal="class: large"
-             i18n:translate="header_login"
-          >Login</a>
-          <a class="registration"
-             href="${webhelpers/country_or_client_url}/register"
-             i18n:translate="header_register"
-          >Register</a>
-        </tal:if_anon>
         <tal:if_not_anon condition="python: not is_anonymous and not webhelpers.is_guest_account">
           <a class="iconified pat-tooltip pat-switch"
              id="more-menu"

--- a/src/euphorie/client/browser/templates/shell.pt
+++ b/src/euphorie/client/browser/templates/shell.pt
@@ -51,11 +51,6 @@
           type="image/png"
     />
 
-    <script>window.__patternslib_public_path__ = "${webhelpers/client_url}/${webhelpers/script_path}/";</script>
-    <script src="${webhelpers/client_url}/${webhelpers/script_path}/polyfills-loader.js"
-            type="text/javascript"
-    ></script>
-
     <script src="${webhelpers/js_url}"
             type="text/javascript"
     ></script>

--- a/src/euphorie/client/browser/templates/user-menu.pt
+++ b/src/euphorie/client/browser/templates/user-menu.pt
@@ -29,19 +29,6 @@
             >Browse risk assessments</a>
           </li>
 
-          <li class="menu-item-on-screen-help">
-            <button class="icon-circles osh-toggle pat-toggle close-panel"
-                    id="osh-toggle"
-                    data-pat-toggle="selector: body; value: osh-on osh-off; store: local"
-                    i18n:translate=""
-            >Toggle on screen help</button>
-          </li>
-          <li class="menu-item-help">
-            <a class="icon-help-circle close-panel"
-               href="${webhelpers/country_or_client_url}/++resource++euphorie.resources/oira/help/${webhelpers/help_language}/index.html"
-               i18n:translate="navigation_help"
-            >Help</a>
-          </li>
           <li class="menu-item-change-password">
             <a class="icon-key"
                href="${country_url}/account-settings"


### PR DESCRIPTION
- Remove obsolete ``__patternslib_public_path__`` global JavaScript variable. The public path and chunk directory is automatically discovered.
- Remove Login/Registrations menus from unauth toolbar - aligned with prototype.
- Integrate help menu.

Ref: scr-1198