### PR TITLE
Enforce client password policy

### DIFF
--- a/src/euphorie/client/browser/login.py
+++ b/src/euphorie/client/browser/login.py
@@ -98,6 +98,27 @@ class Login(BrowserView):
         for session in sessions:
             session.account_id = account.id
 
+    def is_valid_password(self, password):
+        if (
+            len(password) < 12
+            or not re.search("[A-Z]", password)
+            or not re.search("[a-z]", password)
+            or not re.search("[1-9]", password)
+        ):
+            return False
+        return True
+
+    def check_password_policy(self, password):
+        if not self.is_valid_password(password):
+            return _(
+                "error_password_policy_violation",
+                default=(
+                    u"The password needs to be at least 12 characters long and "
+                    u"needs to contain at least one lower case letter, one upper "
+                    u"case letter and one digit."
+                )
+            )
+
     def _tryRegistration(self):
         form = self.request.form
         loginname = form.get("email")
@@ -117,6 +138,10 @@ class Login(BrowserView):
             self.errors["password"] = _(
                 "error_password_mismatch", default=u"Passwords do not match"
             )
+        else:
+            policy_error = self.check_password_policy(form.get("password1"))
+            if policy_error:
+                self.errors["password"] = policy_error
         if not form.get("terms"):
             self.errors["terms"] = _(
                 "error_terms_not_accepted",

--- a/src/euphorie/client/browser/settings.py
+++ b/src/euphorie/client/browser/settings.py
@@ -109,6 +109,14 @@ class AccountSettings(AutoExtensibleForm, form.Form):
         if not data["new_password"]:
             flash(_(u"There were no changes to be saved."), "notice")
             return
+        login_view = api.content.get_view(
+            name="login",
+            context=self.context,
+            request=self.request,
+        )
+        error = login_view.check_password_policy(data["new_password"])
+        if error:
+            raise WidgetActionExecutionError("new_password", Invalid(error))
         if not user.verify_password(data["old_password"]):
             raise WidgetActionExecutionError(
                 "old_password", Invalid(_(u"Invalid password"))

--- a/src/euphorie/client/tests/test_authentication.py
+++ b/src/euphorie/client/tests/test_authentication.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from euphorie.client import model
+from euphorie.client.browser.login import Login
 from euphorie.client.authentication import EuphorieAccountPlugin
 from euphorie.client.interfaces import IClientSkinLayer
 from euphorie.client.tests.database import DatabaseTests
@@ -8,6 +9,7 @@ from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 from Products.PluggableAuthService.interfaces.plugins import IExtractionPlugin
 from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlugin
 from Products.PluggableAuthService.interfaces.plugins import IUserFactoryPlugin
+from unittest import TestCase
 from z3c.saconfig import Session
 from zope.interface import directlyProvides
 from zope.interface.verify import verifyClass
@@ -193,4 +195,37 @@ class EuphorieAccountPluginTests(DatabaseTests):
             response.redirect_url,
             "http://www.example.com/base/@@login?"
             "came_from=http%3A%2F%2Fwww.example.com%2Fclient%3Fone%3D1",
+        )
+
+
+class PasswordPolicyTests(TestCase):
+
+    def setUp(self):
+        self.login_view = Login(None, None)
+
+    def test_password_valid(self):
+        self.assertTrue(self.login_view.is_valid_password("Abcdef123456"))
+
+    def test_password_length(self):
+        self.assertFalse(
+            self.login_view.is_valid_password("Ab12"),
+            "Minimal length not enforced",
+        )
+
+    def test_password_upper_case(self):
+        self.assertFalse(
+            self.login_view.is_valid_password("abcdef123456"),
+            "Upper case letter not enforced",
+        )
+
+    def test_password_lower_case(self):
+        self.assertFalse(
+            self.login_view.is_valid_password("ABCDEF123456"),
+            "Lower case letter not enforced",
+        )
+
+    def test_password_digit(self):
+        self.assertFalse(
+            self.login_view.is_valid_password("ABCDEFghijkl"),
+            "Digit not enforced",
         )


### PR DESCRIPTION
“The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit.”

Refs SCR-1388