### PR TITLE
The euphorie user factory plugin is enabled now only in the client

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,7 @@ Changelog
 12.0.10 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- The euphorie user factory plugin is enabled now only in the client
 
 
 12.0.9 (2021-09-08)

--- a/src/euphorie/client/authentication.py
+++ b/src/euphorie/client/authentication.py
@@ -214,6 +214,8 @@ class EuphorieAccountPlugin(BasePlugin):
         # a case, query like `get(user_id)` matches the 'id' column in Account
         # first. If the loginname that is an integer also corresponds to an id
         # in the Account table, we would find the wrong user.
+        if not IClientSkinLayer.providedBy(self.REQUEST):
+            return None
         if not name:
             return (
                 Session()


### PR DESCRIPTION
Other plugins follow the same logic, see e.g.:
https://github.com/euphorie/Euphorie/commit/6f20f60dc4c52287c68f4ad72951672a22a63640