### PR TITLE
Add a subscriber to record the last login for a client account.

### DIFF
--- a/src/euphorie/client/browser/login.py
+++ b/src/euphorie/client/browser/login.py
@@ -23,6 +23,7 @@ from plone.session.plugins.session import cookie_expiration_date
 from plonetheme.nuplone.tiles.analytics import trigger_extra_pageview
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
+from Products.PlonePAS.events import UserLoggedInEvent
 from Products.statusmessages.interfaces import IStatusMessage
 from six.moves.urllib.parse import parse_qs
 from six.moves.urllib.parse import urlencode
@@ -30,6 +31,7 @@ from six.moves.urllib.parse import urlparse
 from six.moves.urllib.parse import urlsplit
 from z3c.saconfig import Session
 from zExceptions import Unauthorized
+from zope.lifecycleevent import notify
 
 import datetime
 import logging
@@ -74,7 +76,7 @@ class Login(BrowserView):
             account.loginname,
             account.password,
         )
-        account.last_login = datetime.datetime.now()
+        notify(UserLoggedInEvent(account))
         if remember:
             self.request.RESPONSE.cookies["__ac"]["expires"] = cookie_expiration_date(
                 120

--- a/src/euphorie/client/subscribers/configure.zcml
+++ b/src/euphorie/client/subscribers/configure.zcml
@@ -30,4 +30,6 @@
       	handler=".module.handle_custom_risks_order"
  	/>
 
+    <subscriber handler=".login.record_last_login" />
+
 </configure>

--- a/src/euphorie/client/subscribers/login.py
+++ b/src/euphorie/client/subscribers/login.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+from euphorie.client.model import Account
+from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
+from zope.component import adapter
+
+
+@adapter(Account, IUserLoggedInEvent)
+def record_last_login(account, event=None):
+    account.last_login = datetime.now()


### PR DESCRIPTION
A short discussion on this...
For some reason the authentication process for the client does not fire the user logged in event.
In the previous PR I then just recorded login time in the login view.
Anyway there might be other projects that override that view or use different authentication methods.
Having a subscriber is then a more compatible and secure way to have the last login time recorded.