### PR TITLE
Keep country after registration

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Changelog
 --------------------
 
 - Prevent execution of malicious code entered as custom measure or training notes.
+- Prevent redirect to default country after registration.
 
 12.0.16 (2021-11-11)
 --------------------

--- a/scripts/proto2diazo.py
+++ b/scripts/proto2diazo.py
@@ -88,9 +88,7 @@ def fix_urls(filepath):
     content = content.replace(
         "url(/media/", "url(++resource++euphorie.resources/media/"
     )
-    content = content.replace(
-        "url(/assets/", "url(++resource++euphorie.resources/"
-    )
+    content = content.replace("url(/assets/", "url(++resource++euphorie.resources/")
 
     open(filepath, "w").write(content)
 

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -463,10 +463,7 @@ class Surveys(BrowserView, SurveyTemplatesMixin):
     def languages(self):
         return sorted(
             [
-                {
-                    "code": code,
-                    "name": self.webhelpers.getNameForLanguageCode(code)
-                }
+                {"code": code, "name": self.webhelpers.getNameForLanguageCode(code)}
                 for code in api.portal.get_tool("portal_catalog").uniqueValuesFor(
                     "Language"
                 )

--- a/src/euphorie/client/browser/login.py
+++ b/src/euphorie/client/browser/login.py
@@ -10,7 +10,6 @@ from ..utils import setLanguage
 from .conditions import approvedTermsAndConditions
 from Acquisition import aq_chain
 from Acquisition import aq_inner
-from Acquisition import aq_parent
 from euphorie.client import config
 from euphorie.client import MessageFactory as _
 from euphorie.client import model
@@ -220,7 +219,8 @@ class Login(BrowserView):
             self.setLanguage(came_from)
         else:
             # Set to country url
-            came_from = aq_parent(context).absolute_url()
+            webhelpers = api.content.get_view("webhelpers", context, self.request)
+            came_from = webhelpers.country_url
 
         account = get_current_account()
         self.allow_guest_accounts = api.portal.get_registry_record(

--- a/src/euphorie/client/browser/login.py
+++ b/src/euphorie/client/browser/login.py
@@ -292,7 +292,7 @@ class Login(BrowserView):
         return self.index()
 
     def get_image_version(self, name):
-        """" Needed on the reports overview shown to the guest user
+        """Needed on the reports overview shown to the guest user
         (view name: @@register_session)
         """
         fdir = os.path.join(

--- a/src/euphorie/client/browser/survey.py
+++ b/src/euphorie/client/browser/survey.py
@@ -57,7 +57,6 @@ class SurveySessionsView(SessionsView):
 
 
 class SurveySessionsViewAnon(SurveySessionsView):
-
     def __call__(self):
         self.set_language()
         return self.index()

--- a/src/euphorie/client/tests/test_authentication.py
+++ b/src/euphorie/client/tests/test_authentication.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from euphorie.client import model
-from euphorie.client.browser.login import Login
 from euphorie.client.authentication import EuphorieAccountPlugin
+from euphorie.client.browser.login import Login
 from euphorie.client.interfaces import IClientSkinLayer
 from euphorie.client.tests.database import DatabaseTests
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
@@ -202,7 +202,6 @@ class EuphorieAccountPluginTests(DatabaseTests):
 
 
 class PasswordPolicyTests(TestCase):
-
     def setUp(self):
         self.login_view = Login(None, None)
 

--- a/src/euphorie/upgrade/content/v1/20210730081303_add_lead_image_behavior_to_survey/upgrade.py
+++ b/src/euphorie/upgrade/content/v1/20210730081303_add_lead_image_behavior_to_survey/upgrade.py
@@ -2,8 +2,7 @@ from ftw.upgrade import UpgradeStep
 
 
 class AddLeadImageBehaviorToSurvey(UpgradeStep):
-    """Add lead image behavior to survey.
-    """
+    """Add lead image behavior to survey."""
 
     def __call__(self):
         self.install_upgrade_profile()


### PR DESCRIPTION
Login/Registration: Use webhelpers to get country URL. Fixes redirect to default country when came_from is missing.

Refs [SCR-1586](https://jira.syslab.com/browse/SCR-1586)