### PR TITLE
Adjust instructions on Profile page to actual situation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,8 +4,9 @@ Changelog
 13.0.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Profile page: if none of the profile questions uses the location question, do
+  not show the intro text that informs about multiple locations
+  Refs #MOI-532
 
 13.0.5 (2022-01-11)
 -------------------

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -398,6 +398,10 @@ class Profile(SessionMixin, AutoExtensibleForm, EditForm):
     def current_profile(self):
         return extractProfile(self.context.aq_parent, self.session)
 
+    @property
+    def has_location_questions(self):
+        return any([x["use_location_question"] for x in self.profile_questions])
+
     def update(self):
         utils.setLanguage(self.request, self.survey, self.survey.language)
         if not self.profile_questions or self.request.method == "POST":

--- a/src/euphorie/client/browser/templates/profile.pt
+++ b/src/euphorie/client/browser/templates/profile.pt
@@ -27,7 +27,9 @@
             <li i18n:translate="expl_profile_bullet1">select or skip situation(s) relevant or not to your business activity and
         tick the box(es) if appropriate
             </li>
-            <li i18n:translate="expl_profile_bullet2">list multiple business units, or branches, or stores, etc. These related
+            <li tal:condition="view/has_location_questions"
+                i18n:translate="expl_profile_bullet2"
+            >list multiple business units, or branches, or stores, etc. These related
         risks will be repeated for each name you have entered.
             </li>
           </ul>
@@ -128,10 +130,10 @@
                            tal:condition="not:current"
                     >
                       <input class="pat-depends"
+                             name="${question/id}:utf8:utext:list"
+                             required="required"
                              size="40"
                              type="text"
-                             required="required"
-                             name="${question/id}:utf8:utext:list"
                              data-pat-depends="condition: pq${question/id}.present=yes; action: both;"
                       />
                     </label>


### PR DESCRIPTION
Profile page: if none of the profile questions uses the location question, do not show the intro text that informs about multiple locations
Refs: #SCR-1683