### PR TITLE
Improve the clone functionality

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 13.0.10 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- When a user tries to operate on a session without enough rights,
+  they are redirected to the sessions overview
+  [ale-rt]
 
 
 13.0.9 (2022-02-23)

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -975,7 +975,7 @@ class ImageDisplay(DisplayFile):
         if not self.webhelpers.can_view_session:
             # The user cannot call this view to go the sessions overview.
             return self.request.response.redirect(self.webhelpers.client_url)
-        return super().__call__()
+        return super(ImageDisplay, self).__call__()
 
 
 class ActionPlanView(RiskBase):

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -403,6 +403,12 @@ class IdentificationView(RiskBase):
         return condition
 
     def __call__(self):
+        # Render the page only if the user has edit rights,
+        # otherwise redirect to the start page of the session.
+        if not self.webhelpers.can_edit_session:
+            return self.request.response.redirect(
+                self.context.aq_parent.absolute_url() + "/@@start"
+            )
         super(IdentificationView, self).__call__()
         self.check_render_condition()
 
@@ -883,7 +889,15 @@ class ImageUpload(BrowserView):
             "{}/@@identification".format(self.context.absolute_url())
         )
 
+    @property
+    @memoize
+    def webhelpers(self):
+        return api.content.get_view("webhelpers", self.context.aq_parent, self.request)
+
     def __call__(self):
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
         if self.request.form.get("image"):
             image = self.request.form["image"]
             new_data = image.read()
@@ -918,6 +932,11 @@ class ImageDisplay(DisplayFile):
     ../@@image-display/image_large/${here/image_filename}
     """
 
+    @property
+    @memoize
+    def webhelpers(self):
+        return api.content.get_view("webhelpers", self.context.aq_parent, self.request)
+
     def get_or_create_image_scaled(self):
         """Get the image scaled"""
         if self.context.image_data_scaled:
@@ -951,6 +970,12 @@ class ImageDisplay(DisplayFile):
             image_data = self.context.image_data
 
         return NamedBlobImage(image_data, filename=self.context.image_filename)
+
+    def __call__(self):
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
+        return super().__call__()
 
 
 class ActionPlanView(RiskBase):
@@ -1174,6 +1199,9 @@ class ConfirmationDeleteRisk(BrowserView):
 
     def __call__(self, *args, **kwargs):
         """Before rendering check if we can find session title"""
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
         self.risk_title
         return super(ConfirmationDeleteRisk, self).__call__(*args, **kwargs)
 
@@ -1182,6 +1210,10 @@ class DeleteRisk(BrowserView):
     """View name: @@delete-risk"""
 
     def __call__(self):
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
+
         risk_id = self.request.form.get("risk_id", None)
         if risk_id:
             try:

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -774,7 +774,7 @@ class CloneSession(SessionMixin, BrowserView):
         if not self.webhelpers.can_view_session:
             # The user cannot call this view to go the sessions overview.
             return self.request.response.redirect(self.webhelpers.client_url)
-        return super().__call__()
+        return super(CloneSession, self).__call__()
 
 
 class PublicationMenu(SessionMixin, BrowserView):

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -438,6 +438,10 @@ class Involve(SessionMixin, BrowserView):
         )
 
     def __call__(self):
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view, to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
+
         utils.setLanguage(self.request, self.survey, self.survey.language)
         return super(Involve, self).__call__()
 
@@ -753,6 +757,10 @@ class CloneSession(SessionMixin, BrowserView):
 
     def clone(self):
         """Clone this session and redirect to the start view"""
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
+
         new_session = self.get_cloned_session()
         api.portal.show_message(
             _("The risk assessment has been cloned"), self.request, "success"
@@ -761,6 +769,12 @@ class CloneSession(SessionMixin, BrowserView):
             contexturl=aq_parent(self.context).absolute_url(), sessionid=new_session.id
         )
         self.request.response.redirect(target)
+
+    def __call__(self):
+        if not self.webhelpers.can_view_session:
+            # The user cannot call this view to go the sessions overview.
+            return self.request.response.redirect(self.webhelpers.client_url)
+        return super().__call__()
 
 
 class PublicationMenu(SessionMixin, BrowserView):

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1097,6 +1097,10 @@ class SurveySession(BaseObject):
         return client.restrictedTraverse(str(self.zodb_path), None)
 
     @property
+    def traversed_session(self):
+        return self.tool.restrictedTraverse("++session++%s" % self.id)
+
+    @property
     def country(self):
         return str(self.zodb_path).split("/")[0]
 

--- a/src/euphorie/client/tests/test_cloning.py
+++ b/src/euphorie/client/tests/test_cloning.py
@@ -1,11 +1,11 @@
 # coding=utf-8
-from AccessControl.SecurityManagement import newSecurityManager
 from datetime import datetime
 from euphorie.client import model
 from euphorie.client.tests.utils import addAccount
 from euphorie.client.tests.utils import addSurvey
 from euphorie.content.tests.utils import BASIC_SURVEY
 from euphorie.testing import EuphorieIntegrationTestCase
+from plone import api
 
 
 class TestCloningViews(EuphorieIntegrationTestCase):
@@ -13,13 +13,23 @@ class TestCloningViews(EuphorieIntegrationTestCase):
         super(TestCloningViews, self).setUp()
         self.loginAsPortalOwner()
         addSurvey(self.portal, BASIC_SURVEY)
-        account = addAccount(password="secret")
+        self.jane = addAccount("jane@example.com", password="secret")
+        self.john = addAccount("john@example.com", password="secret")
+
+        group = model.Group(group_id="1")
+        model.Session.add(group)
+
+        self.jane.group = group
+        self.john.group = group
+        model.Session.flush()
+
         survey_session = model.SurveySession(
             title=u"Dummy session",
             created=datetime(2012, 4, 22, 23, 5, 12),
             modified=datetime(2012, 4, 23, 11, 50, 30),
             zodb_path="nl/ict/software-development",
-            account=account,
+            account=self.jane,
+            group=group,
             company=model.Company(country="nl", employees="1-9", referer="other"),
         )
         module = survey_session.addChild(
@@ -33,48 +43,55 @@ class TestCloningViews(EuphorieIntegrationTestCase):
 
     def test_clone(self):
         country = self.portal.client.nl
-        john = model.Account(loginname="john@example.com")
-        model.Session.add(john)
-        newSecurityManager(None, john)
-
         traversed_session = country.ict["software-development"].restrictedTraverse(
             "++session++1"
-        )  # noqa: E501
-
-        # Calling the view redirects to the cloned session
+        )
+        # Calling the view redirects to the client home page if we are not autenticated
         with self._get_view("clone-session", traversed_session) as view:
             view()
             self.assertDictEqual(
                 view.request.response.headers,
-                {
-                    "location": "http://nohost/plone/client/nl/ict/software-development/++session++2/@@start?new_clone=1"  # noqa: E501
-                },
+                {"location": "http://nohost/plone/client"},
             )
 
-        with self._get_view("clone-session", traversed_session) as view:
-            original = model.Session.query(model.SurveySession).get(1)
-            clone = view.get_cloned_session()
-            # The cloned session has a lot in common with the original one
-            # The title is prefixed with a COPY marker
-            self.assertEqual(clone.title, u"COPY: {}".format(original.title))
-            self.assertEqual(clone.company.country, original.company.country)
-            # But is marked with the account that made the clone
-            self.assertEqual(original.account.login, "jane@example.com")
-            self.assertEqual(clone.account.login, "john@example.com")
+        # Calling the view redirects to the cloned session if authenticated
+        with api.env.adopt_user(user=self.john):
+            with self._get_view(
+                "clone-session", traversed_session, traversed_session.session
+            ) as view:
+                view()
+                self.assertDictEqual(
+                    view.request.response.headers,
+                    {
+                        "location": "http://nohost/plone/client/nl/ict/software-development/++session++2/@@start?new_clone=1"  # noqa: E501
+                    },
+                )
 
-            # Also all the tree is copied
-            self.assertListEqual(
-                [(x.id, x.title) for x in clone.children()], [(5, u"module 1")]
-            )
-            module = clone.children()[0]
-            self.assertListEqual(
-                [(x.id, x.title) for x in module.children()], [(6, u"question 1")]
-            )
-            risk = module.children()[0]
-            self.assertListEqual(
-                [(x.id, x.action_plan) for x in risk.action_plans],
-                [(3, u"This is the plan")],
-            )
-            # Also verify that the cloned risk has
-            # the cloned module as a parent
-            self.assertEqual(risk.parent, module)
+        with api.env.adopt_user(user=self.john):
+            with self._get_view("clone-session", traversed_session) as view:
+                original = model.Session.query(model.SurveySession).get(1)
+                clone = view.get_cloned_session()
+                # The cloned session has a lot in common with the original one
+                # The title is prefixed with a COPY marker
+                self.assertEqual(clone.title, u"COPY: {}".format(original.title))
+                self.assertEqual(clone.company.country, original.company.country)
+                # But is marked with the account that made the clone
+                self.assertEqual(original.account.login, "jane@example.com")
+                self.assertEqual(clone.account.login, "john@example.com")
+
+                # Also all the tree is copied
+                self.assertListEqual(
+                    [(x.id, x.title) for x in clone.children()], [(5, u"module 1")]
+                )
+                module = clone.children()[0]
+                self.assertListEqual(
+                    [(x.id, x.title) for x in module.children()], [(6, u"question 1")]
+                )
+                risk = module.children()[0]
+                self.assertListEqual(
+                    [(x.id, x.action_plan) for x in risk.action_plans],
+                    [(3, u"This is the plan")],
+                )
+                # Also verify that the cloned risk has
+                # the cloned module as a parent
+                self.assertEqual(risk.parent, module)


### PR DESCRIPTION
When a user tries to clone a session without enough rights,
they are redirected to the sessions overview