### PR TITLE
Password reset: Fix email tampering

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Changelog
 - Improved error handling
 - Fix injection-related problem on tools with integrated action plan that also
   use measures in place
+- Password Reset: Verify IP address validity
 
 
 14.0.0 (2022-03-16)

--- a/src/euphorie/client/browser/templates/password_recovery_email.pt
+++ b/src/euphorie/client/browser/templates/password_recovery_email.pt
@@ -22,10 +22,7 @@
 
   <tal:i18n i18n:translate="mailtemplate_tracking_information">If you didn't expect to receive this email, please ignore it. Your password has not been changed.
    Request made from IP address
-    <tal:i18n tal:define="
-                host request/HTTP_X_FORWARDED_FOR|request/REMOTE_ADDR;
-              "
-              tal:content="host"
+    <tal:i18n tal:content="options/host|nothing"
               i18n:name="ipaddress"
     />
   </tal:i18n>


### PR DESCRIPTION
Password reset: Only use X-Forwarded-For if it contains an IP address. Fixes email tampering attack.

Refs syslabcom/scrum#158