### PR TITLE
CSRF for SQL writes

### DIFF
--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -30,6 +30,7 @@ from plone.app.event.base import localized_now
 from plone.autoform.form import AutoExtensibleForm
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
+from plone.protect.utils import addTokenToUrl
 from plone.supermodel import model
 from Products.CMFPlone import PloneLocalesMessageFactory
 from Products.Five import BrowserView
@@ -227,7 +228,7 @@ class Start(SessionMixin, AutoExtensibleForm, EditForm):
         # show the "start" page again
         if "form.button.submit" in self.request:
             return self.request.response.redirect(
-                "%s/@@profile" % self.context.absolute_url()
+                addTokenToUrl("%s/@@profile" % self.context.absolute_url())
             )
 
 

--- a/src/euphorie/client/browser/settings.py
+++ b/src/euphorie/client/browser/settings.py
@@ -15,6 +15,7 @@ from plone import api
 from plone.autoform import directives
 from plone.autoform.form import AutoExtensibleForm
 from plone.memoize.instance import memoize
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.supermodel import model
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
@@ -29,6 +30,7 @@ from z3c.saconfig import Session
 from z3c.schema.email import RFC822MailAddress
 from zope import schema
 from zope.i18n import translate
+from zope.interface import alsoProvides
 from zope.interface import directlyProvides
 from zope.interface import Invalid
 from zope.interface import invariant
@@ -360,6 +362,7 @@ class ChangeEmail(BrowserView):
             return
 
         request.account.loginname = request.value
+        alsoProvides(self.request, IDisableCSRFProtection)
         Session.delete(request)
         flash(_("Your email address has been updated."), "success")
         self.request.response.redirect(url)

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -118,6 +118,7 @@
               >Cancel</button>
             </div>
           </div>
+          <tal:csrf replace="structure context/@@authenticator/authenticator" />
         </form>
       </div>
     </metal:slot>

--- a/src/euphorie/client/browser/templates/portlet-available-tools.pt
+++ b/src/euphorie/client/browser/templates/portlet-available-tools.pt
@@ -107,6 +107,7 @@
                  type="hidden"
                  value="new"
           />
+          <tal:csrf replace="structure context/@@authenticator/authenticator" />
 
         </form>
       </div>

--- a/src/euphorie/client/browser/templates/start.pt
+++ b/src/euphorie/client/browser/templates/start.pt
@@ -129,6 +129,7 @@
                   i18n:translate="label_start_survey"
           >Start</button>
         </div>
+        <tal:csrf replace="structure context/@@authenticator/authenticator" />
       </form>
 
     </metal:slot>

--- a/src/euphorie/content/overrides.zcml
+++ b/src/euphorie/content/overrides.zcml
@@ -3,4 +3,9 @@
     <include package="plone.app.dexterity" file="overrides.zcml" />
     <include package=".behaviour" file="overrides.zcml" />
 
+    <adapter
+        name="plone.protect.autocsrf"
+        factory=".protect.EuphorieProtectTransform"
+        />
+
 </configure>

--- a/src/euphorie/content/protect.py
+++ b/src/euphorie/content/protect.py
@@ -1,0 +1,17 @@
+from plone.protect.auto import ProtectTransform
+from zope.sqlalchemy.datamanager import SessionDataManager
+
+
+class EuphorieProtectTransform(ProtectTransform):
+    def _registered_objects(self):
+        registered = super(EuphorieProtectTransform, self)._registered_objects()
+        app = self.request.PARENTS[-1]
+        for name, conn in app._p_jar.connections.items():
+            if name == "temporary":
+                continue
+            for resource in conn.transaction_manager.get()._resources:
+                if isinstance(resource, SessionDataManager):
+                    registered.extend(resource.session.dirty)
+                    registered.extend(resource.session.new)
+                    registered.extend(resource.session.deleted)
+        return registered


### PR DESCRIPTION
Make CSRF protection kick in if SQL data is being written.

This is a little hacky because `safeWrite` doesn't work for the objects that are added (they have no _p_oid).

The tests do pass but there could of course still be some false positives of the CSRF protection. I would only expect a `@@confirm-action` redirect in this case, but maybe it pays off to do some more thorough manual testing.

Refs syslabcom/scrum#158