### PR TITLE
Training questions: Fix empty list

### DIFF
--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -282,15 +282,14 @@ class TrainingView(BrowserView, survey._StatusHelper):
         None.
         """
         survey = self.webhelpers._survey
-        all_questions = api.content.find(
-            context=survey,
-            portal_type="euphorie.training_question",
+        all_questions = survey.listFolderContents(
+            {"portal_type": "euphorie.training_question"}
         )
         num_training_questions = getattr(survey, "num_training_questions", None) or len(
             all_questions
         )
-        questions = sample(list(all_questions), k=num_training_questions)
-        return {q.getId: None for q in questions}
+        questions = sample(all_questions, k=num_training_questions)
+        return {q.getId(): None for q in questions}
 
     @memoize
     def get_or_create_training(self):
@@ -332,9 +331,8 @@ class TrainingView(BrowserView, survey._StatusHelper):
         if not getattr(survey, "enable_web_training", False):
             return ""
         view_name = "slide_question_success"
-        if api.content.find(
-            context=survey,
-            portal_type="euphorie.training_question",
+        if survey.listFolderContents(
+            {"portal_type": "euphorie.training_question"}
         ) and self.training_status not in ("correct", "success"):
             view_name = "slide_question_intro"
         return "{}/@@{}".format(self.context.absolute_url(), view_name)


### PR DESCRIPTION
Get objects directly. Catalog doesn't return them.

I didn't debug much further, but it's not a permission issue. I think the questions are just not indexed on the client side.

Refs syslabcom/scrum#195