### PR TITLE
269 eTranslation export and import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "ftw.upgrade",
         "htmllaundry",
         "lxml",
+        "markdownify",
         "path.py",
         "plone.app.dexterity [relations]",
         "plone.app.folder",

--- a/src/euphorie/content/browser/export.py
+++ b/src/euphorie/content/browser/export.py
@@ -306,19 +306,46 @@ class ExportSurvey(AutoExtensibleForm, form.Form):
                 node, "classification-code"
             ).text = survey.classification_code
         etree.SubElement(node, "language").text = survey.language
-        etree.SubElement(node, "tool_type").text = get_tool_type(survey)
-        etree.SubElement(node, "measures_text_handling").text = getattr(
-            survey, "measures_text_handling", "full"
-        )
-        etree.SubElement(node, "integrated_action_plan").text = (
-            "true" if getattr(survey, "integrated_action_plan", False) else "false"
-        )
-        etree.SubElement(node, "evaluation-algorithm").text = aq_parent(
-            survey
-        ).evaluation_algorithm
-        etree.SubElement(node, "evaluation-optional").text = (
-            "true" if survey.evaluation_optional else "false"
-        )
+        if self.is_etranslate_compatible:
+            etree.SubElement(node, "tool_type", attrib={"value": get_tool_type(survey)})
+            etree.SubElement(
+                node,
+                "measures_text_handling",
+                attrib={"value": getattr(survey, "measures_text_handling", "full")},
+            )
+            etree.SubElement(
+                node,
+                "integrated_action_plan",
+                attrib={
+                    "value": "true"
+                    if getattr(survey, "integrated_action_plan", False)
+                    else "false"
+                },
+            )
+            etree.SubElement(
+                node,
+                "evaluation-algorithm",
+                attrib={"value": aq_parent(survey).evaluation_algorithm},
+            )
+            etree.SubElement(
+                node,
+                "evaluation-optional",
+                attrib={"value": "true" if survey.evaluation_optional else "false"},
+            )
+        else:
+            etree.SubElement(node, "tool_type").text = get_tool_type(survey)
+            etree.SubElement(node, "measures_text_handling").text = getattr(
+                survey, "measures_text_handling", "full"
+            )
+            etree.SubElement(node, "integrated_action_plan").text = (
+                "true" if getattr(survey, "integrated_action_plan", False) else "false"
+            )
+            etree.SubElement(node, "evaluation-algorithm").text = aq_parent(
+                survey
+            ).evaluation_algorithm
+            etree.SubElement(node, "evaluation-optional").text = (
+                "true" if survey.evaluation_optional else "false"
+            )
         if IToolCategory.providedBy(survey):
             tool_category = IToolCategory(survey).tool_category or []
             etree.SubElement(node, "tool-category").text = ", ".join(
@@ -413,9 +440,16 @@ class ExportSurvey(AutoExtensibleForm, form.Form):
             node = self._add_string_or_html(
                 node, risk.legal_reference, "legal-reference"
             )
-        etree.SubElement(node, "show-not-applicable").text = (
-            "true" if risk.show_notapplicable else "false"
-        )
+        if self.is_etranslate_compatible:
+            etree.SubElement(
+                node,
+                "show-not-applicable",
+                attrib={"value": "true" if risk.show_notapplicable else "false"},
+            )
+        else:
+            etree.SubElement(node, "show-not-applicable").text = (
+                "true" if risk.show_notapplicable else "false"
+            )
         if risk.type == "risk":
             method = etree.SubElement(node, "evaluation-method")
             method.text = risk.evaluation_method

--- a/src/euphorie/content/browser/export.py
+++ b/src/euphorie/content/browser/export.py
@@ -473,9 +473,9 @@ class ExportSurvey(AutoExtensibleForm, form.Form):
             solution_view = api.content.get_view(
                 context=solution, name="nuplone-view", request=self.request
             )
-            action_html = solution_view.render_md(stripped_action)
-            action_with_br = action_html.replace("\n", "<br/>")
-            fragment = html.fragment_fromstring(action_with_br, "action")
+            action_with_br = stripped_action.replace("\n", "<br/>")
+            action_html = solution_view.render_md(action_with_br)
+            fragment = html.fragment_fromstring(action_html, "action")
             node.append(fragment)
         else:
             etree.SubElement(node, "action").text = stripped_action

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -67,7 +67,7 @@ def attr_unicode(node, attr, default=None):
 def attr_string(node, tag, attr, default=None):
     value = default
     element = getattr(node, tag, None)
-    if element != None:
+    if element is not None:
         value = element.attrib.get(attr)
     return value
 
@@ -85,7 +85,7 @@ def attr_vocabulary(node, tag, field, default=None):
 def attr_bool(node, tag, attr, default=False):
     value = default
     element = getattr(node, tag, None)
-    if element != None:
+    if element is not None:
         value = element.get(attr)
     return value == "true"
 

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -238,8 +238,14 @@ class SurveyImporter(object):
         )
         EnsureInterface(risk)
         risk.type = node.get("type")
-        risk.description = six.text_type(getattr(node, "description", ""))
-        risk.problem_description = el_unicode(node, "problem-description")
+        risk.description = el_unicode(
+            node, "description", is_etranslate_compatible=self.is_etranslate_compatible
+        )
+        risk.problem_description = el_unicode(
+            node,
+            "problem-description",
+            is_etranslate_compatible=self.is_etranslate_compatible,
+        )
         risk.legal_reference = el_unicode(node, "legal-reference")
         risk.show_notapplicable = el_bool(node, "show-not-applicable")
         risk.external_id = attr_unicode(node, "external-id")
@@ -337,7 +343,9 @@ class SurveyImporter(object):
             profile = createContentInContainer(
                 survey, "euphorie.profilequestion", title=six.text_type(node.title)
             )
-        profile.description = el_unicode(node, "description")
+        profile.description = el_unicode(
+            node, "description", is_etranslate_compatible=self.is_etranslate_compatible
+        )
         profile.question = six.text_type(node.question)
         profile.external_id = attr_unicode(node, "external-id")
         for fname in ProfileQuestionLocationFields:

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -215,7 +215,11 @@ class SurveyImporter(object):
         :returns: :obj:`euphorie.content.solution`.
         """
         solution = createContentInContainer(risk, "euphorie.solution")
-        solution.description = six.text_type(node.description)
+        solution.description = el_unicode(
+            node,
+            "description",
+            is_etranslate_compatible=self.is_etranslate_compatible,
+        )
         solution.action = six.text_type(
             getattr(node, "action", None) or node.description
         )

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -226,7 +226,7 @@ class SurveyImporter(object):
             node,
             "action",
             is_etranslate_compatible=self.is_etranslate_compatible,
-            convert_to_markdown=True
+            convert_to_markdown=True,
         )
         solution.action = action or node.description
         solution.action_plan = six.text_type(getattr(node, "action-plan", ""))
@@ -384,6 +384,19 @@ class SurveyImporter(object):
         survey.classification_code = el_unicode(node, "classification-code")
         survey.language = el_string(node, "language")
         tti = getUtility(IToolTypesInfo)
+        if self.is_etranslate_compatible:
+            survey.tool_type = (
+                getattr(node, "tool_type").get("value") or tti.default_tool_type
+            )
+            survey.measures_text_handling = (
+                getattr(node, "measures_text_handling").get("value") or "full"
+            )
+            survey.integrated_action_plan = getattr(node, "integrated_action_plan").get(
+                "value"
+            )
+            survey.evaluation_optional = getattr(node, "evaluation-optional").get(
+                "value"
+            )
         survey.tool_type = el_string(node, "tool_type", tti.default_tool_type)
         survey.measures_text_handling = el_string(
             node, "measures_text_handling", "full"

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -220,9 +220,12 @@ class SurveyImporter(object):
             "description",
             is_etranslate_compatible=self.is_etranslate_compatible,
         )
-        solution.action = six.text_type(
-            getattr(node, "action", None) or node.description
+        action = el_unicode(
+            node,
+            "action",
+            is_etranslate_compatible=self.is_etranslate_compatible,
         )
+        solution.action = action or node.description
         solution.action_plan = six.text_type(getattr(node, "action-plan", ""))
         solution.prevention_plan = el_unicode(node, "prevention-plan")
         solution.requirements = el_unicode(node, "requirements")

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -88,10 +88,11 @@ def el_unicode(
     if value is None:
         return default
     if is_etranslate_compatible:
-        # Remove the outer XML element e.g. <description>
-        # Fixme: this is ugly and may be error prone
+        # We need to remove the outer XML element e.g. <description>
         wrapped_xml = lxml.etree.tostring(value, encoding="unicode", pretty_print=True)
-        unwrapped_html = "".join(wrapped_xml.strip().split("\n")[1:-1])
+        end_of_first_tag = wrapped_xml.find(">") + 1
+        start_of_last_tag = wrapped_xml.rfind("<")
+        unwrapped_html = wrapped_xml[end_of_first_tag:start_of_last_tag]
         if convert_to_markdown:
             return markdownify(unwrapped_html)
         else:

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -442,7 +442,7 @@ class SurveyImporter(object):
         return survey
 
     def __call__(
-        self, input, surveygroup_title, survey_title, is_etranslate_compatible
+        self, input, surveygroup_title, survey_title, is_etranslate_compatible=False
     ):
         """Import a new survey from the XML data in `input` and create a
         new survey with the given `title`.

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -64,6 +64,14 @@ def attr_unicode(node, attr, default=None):
     return value
 
 
+def attr_string(node, tag, attr, default=None):
+    value = default
+    element = getattr(node, tag, None)
+    if element != None:
+        value = element.attrib.get(attr)
+    return value
+
+
 def attr_vocabulary(node, tag, field, default=None):
     value = node.get(tag, "").strip() if node else None
     if not value:
@@ -75,9 +83,10 @@ def attr_vocabulary(node, tag, field, default=None):
 
 
 def attr_bool(node, tag, attr, default=False):
-    value = getattr(node, tag).get(attr)
-    if value is None:
-        return default
+    value = default
+    element = getattr(node, tag, None)
+    if element != None:
+        value = element.get(attr)
     return value == "true"
 
 
@@ -393,11 +402,11 @@ class SurveyImporter(object):
         survey.language = el_string(node, "language")
         tti = getUtility(IToolTypesInfo)
         if self.is_etranslate_compatible:
-            survey.tool_type = (
-                getattr(node, "tool_type").get("value") or tti.default_tool_type
+            survey.tool_type = attr_string(
+                node, "tool_type", "value", tti.default_tool_type
             )
-            survey.measures_text_handling = (
-                getattr(node, "measures_text_handling").get("value") or "full"
+            survey.measures_text_handling = attr_string(
+                node, "measures_text_handling", "value", "full"
             )
             survey.integrated_action_plan = attr_bool(
                 node, "integrated_action_plan", "value"

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -74,6 +74,13 @@ def attr_vocabulary(node, tag, field, default=None):
         return default
 
 
+def attr_bool(node, tag, attr, default=False):
+    value = getattr(node, tag).get(attr)
+    if value is None:
+        return default
+    return value == "true"
+
+
 def el_unicode(
     node, tag, default=None, is_etranslate_compatible=False, convert_to_markdown=False
 ):
@@ -391,18 +398,18 @@ class SurveyImporter(object):
             survey.measures_text_handling = (
                 getattr(node, "measures_text_handling").get("value") or "full"
             )
-            survey.integrated_action_plan = getattr(node, "integrated_action_plan").get(
-                "value"
+            import pdb; pdb.set_trace()
+            survey.integrated_action_plan = attr_bool(
+                node, "integrated_action_plan", "value"
             )
-            survey.evaluation_optional = getattr(node, "evaluation-optional").get(
-                "value"
+            survey.evaluation_optional = attr_bool(node, "evaluation-optional", "value")
+        else:
+            survey.tool_type = el_string(node, "tool_type", tti.default_tool_type)
+            survey.measures_text_handling = el_string(
+                node, "measures_text_handling", "full"
             )
-        survey.tool_type = el_string(node, "tool_type", tti.default_tool_type)
-        survey.measures_text_handling = el_string(
-            node, "measures_text_handling", "full"
-        )
-        survey.integrated_action_plan = el_bool(node, "integrated_action_plan")
-        survey.evaluation_optional = el_bool(node, "evaluation-optional")
+            survey.integrated_action_plan = el_bool(node, "integrated_action_plan")
+            survey.evaluation_optional = el_bool(node, "evaluation-optional")
         survey.external_id = attr_unicode(node, "external-id")
         external_site_logo = getattr(node, "external_site_logo", None)
         if external_site_logo is not None:

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -215,11 +215,7 @@ class SurveyImporter(object):
         :returns: :obj:`euphorie.content.solution`.
         """
         solution = createContentInContainer(risk, "euphorie.solution")
-        solution.description = el_unicode(
-            node,
-            "description",
-            is_etranslate_compatible=self.is_etranslate_compatible,
-        )
+        solution.description = six.text_type(node.description)
         action = el_unicode(
             node,
             "action",

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -398,7 +398,6 @@ class SurveyImporter(object):
             survey.measures_text_handling = (
                 getattr(node, "measures_text_handling").get("value") or "full"
             )
-            import pdb; pdb.set_trace()
             survey.integrated_action_plan = attr_bool(
                 node, "integrated_action_plan", "value"
             )

--- a/src/euphorie/content/tests/test_export.py
+++ b/src/euphorie/content/tests/test_export.py
@@ -814,3 +814,50 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
                 "  </survey>\n"
                 "</sector>\n",
             )
+
+    def testEtranslateRenderWithHTML(self):
+        profile = ProfileQuestion()
+        profile.title = "Office buildings"
+        profile.question = "Do you have an office building?"
+        profile.description = "<p>No</p><p>container</p>"
+        root = self.root()
+        view = ExportSurvey(None, None)
+        view.is_etranslate_compatible = True
+        node = view.exportProfileQuestion(root, profile)
+        self.assertTrue(node in root)
+        self.assertEqual(
+            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
+            "  <profile-question>\n"
+            "    <title>Office buildings</title>\n"
+            "    <question>Do you have an office building?</question>\n"
+            "    <description>\n"
+            "      <p>No</p>\n"
+            "      <p>container</p>\n"
+            "    </description>\n"
+            "    <use-location-question>true</use-location-question>\n"
+            "  </profile-question>\n"
+            "</root>\n",
+        )
+
+    def testEtranslateRenderWithoutHTML(self):
+        profile = ProfileQuestion()
+        profile.title = "Office buildings"
+        profile.question = "Do you have an office building?"
+        profile.description = "Plain text"
+        root = self.root()
+        view = ExportSurvey(None, None)
+        view.is_etranslate_compatible = True
+        node = view.exportProfileQuestion(root, profile)
+        self.assertTrue(node in root)
+        self.assertEqual(
+            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
+            "  <profile-question>\n"
+            "    <title>Office buildings</title>\n"
+            "    <question>Do you have an office building?</question>\n"
+            "    <description>Plain text</description>\n"
+            "    <use-location-question>true</use-location-question>\n"
+            "  </profile-question>\n"
+            "</root>\n",
+        )

--- a/src/euphorie/content/tests/test_functional_upload.py
+++ b/src/euphorie/content/tests/test_functional_upload.py
@@ -116,9 +116,7 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
         importer.is_etranslate_compatible = True
         solution = importer.ImportSolution(snippet, risk)
         self.assertEqual(risk.keys(), ["3"])
-        self.assertEqual(
-            solution.action, "With **HTML**  \n"
-        )
+        self.assertEqual(solution.action, "With **HTML**  \n")
         self.assertTrue(isinstance(solution.action, six.text_type))
 
     def testImportSolution_MissingFields(self):

--- a/src/euphorie/content/tests/test_functional_upload.py
+++ b/src/euphorie/content/tests/test_functional_upload.py
@@ -105,7 +105,7 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
         snippet = objectify.fromstring(
             """<solution xmlns="http://xml.simplon.biz/euphorie/survey/1.0">
              <description>Add more abstraction layers</description>
-             <action><p>With HTML</p></action>
+             <action>With <strong>HTML</strong><br/></action>
              <action-plan>Add another level</action-plan>
              <prevention-plan>Ask a code reviewer to verify the design</prevention-plan>
              <requirements>A good understanding of architecture</requirements>
@@ -117,7 +117,7 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
         solution = importer.ImportSolution(snippet, risk)
         self.assertEqual(risk.keys(), ["3"])
         self.assertEqual(
-            solution.action.strip(), "<p>With HTML</p>"
+            solution.action, "With **HTML**  \n"
         )
         self.assertTrue(isinstance(solution.action, six.text_type))
 

--- a/src/euphorie/content/tests/test_functional_upload.py
+++ b/src/euphorie/content/tests/test_functional_upload.py
@@ -478,6 +478,26 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
         self.assertTrue(isinstance(survey.classification_code, six.text_type))
         self.assertEqual(survey.evaluation_optional, True)
 
+    def testImportSurveyFromEtranslate(self):
+        snippet = objectify.fromstring(
+            """<survey xmlns="http://xml.simplon.biz/euphorie/survey/1.0">
+             <title>Software development</title>
+             <measures_text_handling value="partial"/>
+             <tool_type value="existing_measures"/>
+             <evaluation-optional value="true"/>
+             <integrated_action_plan>false</integrated_action_plan>
+           </survey>"""
+        )
+        self.loginAsPortalOwner()
+        surveygroup = self.createSurveyGroup()
+        importer = upload.SurveyImporter(None)
+        importer.is_etranslate_compatible = True
+        survey = importer.ImportSurvey(snippet, surveygroup, "Fresh import")
+        self.assertEqual(survey.measures_text_handling, "partial")
+        self.assertEqual(survey.tool_type, "existing_measures")
+        self.assertEqual(survey.evaluation_optional, True)
+        self.assertEqual(survey.integrated_action_plan, False)
+
     def testImportSurvey_WithModule(self):
         snippet = objectify.fromstring(
             """<survey optional="no" xmlns="http://xml.simplon.biz/euphorie/survey/1.0">

--- a/src/euphorie/content/tests/test_functional_upload.py
+++ b/src/euphorie/content/tests/test_functional_upload.py
@@ -104,7 +104,8 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
     def testImportSolutionFromEtranslate(self):
         snippet = objectify.fromstring(
             """<solution xmlns="http://xml.simplon.biz/euphorie/survey/1.0">
-             <description><p>Add more abstraction layers</p></description>
+             <description>Add more abstraction layers</description>
+             <action><p>With HTML</p></action>
              <action-plan>Add another level</action-plan>
              <prevention-plan>Ask a code reviewer to verify the design</prevention-plan>
              <requirements>A good understanding of architecture</requirements>
@@ -116,9 +117,9 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
         solution = importer.ImportSolution(snippet, risk)
         self.assertEqual(risk.keys(), ["3"])
         self.assertEqual(
-            solution.description.strip(), "<p>Add more abstraction layers</p>"
+            solution.action.strip(), "<p>With HTML</p>"
         )
-        self.assertTrue(isinstance(solution.description, six.text_type))
+        self.assertTrue(isinstance(solution.action, six.text_type))
 
     def testImportSolution_MissingFields(self):
         snippet = objectify.fromstring(

--- a/src/euphorie/content/tests/test_functional_upload.py
+++ b/src/euphorie/content/tests/test_functional_upload.py
@@ -101,6 +101,25 @@ class SurveyImporterTests(EuphorieIntegrationTestCase):
         self.assertEqual(solution.requirements, "A good understanding of architecture")
         self.assertTrue(isinstance(solution.requirements, six.text_type))
 
+    def testImportSolutionFromEtranslate(self):
+        snippet = objectify.fromstring(
+            """<solution xmlns="http://xml.simplon.biz/euphorie/survey/1.0">
+             <description><p>Add more abstraction layers</p></description>
+             <action-plan>Add another level</action-plan>
+             <prevention-plan>Ask a code reviewer to verify the design</prevention-plan>
+             <requirements>A good understanding of architecture</requirements>
+           </solution>"""  # noqa
+        )
+        risk = self.createRisk()
+        importer = upload.SurveyImporter(None)
+        importer.is_etranslate_compatible = True
+        solution = importer.ImportSolution(snippet, risk)
+        self.assertEqual(risk.keys(), ["3"])
+        self.assertEqual(
+            solution.description.strip(), "<p>Add more abstraction layers</p>"
+        )
+        self.assertTrue(isinstance(solution.description, six.text_type))
+
     def testImportSolution_MissingFields(self):
         snippet = objectify.fromstring(
             """<solution xmlns="http://xml.simplon.biz/euphorie/survey/1.0">


### PR DESCRIPTION
Add support for exporting and importing in an XML format which the eTranslation service can handle without losing tool configuration settings or (much) formatting.

Refs https://github.com/syslabcom/scrum/issues/269