### PR TITLE
Fix permission check on tabs (experimental)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 14.1.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed permission check in tabs.
 
 
 14.1.1 (2022-06-07)

--- a/src/euphorie/deployment/tiles/tabs.py
+++ b/src/euphorie/deployment/tiles/tabs.py
@@ -72,7 +72,7 @@ class SiteRootTabsTile(TabsTile):
                 }
             )
 
-        if api.user.has_permission("Manage portal", user=self.user):
+        if api.user.has_permission("Manage portal"):
             self.tabs.append(
                 {
                     "id": "documents",


### PR DESCRIPTION
Tabs Tile: Don't explicitly pass in a user to the permission check. Doing so seems to cause an error sometimes.

This fix is somewhat experimental. We can't reproduce the issue on any other system than production. It seems similar to zopefoundation/AccessControl#130 though. The risk is that some subclass might be overriding `self.user` to return something other than the current user. This would stop working if this PR was merged. However, it is unlikely and I've checked that neither osha nor daimler nor TNO are doing that.

```
2022-06-03 22:42:41,889 ERROR   [waitress:358][waitress-0] Exception while serving /VirtualHostBase/https/admin.oiraproject.eu:443/Plone2/VirtualHostRoot/_vh_tool-creator/@@login
Traceback (most recent call last):
  File "/home/osha/oira.application.py3/eggs/Chameleon-3.9.1-py3.6.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/home/osha/oira.application.py3/var/cache/22dc09340337e18f45de8a21a61bfd3c.py", line 648, in render
    __m(__stream, econtext.copy(), rcontext, __i18n_domain)
  File "/home/osha/oira.application.py3/var/cache/58029749146fdb78594ee88df7803ec5.py", line 545, in render_layout
    __cache_140698995705504 = _static_140699264336448('tile', 'tabs', econtext=econtext)(_static_140699264336784(econtext, __zt_tmp))
  File "/home/osha/oira.application.py3/eggs/NuPlone-2.1.1-py3.6.egg/plonetheme/nuplone/tiles/tales.py", line 22, in __call__
    return Markup(tile())
  File "/home/osha/oira.application.py3/eggs/NuPlone-2.1.1-py3.6.egg/plonetheme/nuplone/tiles/tabs.py", line 63, in __call__
    self.update()
  File "/home/osha/oira.application.py3/eggs/osha.oira-8.1.1-py3.6.egg/osha/oira/tiles/tabs.py", line 32, in update
    super(OiRASiteRootTabsTile, self).update()
  File "/home/osha/oira.application.py3/eggs/Euphorie-14.1.0-py3.6.egg/euphorie/deployment/tiles/tabs.py", line 75, in update
    if api.user.has_permission("Manage portal", user=self.user):
  File "<decorator-gen-37>", line 2, in has_permission
  File "/home/osha/oira.application.py3/eggs/plone.api-1.11.1-py3.6.egg/plone/api/validation.py", line 116, in wrapped
    return function(*args, **kwargs)
  File "/home/osha/oira.application.py3/eggs/plone.api-1.11.1-py3.6.egg/plone/api/user.py", line 339, in has_permission
    return bool(getSecurityManager().checkPermission(permission, obj))
  File "/home/osha/oira.application.py3/eggs/AccessControl-4.3-py3.6-linux-x86_64.egg/AccessControl/ImplPython.py", line 645, in checkPermission
    return policy.checkPermission(permission, object, self._context)
  File "/home/osha/oira.application.py3/eggs/AccessControl-4.3-py3.6-linux-x86_64.egg/AccessControl/ImplPython.py", line 522, in checkPermission
    return context.user.allowed(object, roles)
AttributeError: 'MemberData' object has no attribute 'allowed'
```

Refs syslabcom/scrum#384