### PR TITLE
Harden password reset

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 14.1.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Stricter password reset handling.
 
 
 14.1.2 (2022-06-15)

--- a/src/euphorie/client/browser/reset_password.py
+++ b/src/euphorie/client/browser/reset_password.py
@@ -102,6 +102,11 @@ class ResetPasswordRequest(BaseForm):
     def email_from_address(self):
         return api.portal.get_registry_record("plone.email_from_address")
 
+    def expiration_timeout(self):
+        ppr = api.portal.get_tool("portal_password_reset")
+        timeout = ppr.getExpirationTimeout() or 0
+        return int(timeout * 24)  # timeout is in days, but templates want in hours.
+
     def log_error(self, msg):
         """Log an error message, set the view error attribute and return False"""
         logger.error(msg)

--- a/src/euphorie/client/browser/reset_password.py
+++ b/src/euphorie/client/browser/reset_password.py
@@ -130,7 +130,6 @@ class ResetPasswordRequest(BaseForm):
                 del ppr._requests[token]
                 ppr._p_changed = 1
 
-        ppr.setExpirationTimeout(0.5)
         reset_info = ppr.requestReset(account.id)
         reset_info["host"] = self.get_remote_host()
         mailhost = api.portal.get_tool("MailHost")

--- a/src/euphorie/client/browser/templates/password_recovery_email.pt
+++ b/src/euphorie/client/browser/templates/password_recovery_email.pt
@@ -14,9 +14,8 @@
     <tal:i18n i18n:name="reset_url">${here/absolute_url}/passwordreset/${randomstring}</tal:i18n></tal:i18n>
 
   <tal:i18n i18n:translate="mailtemplate_text_expirationdate_linkreset">(This link is valid for
-    <span tal:replace="plone_mail_password_view/expiration_timeout"
-          i18n:name="hours"
-    ></span>
+    <tal:hours i18n:name="hours"
+    >12</tal:hours>
   hours)
   </tal:i18n>
 

--- a/src/euphorie/client/browser/templates/password_recovery_email.pt
+++ b/src/euphorie/client/browser/templates/password_recovery_email.pt
@@ -1,6 +1,5 @@
 <tal:root define="
             portal_state context/@@plone_portal_state;
-            plone_mail_password_view nocall:context/@@mail_password_template;
             isAnon portal_state/anonymous;
             randomstring options/randomstring;
           "
@@ -14,8 +13,9 @@
     <tal:i18n i18n:name="reset_url">${here/absolute_url}/passwordreset/${randomstring}</tal:i18n></tal:i18n>
 
   <tal:i18n i18n:translate="mailtemplate_text_expirationdate_linkreset">(This link is valid for
-    <tal:hours i18n:name="hours"
-    >12</tal:hours>
+    <span tal:replace="view/expiration_timeout"
+          i18n:name="hours"
+    ></span>
   hours)
   </tal:i18n>
 

--- a/src/euphorie/client/setuphandlers.py
+++ b/src/euphorie/client/setuphandlers.py
@@ -31,3 +31,5 @@ def setupVarious(context):
     pas = site.acl_users
     if not pas.objectIds([EuphorieAccountPlugin.meta_type]):
         add_account_plugin(pas)
+    ppr = api.portal.get_tool("portal_password_reset")
+    ppr.setExpirationTimeout(0.5)

--- a/src/euphorie/client/tests/test_functional_login.py
+++ b/src/euphorie/client/tests/test_functional_login.py
@@ -19,6 +19,7 @@ from zope.interface import alsoProvides
 import datetime
 import re
 import six
+import transaction
 
 
 class GuestAccountTests(EuphorieFunctionalTestCase):
@@ -281,3 +282,170 @@ class ResetPasswordTests(EuphorieFunctionalTestCase):
             ).value = "Secret123Secret"
             browser.getControl(label="Save changes").click()
             self.assertIn("Invalid security token", browser.contents)
+
+    def test_token_invalid_after_use(self):
+        self.add_dummy_survey()
+        addAccount()
+        mail_fixture = MockMailFixture()
+
+        browser = self.get_browser()
+        url = self.portal.client.nl.absolute_url()
+
+        browser.open(url + "/@@login")
+        browser.getLink("I forgot my password").click()
+        browser.getControl(name="form.widgets.email").value = "jane@example.com"
+        browser.getControl(name="form.buttons.save").click()
+
+        args = mail_fixture.storage[0][0]
+        mail = args[0]
+        mail_text = "".join(
+            [
+                (part.get_payload(decode=True) or b"").decode(
+                    part.get_content_charset("iso-8859-1")
+                )
+                for part in mail.walk()
+            ]
+        )
+
+        reset_url = re.search("http.*passwordreset/\\S*", mail_text).group(0)
+        browser.open(reset_url)
+        browser.getControl(name="form.widgets.new_password").value = "Test12345678"
+        browser.getControl(
+            name="form.widgets.new_password_confirmation"
+        ).value = "Test12345678"
+        browser.getControl(name="form.buttons.save").click()
+
+        self.assertIn("success", browser.contents)
+
+        # Token has been used already - second time should fail
+        browser.open(reset_url)
+        self.assertIn("Invalid security token", browser.contents)
+
+        # You're free to fill in the form but it won't work
+        browser.getControl(name="form.widgets.new_password").value = "Test12345670"
+        browser.getControl(
+            name="form.widgets.new_password_confirmation"
+        ).value = "Test12345670"
+        browser.getControl(name="form.buttons.save").click()
+
+        self.assertNotIn("success", browser.contents)
+
+    def test_token_invalid_after_new_request(self):
+        self.add_dummy_survey()
+        addAccount()
+        mail_fixture = MockMailFixture()
+
+        browser = self.get_browser()
+        url = self.portal.client.nl.absolute_url()
+
+        browser.open(url + "/@@login")
+        browser.getLink("I forgot my password").click()
+        browser.getControl(name="form.widgets.email").value = "jane@example.com"
+        browser.getControl(name="form.buttons.save").click()
+
+        # Request another password reset without using the first one
+
+        browser.open(url + "/@@login")
+        browser.getLink("I forgot my password").click()
+        browser.getControl(name="form.widgets.email").value = "jane@example.com"
+        browser.getControl(name="form.buttons.save").click()
+
+        args = mail_fixture.storage[0][0]
+        mail = args[0]
+        mail_text = "".join(
+            [
+                (part.get_payload(decode=True) or b"").decode(
+                    part.get_content_charset("iso-8859-1")
+                )
+                for part in mail.walk()
+            ]
+        )
+
+        # Now try using the first token
+        reset_url = re.search("http.*passwordreset/\\S*", mail_text).group(0)
+        browser.open(reset_url)
+        self.assertIn("Invalid security token", browser.contents)
+
+        # You're free to fill in the form but it won't work
+        browser.getControl(name="form.widgets.new_password").value = "Test12345678"
+        browser.getControl(
+            name="form.widgets.new_password_confirmation"
+        ).value = "Test12345678"
+        browser.getControl(name="form.buttons.save").click()
+
+        self.assertNotIn("success", browser.contents)
+
+    def test_token_expired(self):
+        self.add_dummy_survey()
+        addAccount()
+        mail_fixture = MockMailFixture()
+
+        browser = self.get_browser()
+        url = self.portal.client.nl.absolute_url()
+
+        browser.open(url + "/@@login")
+        browser.getLink("I forgot my password").click()
+        browser.getControl(name="form.widgets.email").value = "jane@example.com"
+        browser.getControl(name="form.buttons.save").click()
+
+        args = mail_fixture.storage[0][0]
+        mail = args[0]
+        mail_text = "".join(
+            [
+                (part.get_payload(decode=True) or b"").decode(
+                    part.get_content_charset("iso-8859-1")
+                )
+                for part in mail.walk()
+            ]
+        )
+        token = re.search("passwordreset/(\\S*)", mail_text).group(1)
+        # fake that the token has expired
+        ppr = api.portal.get_tool("portal_password_reset")
+        ppr._requests[token] = (ppr._requests[token][0], datetime.datetime(2001, 1, 1))
+        ppr._p_changed = 1
+        transaction.commit()
+
+        reset_url = re.search("http.*passwordreset/\\S*", mail_text).group(0)
+        browser.open(reset_url)
+        self.assertIn("Invalid security token", browser.contents)
+
+        # You're free to fill in the form but it won't work
+
+        browser.getControl(name="form.widgets.new_password").value = "Test12345678"
+        browser.getControl(
+            name="form.widgets.new_password_confirmation"
+        ).value = "Test12345678"
+        browser.getControl(name="form.buttons.save").click()
+
+        self.assertNotIn("success", browser.contents)
+        self.assertIn("Invalid security token", browser.contents)
+
+    def test_token_expires_after_12_hours(self):
+        self.add_dummy_survey()
+        addAccount()
+        mail_fixture = MockMailFixture()
+
+        browser = self.get_browser()
+        url = self.portal.client.nl.absolute_url()
+
+        browser.open(url + "/@@login")
+        browser.getLink("I forgot my password").click()
+        browser.getControl(name="form.widgets.email").value = "jane@example.com"
+        browser.getControl(name="form.buttons.save").click()
+
+        args = mail_fixture.storage[0][0]
+        mail = args[0]
+        mail_text = "".join(
+            [
+                (part.get_payload(decode=True) or b"").decode(
+                    part.get_content_charset("iso-8859-1")
+                )
+                for part in mail.walk()
+            ]
+        )
+        token = re.search("passwordreset/(\\S*)", mail_text).group(1)
+        ppr = api.portal.get_tool("portal_password_reset")
+        _, expiry = ppr._requests[token]
+        self.assertLessEqual(
+            expiry, datetime.datetime.now() + datetime.timedelta(hours=12)
+        )

--- a/src/euphorie/upgrade/client/v1/20220622072638_set_password_expiration_timeout/upgrade.py
+++ b/src/euphorie/upgrade/client/v1/20220622072638_set_password_expiration_timeout/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class SetPasswordExpirationTimeout(UpgradeStep):
+    """Set password expiration timeout."""
+
+    def __call__(self):
+        ppr = api.portal.get_tool("portal_password_reset")
+        ppr.setExpirationTimeout(0.5)


### PR DESCRIPTION
Invalidate password reset after 12 hours, when a new reset is requested, or when it has been used, respectively.

Refs syslabcom/scrum#241