### PR TITLE
Fix the way get_survey_templates handles a survey with an unset category

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 14.1.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix the way ``get_survey_templates`` handles a survey with an unset category.
 
 
 14.1.5 (2022-07-13)

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -146,7 +146,7 @@ class SurveyTemplatesMixin(object):
                     categories = ["None"]
                 for category in categories:
                     survey_items.append((category, survey, id))
-        return sorted(survey_items, key=lambda x: (x[0], x[1].title))
+        return sorted(survey_items, key=lambda x: (x[0] or "None", x[1].title))
 
 
 class SessionsView(BrowserView, SurveyTemplatesMixin):


### PR DESCRIPTION
Assuming that `categories == None`, the second `if` in:
```
                if not isinstance(categories, list):		
                    categories = [categories]		
                if not categories:		                if not categories:
                    categories = ["None"]
```
was never entered.

That caused `categories` to be modified in the end to `[None]`.

Then sorting:
```
return sorted(survey_items, key=lambda x: (x[0], x[1].title))
```
would fail with:
```
TypeError: '<' not supported between instances of 'str' and 'NoneType
```

