### PR TITLE
Login cookie tweaks

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,9 @@ Changelog
   [ale-rt]
 - The training certificate shows the fullname of the user if present
   [ale-rt]
+- Removed the “Keep me logged in”-checkbox. Limit login session to 12 hours or 30 minutes of inactivity.
+  `#454 <https://github.com/syslabcom/scrum/issues/454>`_
+  [reinhardt]
 
 
 14.1.5 (2022-07-13)

--- a/src/euphorie/client/browser/templates/login.pt
+++ b/src/euphorie/client/browser/templates/login.pt
@@ -77,15 +77,6 @@
               >reset your password</a>.
             </p>
 
-            <fieldset class="pat-checklist">
-              <label>
-                <i18n:msg translate="label_keep_logged_in">Keep me logged in.</i18n:msg>
-                <input name="remember"
-                       type="checkbox"
-                />
-              </label>
-            </fieldset>
-
             <div class="button-bar">
               <button class="pat-button default"
                       name="login"

--- a/src/euphorie/client/setuphandlers.py
+++ b/src/euphorie/client/setuphandlers.py
@@ -26,10 +26,18 @@ def add_account_plugin(pas):
     enable_plugin_and_move_to_top(pas, pas.euphorie)
 
 
+def set_up_session_plugin(pas):
+    if "session" in pas:
+        pas.session.cookie_lifetime = 0.5
+        pas.session.timeout = 180
+        pas.session.refresh_interval = 90
+
+
 def setupVarious(context):
     site = api.portal.get()
     pas = site.acl_users
     if not pas.objectIds([EuphorieAccountPlugin.meta_type]):
         add_account_plugin(pas)
+    set_up_session_plugin(pas)
     ppr = api.portal.get_tool("portal_password_reset")
     ppr.setExpirationTimeout(0.5)

--- a/src/euphorie/upgrade/deployment/v1/20220805110836_tweak_login_cookie_attributes/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20220805110836_tweak_login_cookie_attributes/upgrade.py
@@ -1,0 +1,13 @@
+from euphorie.client.setuphandlers import set_up_session_plugin
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class TweakLoginCookieAttributes(UpgradeStep):
+    """Tweak login cookie attributes."""
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        site = api.portal.get()
+        pas = site.acl_users
+        set_up_session_plugin(pas)


### PR DESCRIPTION
* Removed the “Keep me logged in”-checkbox.
* Login cookie is always valid for 12 hours.
* Login times out after 30 minutes of inactivity.

Refs syslabcom/scrum#454