### PR TITLE
Convert deleted measures

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,8 @@ Changelog
   [ale-rt]
 - The training certificate shows the fullname of the user if present
   [ale-rt]
+- Measures that are deleted in the CMS stay visible in the client.
+  [reinhardt]
 
 
 14.1.5 (2022-07-13)

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -329,8 +329,15 @@ class Profile(SessionMixin, AutoExtensibleForm, EditForm):
             # Touch means: the modification timestamp is set.
             # But we need to make sure the refreshed marker is up to date!
             survey_session.refresh_survey(survey)
-            return survey_session
+            new_session = survey_session
+        else:
+            new_session = self.rebuild_session(survey, profile)
 
+        new_session.update_measure_types(survey)
+        return new_session
+
+    def rebuild_session(self, survey, profile):
+        survey_session = self.session
         params = {}
         # Some values might not be present, depending on the type of survey session
         _marker = object()


### PR DESCRIPTION
Change type of measure in session if it is deleted in ZODB so that it stays visible in the client.

Refs syslabcom/scrum#351