### PR TITLE
pat-navigation updates

### DIFF
--- a/src/euphorie/client/browser/templates/sessions-dashboard.pt
+++ b/src/euphorie/client/browser/templates/sessions-dashboard.pt
@@ -24,7 +24,7 @@
             <div class="toolbar-section navigation"
                  id="assessments-toolbar-navigation"
             >
-              <nav class="pat-tabs pat-button-cluster"
+              <nav class="pat-tabs pat-button-cluster pat-navigation"
                    id="homescreen-sections"
               >
                 <a class="icon icon-gauge pat-inject ${python:'current' if dashboard_tab=='dashboard' else None}"

--- a/src/euphorie/client/browser/templates/shell.pt
+++ b/src/euphorie/client/browser/templates/shell.pt
@@ -214,7 +214,7 @@
                          "
           />
           <metal:slot define-slot="aside-navigator">
-            <ol class="navigation"
+            <ol class="navigation pat-navigation"
                 id="steps"
             >
               <tal:if_not_anon define="

--- a/src/euphorie/client/browser/templates/training.pt
+++ b/src/euphorie/client/browser/templates/training.pt
@@ -47,7 +47,7 @@
               <div id="toc-trainings"
                    hidden
               >
-                <nav class="assessment-toc">
+                <nav class="assessment-toc pat-navigation">
                   <tal:items repeat="slide_path slide_data/keys">
                     <tal:slide define="
                                  slide_info python:slide_data[slide_path];

--- a/src/euphorie/deployment/tiles/templates/usermgmt-tree.pt
+++ b/src/euphorie/deployment/tiles/templates/usermgmt-tree.pt
@@ -4,7 +4,7 @@
       tal:omit-tag=""
       i18n:domain="euphorie"
       meta:interpolation="true">
-  <ul id="navigation" class="navigation">
+  <ul id="navigation" class="navigation pat-navigation">
     <tal:block define='countries python:view.countries.get("region")' condition="python:countries">
       <li class="${python:'active' if any([c['current'] for c in countries]) else None}"><tal:span i18n:translate="">Regions</tal:span>
         <ul>


### PR DESCRIPTION
Use explicit pat-navigation trigger class on navigation elements which were pre Patternslib 9.2 also initialized.