### PR TITLE
Sanitize the permissions handling in the client section

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Changelog
 - Export/import training questions
   `#435 <https://github.com/euphorie/Euphorie/pull/435>`_.
 - Introduce the concept of "organisations"
+- Sanitize the permissions handling in the client section
+  [ale-rt]
 - Added an `@@export.json` view that allows to export a session and the related content in a single json file.
   [ale-rt]
 - Upgrade plone to 5.2.9

--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -512,7 +512,7 @@
   <browser:page
       name="surveys"
       for="euphorie.client.country.IClientCountry"
-      permission="zope2.Public"
+      permission="zope2.View"
       class=".country.Surveys"
       template="templates/surveys.pt"
       layer="euphorie.client.interfaces.IClientSkinLayer"

--- a/src/euphorie/deployment/setuphandlers.py
+++ b/src/euphorie/deployment/setuphandlers.py
@@ -120,7 +120,7 @@ def setupInitialContent(site):
 
     if "client" not in present:
         site.invokeFactory("euphorie.client", "client", title="Client")
-        # wt.doActionFor(site.client, "publish")
+        api.content.transition(site.client, to_state="published")
         log.info("Added Euphorie client instance")
 
     if "documents" not in present:

--- a/src/euphorie/testing.py
+++ b/src/euphorie/testing.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from contextlib import contextmanager
 from euphorie.client import model
 from euphorie.client.interfaces import IClientSkinLayer
@@ -75,6 +74,9 @@ class EuphorieFixture(PloneSandboxLayer):
         default_zpublisher_encoding("utf-8")
 
     def setUpPloneSite(self, portal):
+        pw = api.portal.get_tool("portal_workflow")
+        pw.setDefaultChain("simple_publication_workflow")
+
         quickInstallProduct(portal, "plonetheme.nuplone")
         quickInstallProduct(portal, "euphorie.client")
         quickInstallProduct(portal, "euphorie.content")


### PR DESCRIPTION
This [restores a line of code](https://github.com/euphorie/Euphorie/pull/461/files#diff-9687043f5fc4f5ff7e02e6778821127d070d35ee7d1c22e59d1cc50d155ebf4bL123) in the setup handler that publishes the client folder.
That line has been present for years and it is indeed needed for the application to work at all.
It was probably commented because the switch to the Plone 5 default test layer did not included setting up a default workflow chain.
This is now done in https://github.com/euphorie/Euphorie/pull/461/files#diff-972db14e3a8d2a845681d1db32e486a080300af841abac8d99d3d43181f3eb64R77-R78

With this change the test pass even if the "surveys" view is protected by the `zope2.View` permission, which is what we want to not leak unwanted informations.
