### PR TITLE
Remove the rolemap assignment for Zope2.Public

### DIFF
--- a/src/euphorie/deployment/profiles/default/rolemap.xml
+++ b/src/euphorie/deployment/profiles/default/rolemap.xml
@@ -10,8 +10,5 @@
     <permission name="View" acquire="False">
       <role name="Authenticated" />
     </permission>
-    <permission name="Public, everyone can access" acquire="True">
-      <role name="Anonymous" />
-    </permission>
   </permissions>
 </rolemap>


### PR DESCRIPTION
That is the default, there is no need for this redundant setting