### PR TITLE
Support for Python 3.10.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,7 +3,8 @@ Changelog
 
 14.2.0 (unreleased)
 -------------------
-
+- Support for Python 3.10.
+  [thet]
 - Upgrade Patternslib to 9.7.0-alpha.5
   [thet]
 - Export/import training questions

--- a/versions.cfg
+++ b/versions.cfg
@@ -26,6 +26,7 @@ psycopg2-binary = 2.8.6
 py-bcrypt = 0.4
 python-docx = 0.8.10
 python-editor = 1.0.4
+python-dotenv = 0.21.0
 repoze.formapi = 0.6.1
 repoze.sphinx.autointerface = 0.8
 tarjan = 0.2.3.2


### PR DESCRIPTION
The 5.2 versions file `versions-plone-5.2-latest.cfg` fixes `python-dotenv = 0.15.0`, which is incompatible with Python 3.10.

I'm raising to 0.21.0, even if 3.10 support is available since 0.19.0, but the latest version has some other useful fixes.

Not sure, if that's all what is needed for 3.10 compatibility, but I'm using 3.10 on my machine and this change is necessary.

This is the traceback:
```
thet@then:/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout$ ./bin/instance fg
Traceback (most recent call last):
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/./bin/instance", line 316, in <module>
    import plone.recipe.zope2instance.ctl
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/plone.recipe.zope2instance-6.11.0-py3.10.egg/plone/recipe/zope2instance/ctl.py", line 30, in <module>
    from dotenv import load_dotenv
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/python_dotenv-0.15.0-py3.10.egg/dotenv/__init__.py", line 1, in <module>
    from .compat import IS_TYPE_CHECKING
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/python_dotenv-0.15.0-py3.10.egg/dotenv/compat.py", line 20, in <module>
    IS_TYPE_CHECKING = is_type_checking()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/python_dotenv-0.15.0-py3.10.egg/dotenv/compat.py", line 14, in is_type_checking
    from typing import TYPE_CHECKING
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/typing-3.10.0.0-py3.10.egg/typing.py", line 1359, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/typing-3.10.0.0-py3.10.egg/typing.py", line 1007, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```
