### PR TITLE
Fix a padding issue in the risk evaluation template.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changelog
 14.2.1 (unreleased)
 -------------------
 
+- Fix a padding issue in the risk evaluation template.
+  Refs: `#688 <https://github.com/syslabcom/scrum/issues/688>`_.
+  [thet]
 - Fix issue where tiptap context menu didn't load.
   Refs: `#477 <https://github.com/euphorie/Euphorie/issues/477>`_.
   [thet]

--- a/src/euphorie/client/browser/templates/risk_identification_custom.pt
+++ b/src/euphorie/client/browser/templates/risk_identification_custom.pt
@@ -178,7 +178,7 @@
           <!-- END Action Plan -->
 
           <!-- Evaluation -->
-          <fieldset class="pat-well notice pat-depends vertical evaluation"
+          <div class="risk-module pat-well notice pat-depends vertical evaluation"
                     id="evaluation"
                     data-pat-depends="condition: answer=no; transition: slide"
                     tal:condition="not:view/skip_evaluation"
@@ -209,7 +209,7 @@
                 />
                 <tal:span i18n:translate="priority_high">High</tal:span></label>
             </fieldset>
-          </fieldset>
+          </div>
           <!-- END Evaluation -->
 
           <!-- Information -->

--- a/src/euphorie/client/browser/templates/webhelpers.pt
+++ b/src/euphorie/client/browser/templates/webhelpers.pt
@@ -321,7 +321,7 @@
   </metal:risk_identification>
 
   <metal:risk_evaluation define-macro="risk_evaluation">
-    <fieldset class="pat-well notice pat-depends vertical evaluation"
+    <div class="risk-module pat-well notice pat-depends vertical evaluation"
               id="evaluation"
               data-pat-depends="${view/evaluation_condition}; transition: slide"
               tal:define="
@@ -583,7 +583,7 @@
       <tal:block condition="python:evaluation_method in ('top5', 'policy', 'fixed')">
         <p i18n:translate="description_automatic_evaluation">The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan.</p>
       </tal:block>
-    </fieldset>
+    </div>
   </metal:risk_evaluation>
 
   <metal:legal_references define-macro="legal_references">


### PR DESCRIPTION
Fixes: https://github.com/syslabcom/scrum/issues/688

This handles two cases, one for custom risks and one for standard risks. Evaluating the source of Euphorie, it seems that the custom risk is always used, unless there are some overrides in Euphorie policy add-ons.