### PR TITLE
Added mailing-lists.json

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,9 @@ Changelog
   [thet]
 - Formatting is available for in-place measures.
   [reinhardt]
+- Mailing lists json view.
+  `#739 <https://github.com/syslabcom/scrum/issues/739>`_.
+  [reinhardt]
 
 
 14.2.0 (2022-11-09)

--- a/src/euphorie/client/browser/client.py
+++ b/src/euphorie/client/browser/client.py
@@ -3,6 +3,9 @@
 from Acquisition import aq_base
 from euphorie.client.browser.webhelpers import WebHelpers
 from euphorie.client.country import IClientCountry
+from json import dumps
+from plone import api
+from Products.Five import BrowserView
 
 
 class ClientView(WebHelpers):
@@ -26,3 +29,30 @@ class ClientView(WebHelpers):
         if not target:
             return "No country was identified"
         self.request.RESPONSE.redirect("{}{}".format(target.absolute_url(), url_param))
+
+
+class MailingListsJson(BrowserView):
+    """Mailing lists (countries, in the future also sectors and tools)"""
+
+    def __call__(self):
+        """Json list of mailing list ids/names"""
+        lists = []
+        catalog = api.portal.get_tool(name="portal_catalog")
+        self.request.response.setHeader("Content-type", "application/json")
+        # TODO: require query.
+        # q = self.request.get("q", "").strip().lower()
+        # if not q:
+        #     return dumps([])
+
+        all_users = {"id": "all", "text": "All OiRA users"}
+        # if q in all_users["id"] or q in all_users["text"].lower():
+        lists.append(all_users)
+
+        # FIXME: SearchableText="de*" doesn't return Germany
+        countries = catalog(portal_type="euphorie.clientcountry")
+        lists.extend(
+            [{"id": country["id"], "text": country["Title"]} for country in countries]
+        )
+        # TODO: add sectors and tools
+
+        return dumps(lists)

--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -574,6 +574,14 @@
       />
 
   <browser:page
+      name="mailing-lists.json"
+      for="euphorie.client.client.IClient"
+      permission="zope2.View"
+      class=".client.MailingListsJson"
+      layer="plonetheme.nuplone.skin.interfaces.NuPloneSkin"
+      />
+
+  <browser:page
       name="new-session.html"
       for="*"
       permission="zope2.View"


### PR DESCRIPTION
I went for the path ID instead of the UID because of the oira convention of using partial paths like /eu/covid/covid-19 and because `UID` was returning None in some cases (scary).

Refs syslabcom/scrum#739