### PR TITLE
Lazily load the dashboard content

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,7 +16,7 @@ Changelog
   [ale-rt]
 - Decoupled loading of the dashboard.
   Refs: `#712 <https://github.com/syslabcom/scrum/issues/712>`_.
-  [reinhardt]
+  [reinhardt, thet]
 
 
 14.2.1 (2022-11-25)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,9 @@ Changelog
   [reinhardt]
 - Upgrade plone to 5.2.10
   [ale-rt]
+- Decoupled loading of the dashboard.
+  Refs: `#712 <https://github.com/syslabcom/scrum/issues/712>`_.
+  [reinhardt]
 
 
 14.2.1 (2022-11-25)

--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -412,6 +412,15 @@
       />
 
   <browser:page
+      name="dashboard"
+      for="euphorie.client.country.IClientCountry"
+      permission="zope2.View"
+      class=".country.SessionsView"
+      template="templates/sessions-dashboard-content.pt"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
+  <browser:page
       name="assessments"
       for="euphorie.client.country.IClientCountry"
       permission="zope2.View"

--- a/src/euphorie/client/browser/templates/sessions-dashboard-content.pt
+++ b/src/euphorie/client/browser/templates/sessions-dashboard-content.pt
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:meta="http://xml.zope.org/namespaces/meta"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/@@shell/macros/shell"
+      i18n:domain="euphorie"
+>
+  <metal:slot fill-slot="content">
+    <div id="content-pane">
+      <div id="application-content">
+        <div class="row pat-masonry"
+             id="dashboard"
+             data-pat-masonry="column-width: .grid-sizer; gutter: 0; item-selector: .portlet; stamp: .stamp;"
+        >
+          <div class="grid-sizer"></div>
+          <tal:portlets repeat="portlet view/portlets"
+                        replace="structure portlet"
+          />
+        </div>
+      </div>
+    </div>
+  </metal:slot>
+</html>

--- a/src/euphorie/client/browser/templates/sessions-dashboard.pt
+++ b/src/euphorie/client/browser/templates/sessions-dashboard.pt
@@ -102,19 +102,13 @@
         </div>
       </metal:homescreen_navigation>
       <div id="application-content">
-        <div class="row pat-masonry"
-             id="dashboard"
-             data-pat-masonry="column-width: .grid-sizer; gutter: 0; item-selector: .portlet; stamp: .stamp;"
-        >
-          <div class="grid-sizer"></div>
-          <tal:portlets repeat="portlet view/portlets"
-                        replace="structure portlet"
-          />
-        </div>
+        <a class="pat-inject infinite-scrolling-trigger"
+           href="${context/absolute_url}/@@dashboard#application-content"
+           data-pat-inject="trigger: autoload"
+        >Loading&hellip;</a>
       </div>
-    </div>
 
-  </metal:slot>
+    </div></metal:slot>
 
   <metal:slot fill-slot="splash_message_slot">
     <div class="splash-message"

--- a/src/euphorie/client/tests/stories/ForgotPassword.txt
+++ b/src/euphorie/client/tests/stories/ForgotPassword.txt
@@ -110,4 +110,4 @@ And we are now indeed at the session screen:
 >>> browser.url
 'http://nohost/plone/client/nl'
 >>> browser.contents
-'...Start a new session...'
+'...Assessments...'

--- a/src/euphorie/client/tests/test_functional_country.py
+++ b/src/euphorie/client/tests/test_functional_country.py
@@ -30,15 +30,21 @@ class CountryFunctionalTests(EuphorieFunctionalTestCase):
         # version
         browser.open("%s?language=nl" % self.portal.client.absolute_url())
         registerUserInClient(browser, link="Registreer")
-        # Note, this used to test that the URL was that of the client,
-        # in the correct country (nl), with `?language=nl-NL` appended.
-        # I don't see where in the code this language URL parameter would
-        # come from, so I remove it in this test as well.
-        self.assertEqual(browser.url, "http://nohost/plone/client/nl")
         self.assertEqual(
             browser.getControl(name="survey").options, ["", "branche/vragenlijst"]
         )
+
+        # Still Dutch
+        browser.open(self.portal.client["nl"].absolute_url() + "/@@dashboard")
+        self.assertEqual(
+            browser.getControl(name="survey").options, ["", "branche/vragenlijst"]
+        )
+
+        # Now, switch to English
         browser.open("%s?language=en" % self.portal.client["nl"].absolute_url())
+        # We need to manually open the @@dashboared view as the test browser
+        # does not handle JavaScript.
+        browser.open(self.portal.client["nl"].absolute_url() + "/@@dashboard")
         self.assertEqual(
             browser.getControl(name="survey").options, ["", "sector/survey"]
         )

--- a/src/euphorie/client/tests/utils.py
+++ b/src/euphorie/client/tests/utils.py
@@ -56,6 +56,11 @@ def registerUserInClient(browser, link="Registreer"):
     # if "terms-and-conditions" in browser.url:
     #     browser.getForm().submit()
 
+    # Now, let's directly open the dashboard contents.
+    # We need to do that manually since the test browser does not handle
+    # JavaScript (pat-inject with trigger autoload).
+    browser.open(f"{browser.url}/@@dashboard")
+
 
 class MockMailFixture(object):
     def __init__(self):


### PR DESCRIPTION
This feels a little silly - maybe we should lazy-load the individual portlets instead. But this does work around the certificate size issue (syslabcom/scrum#712).

See https://github.com/syslabcom/oira.prototype/commit/2c236988ec5ef44cd6a5ec9e86855eed83f9f6ac

syslabcom/scrum#712