### PR TITLE
Lazy-load the dashboard portlets

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,9 @@ Changelog
   [reinhardt]
 - Organisation: Reflect whether training is enabled when adding a user.
   [reinhardt]
+- Decoupled loading of the dashboard portlets.
+  Refs: `#712 <https://github.com/syslabcom/scrum/issues/712>`_.
+  [reinhardt, thet]
 
 
 14.2.1 (2022-11-25)

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -560,6 +560,8 @@ class PortletBase(BrowserView):
 
 
 class MyRAsPortlet(PortletBase):
+    element_id = "portlet-my-risk-assessments"
+
     @property
     def columns(self):
         if self.surveys:
@@ -651,4 +653,4 @@ class MyRAsPortlet(PortletBase):
 
 
 class AvailableToolsPortlet(PortletBase, SurveyTemplatesMixin):
-    pass
+    element_id = "portlet-available-tools"

--- a/src/euphorie/client/browser/templates/portlet-available-tools.pt
+++ b/src/euphorie/client/browser/templates/portlet-available-tools.pt
@@ -1,6 +1,6 @@
 <tal:portlet i18n:domain="euphorie">
   <div class="portlet span-1"
-       id="portlet-available-tools"
+       id="${view/element_id}"
        tal:define="
          root view/get_survey_templates_tree_root;
          threshold view/tools_threshold;

--- a/src/euphorie/client/browser/templates/portlet-my-ras.pt
+++ b/src/euphorie/client/browser/templates/portlet-my-ras.pt
@@ -1,6 +1,6 @@
 <tal:portlet i18n:domain="euphorie">
   <div class="portlet span-${view/columns}"
-       id="portlet-my-risk-assessments"
+       id="${view/element_id}"
        tal:define="
          sessions_by_organisation view/sessions_by_organisation;
        "

--- a/src/euphorie/client/browser/templates/portlet-my-trainings.pt
+++ b/src/euphorie/client/browser/templates/portlet-my-trainings.pt
@@ -6,7 +6,7 @@
              i18n:domain="euphorie"
 >
   <div class="portlet span-${view/columns}"
-       id="portlet-training"
+       id="${view/element_id}"
   >
     <div class="content">
       <article class="portlet-intro">

--- a/src/euphorie/client/browser/templates/sessions-dashboard.pt
+++ b/src/euphorie/client/browser/templates/sessions-dashboard.pt
@@ -107,13 +107,27 @@
              data-pat-masonry="column-width: .grid-sizer; gutter: 0; item-selector: .portlet; stamp: .stamp;"
         >
           <div class="grid-sizer"></div>
-          <tal:portlets repeat="portlet view/portlets"
-                        replace="structure portlet"
-          />
+          <tal:portlets repeat="portlet view/portlets">
+            <div class="portlet span-${portlet/columns|string:1}"
+                 id="${portlet/element_id}"
+                 tal:condition="portlet/element_id|nothing"
+            >
+              <a class="pat-inject infinite-scrolling-trigger"
+                 href="${context/absolute_url}/@@${portlet/__name__}#${portlet/element_id}"
+                 data-pat-inject="trigger: autoload"
+              >Loading&hellip;</a>
+            </div>
+            <tal:comment replace="nothing"><!-- Fallback: If the view has no element_id member, we can't properly pre-render the div --></tal:comment>
+            <a class="pat-inject infinite-scrolling-trigger"
+               href="${context/absolute_url}/@@${portlet/__name__}"
+               data-pat-inject="trigger: autoload; target: self::element"
+               tal:condition="not:portlet/element_id|nothing"
+            >Loading&hellip;</a>
+          </tal:portlets>
         </div>
       </div>
-    </div>
 
+    </div>
   </metal:slot>
 
   <metal:slot fill-slot="splash_message_slot">

--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -701,6 +701,7 @@ class SlideQuestionTryAgain(SlideQuestionIntro):
 
 class MyTrainingsPortlet(BrowserView):
     columns = "1"
+    element_id = "portlet-training"
 
     @property
     @memoize

--- a/src/euphorie/client/tests/stories/ForgotPassword.txt
+++ b/src/euphorie/client/tests/stories/ForgotPassword.txt
@@ -110,4 +110,4 @@ And we are now indeed at the session screen:
 >>> browser.url
 'http://nohost/plone/client/nl'
 >>> browser.contents
-'...Start a new session...'
+'...Assessments...'

--- a/src/euphorie/client/tests/test_functional_client.py
+++ b/src/euphorie/client/tests/test_functional_client.py
@@ -33,6 +33,11 @@ class SurveyTests(EuphorieFunctionalTestCase):
         url = self.portal.client.nl["sector-title"]["survey-title"].absolute_url()
         browser.open(url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["sector-title/survey-title"]
         browser.getForm(action="new-session").submit()
@@ -75,6 +80,11 @@ class SurveyTests(EuphorieFunctionalTestCase):
             self.portal.client.nl["sector-title"]["survey-title"].absolute_url()
         )
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["sector-title/survey-title"]
         browser.getForm(action="new-session").submit()
@@ -117,6 +127,11 @@ class SurveyTests(EuphorieFunctionalTestCase):
             self.portal.client.nl["sector-title"]["survey-title"].absolute_url()
         )
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["sector-title/survey-title"]
         browser.getForm(action="new-session").submit()

--- a/src/euphorie/client/tests/test_functional_country.py
+++ b/src/euphorie/client/tests/test_functional_country.py
@@ -29,15 +29,30 @@ class CountryFunctionalTests(EuphorieFunctionalTestCase):
         # version
         browser.open("%s?language=nl" % self.portal.client.absolute_url())
         registerUserInClient(browser, link="Registreer")
-        # Note, this used to test that the URL was that of the client,
-        # in the correct country (nl), with `?language=nl-NL` appended.
-        # I don't see where in the code this language URL parameter would
-        # come from, so I remove it in this test as well.
-        self.assertEqual(browser.url, "http://nohost/plone/client/nl")
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         self.assertEqual(
             browser.getControl(name="survey").options, ["", "branche/vragenlijst"]
         )
+
+        # Still Dutch
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
+        self.assertEqual(
+            browser.getControl(name="survey").options, ["", "branche/vragenlijst"]
+        )
+
+        # Now, switch to English
         browser.open("%s?language=en" % self.portal.client["nl"].absolute_url())
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         self.assertEqual(
             browser.getControl(name="survey").options, ["", "sector/survey"]
         )

--- a/src/euphorie/client/tests/test_functional_profile.py
+++ b/src/euphorie/client/tests/test_functional_profile.py
@@ -40,6 +40,11 @@ class ProfileTests(EuphorieFunctionalTestCase):
             self.portal.client.nl["sector-title"]["survey-title"].absolute_url()
         )
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["sector-title/survey-title"]
         browser.getForm(action="new-session").submit()

--- a/src/euphorie/client/tests/test_functional_report.py
+++ b/src/euphorie/client/tests/test_functional_report.py
@@ -18,6 +18,11 @@ class ReportTests(EuphorieFunctionalTestCase):
         browser = self.get_browser()
         browser.open(survey_url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()
@@ -50,6 +55,11 @@ class ReportTests(EuphorieFunctionalTestCase):
         browser = self.get_browser()
         browser.open(survey_url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()
@@ -70,6 +80,11 @@ class ReportTests(EuphorieFunctionalTestCase):
         survey_url = self.portal.client.nl["ict"]["software-development"].absolute_url()
         browser.open(survey_url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()

--- a/src/euphorie/client/tests/test_functional_risk.py
+++ b/src/euphorie/client/tests/test_functional_risk.py
@@ -15,6 +15,11 @@ class RiskTests(EuphorieFunctionalTestCase):
         browser = self.get_browser()
         browser.open(survey.absolute_url())
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()
@@ -52,6 +57,11 @@ class RiskTests(EuphorieFunctionalTestCase):
         ].absolute_url()  # noqa: E501
         browser.open(survey_url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()
@@ -95,6 +105,11 @@ class RiskTests(EuphorieFunctionalTestCase):
         survey_url = self.portal.client.nl["ict"]["software-development"].absolute_url()
         browser.open(survey_url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()
@@ -133,6 +148,11 @@ class RiskTests(EuphorieFunctionalTestCase):
         ].absolute_url()  # noqa: E501
         browser.open(survey_url)
         registerUserInClient(browser)
+        # We need to manually open the portlet view as the test browser
+        # does not handle JavaScript.
+        browser.open(
+            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
+        )
         # Create a new survey session
         browser.getControl(name="survey").value = ["ict/software-development"]
         browser.getForm(action="new-session").submit()


### PR DESCRIPTION
See also https://github.com/syslabcom/oira.prototype/pull/402

Replaces #488

In #488 @thet noticed this:

> Please note: any request parameters would get lost when calling the @@dashboard view.

I found that request parameters were only set by `portlet-my-ras` which contains a form for toggling the display of archived items. It was re-injecting the whole dashboard. Now it only injects itself; therefore the dashboard does not need to be aware of request parameters.

For variants with custom dashboards like daimler we need to double check that the portlets also only re-inject themselves.

syslabcom/scrum#712
