### PR TITLE
Fix adding custom risks

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 14.3.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix issue where custom risk could not be added.
+  [reinhardt]
 
 
 14.3.0 (2023-01-26)

--- a/src/euphorie/client/browser/module.py
+++ b/src/euphorie/client/browser/module.py
@@ -195,7 +195,10 @@ class IdentificationView(BrowserView):
     def add_custom_risk(self):
         sql_risks = self.context.children()
         if sql_risks.count():
-            counter_id = max([int(risk.path[-3:]) for risk in sql_risks.all()]) + 1
+            counter_id = (
+                max([int(risk.zodb_path.split("/")[-1]) for risk in sql_risks.all()])
+                + 1
+            )
         else:
             counter_id = 1
 


### PR DESCRIPTION
add_custom_risk: don't use path column to determine next zodb_path

We've encountered a situation where the `path` and `zodb_path` columns had gone out of sync and `add_custom_risk` tried to set a `zodb_path` that already existed. Checking the existing `zodb_path` values is more consistent and fixes the issue.

syslabcom/scrum#911