### PR TITLE
HtmlToWord: Fix problem with different documents for each report compilation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,13 @@ Changelog
 
 14.3.1 (unreleased)
 -------------------
+
+- HtmlToWord: Fix problem with different documents for each report compilation.
+  This fixes a problem where a bullet number counter was not reset among
+  multiple docx compilations, resulting in different documents for the same
+  report when downloaded multiple times.
+  [thet]
+
 - Update CSS and scripts to latest from prototype.
   [thet]
 

--- a/src/euphorie/client/docx/html.py
+++ b/src/euphorie/client/docx/html.py
@@ -51,7 +51,7 @@ def add_hyperlink(paragraph, url, text, style):
     return hyperlink
 
 
-class _HtmlToWord:
+class HtmlToWord:
     def handleInlineText(self, node, p):
         """Handler for elements which can only contain inline text (p, li)"""
         run = p.add_run()
@@ -133,6 +133,3 @@ class _HtmlToWord:
             doc = self.handleElement(node, doc, p_style)
 
         return doc
-
-
-HtmlToWord = _HtmlToWord()

--- a/src/euphorie/content/browser/survey.py
+++ b/src/euphorie/content/browser/survey.py
@@ -232,6 +232,9 @@ class ContentsOfSurveyCompiler(IdentificationReportCompiler):
         self.context = context
         self.request = request
         self.template = Document(self._template_filename)
+
+        self.compiler = HtmlToWord()
+
         self.use_existing_measures = False
         self.tool_type = get_tool_type(self.context)
         self.tti = getUtility(IToolTypesInfo)
@@ -293,7 +296,7 @@ class ContentsOfSurveyCompiler(IdentificationReportCompiler):
 
             description = node.description
 
-            doc = HtmlToWord(_sanitize_html(description or ""), doc)
+            self.compiler(_sanitize_html(description or ""), doc)
 
             if node.typus != "Risk":
                 continue
@@ -310,7 +313,7 @@ class ContentsOfSurveyCompiler(IdentificationReportCompiler):
                         target_language=self.lang,
                     )
                     doc.add_paragraph(legal_heading, style="Legal Heading")
-                    doc = HtmlToWord(_sanitize_html(legal_reference), doc)
+                    self.compiler(_sanitize_html(legal_reference), doc)
 
 
 class Node:


### PR DESCRIPTION
This involves an API change: Instantiate HtmlToWord compiler freshly for each document and make use of oject orientated encapsulation. Also do not call the compiler but create a dedicated compile_inline method.

This fixes a problem where a bullet number counter was not reset among multiple docx compilations, resulting in different documents for the same report when downloaded multiple times.