### PR TITLE
Remove some obsolete JavaScript.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,12 @@ Changelog
 14.3.1 (unreleased)
 -------------------
 
+- Remove some obsolete JavaScript.
+  Remove the polyfills-loader (IE11 compatibility) and the patternslib public
+  path (base directory for JavaScript assets) variable. Both are not used
+  anymore.
+  [thet]
+
 - HtmlToWord: Fix problem with different documents for each report compilation.
   This fixes a problem where a bullet number counter was not reset among
   multiple docx compilations, resulting in different documents for the same

--- a/scripts/proto2diazo.py
+++ b/scripts/proto2diazo.py
@@ -11,11 +11,6 @@ logger = logging.getLogger(sys.argv[0])
 THEME_DIR = os.path.join("src", "euphorie", "client", "resources")
 HELP_DIR = os.path.join("src", "euphorie", "client", "resources", "oira", "help")
 
-ILLUSTRATION_JS_SNIPPET = """
-    <script>window.__patternslib_public_path__ = "/++resource++euphorie.resources/oira/script/";</script>
-    <script src="/++resource++euphorie.resources/oira/script/polyfills-loader.js" type="text/javascript"></script>
-"""  # noqa: E501
-
 
 def strip_help(filepath):
     """Fix the urls in filepath."""
@@ -27,10 +22,6 @@ def strip_help(filepath):
     except Exception:
         logger.exception("Problem reading %s", filepath)
         return
-
-    # We need to set the __patternslib_public_path__ in our screenshots
-    a, b, c = content.partition('<script src="/assets')
-    content = "".join((a + ILLUSTRATION_JS_SNIPPET, b, c))
 
     delta = len(filepath.split("/")) - 7
     shim = "../" * delta


### PR DESCRIPTION
Remove the polyfills-loader (IE11 compatibility) and the patternslib public path (base directory for JavaScript assets) variable. Both are not used anymore.