### PR TITLE
Generate password reset link on country or client

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -59,6 +59,10 @@ Changelog
   Ref: scrum-901
   [cillianderoiste]
 
+- Fix password reset link when called on session
+  Ref: scrum-1026
+  [reinhardt]
+
 14.3.0 (2023-01-26)
 -------------------
 

--- a/src/euphorie/client/browser/templates/password_recovery_email.pt
+++ b/src/euphorie/client/browser/templates/password_recovery_email.pt
@@ -1,6 +1,7 @@
 <tal:root define="
             portal_state context/@@plone_portal_state;
             isAnon portal_state/anonymous;
+            webhelpers nocall:here/webhelpers;
             randomstring options/randomstring;
           "
           i18n:domain="plone"
@@ -10,7 +11,7 @@
               i18n:name="site_name"
     />
   site:
-    <tal:i18n i18n:name="reset_url">${here/absolute_url}/passwordreset/${randomstring}</tal:i18n></tal:i18n>
+    <tal:i18n i18n:name="reset_url">${webhelpers/country_or_client_url}/passwordreset/${randomstring}</tal:i18n></tal:i18n>
 
   <tal:i18n i18n:translate="mailtemplate_text_expirationdate_linkreset">(This link is valid for
     <span tal:replace="view/expiration_timeout"


### PR DESCRIPTION
It does not work when generated on a session because of the custom traversal.

syslabcom/scrum#1026