### PR TITLE
Dashboard: Don't try to inject empty portlets

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,10 @@ Changelog
   Ref: scrum-1026
   [reinhardt]
 
+- Fix “loading” spinner when training dashboard is not displayed.
+  Ref: scrum-1027
+  [reinhardt]
+
 14.3.0 (2023-01-26)
 -------------------
 

--- a/src/euphorie/client/browser/templates/sessions-dashboard.pt
+++ b/src/euphorie/client/browser/templates/sessions-dashboard.pt
@@ -108,21 +108,23 @@
         >
           <div class="grid-sizer"></div>
           <tal:portlets repeat="portlet view/portlets">
-            <div class="portlet span-${portlet/columns|string:1}"
-                 id="${portlet/element_id}"
-                 tal:condition="portlet/element_id|nothing"
-            >
+            <tal:portlet condition="portlet/available|python:True">
+              <div class="portlet span-${portlet/columns|string:1}"
+                   id="${portlet/element_id}"
+                   tal:condition="portlet/element_id|nothing"
+              >
+                <a class="pat-inject infinite-scrolling-trigger"
+                   href="${context/absolute_url}/@@${portlet/__name__}#${portlet/element_id}"
+                   data-pat-inject="trigger: autoload"
+                >Loading&hellip;</a>
+              </div>
+              <tal:comment replace="nothing"><!-- Fallback: If the view has no element_id member, we can't properly pre-render the div --></tal:comment>
               <a class="pat-inject infinite-scrolling-trigger"
-                 href="${context/absolute_url}/@@${portlet/__name__}#${portlet/element_id}"
-                 data-pat-inject="trigger: autoload"
+                 href="${context/absolute_url}/@@${portlet/__name__}"
+                 data-pat-inject="trigger: autoload; target: self::element"
+                 tal:condition="not:portlet/element_id|nothing"
               >Loading&hellip;</a>
-            </div>
-            <tal:comment replace="nothing"><!-- Fallback: If the view has no element_id member, we can't properly pre-render the div --></tal:comment>
-            <a class="pat-inject infinite-scrolling-trigger"
-               href="${context/absolute_url}/@@${portlet/__name__}"
-               data-pat-inject="trigger: autoload; target: self::element"
-               tal:condition="not:portlet/element_id|nothing"
-            >Loading&hellip;</a>
+            </tal:portlet>
           </tal:portlets>
         </div>
       </div>

--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -743,6 +743,10 @@ class MyTrainingsPortlet(BrowserView):
         return api.content.get_view("webhelpers", self.context, self.request)
 
     @property
+    def available(self):
+        return self.my_unfinished_trainings or self.my_certificates
+
+    @property
     @memoize
     def my_unfinished_trainings(self):
         account_id = self.webhelpers.get_current_account().id


### PR DESCRIPTION
Turns out there are optional portlets (see also https://gitlab.com/syslabcom/daimler/daimler.oira/-/merge_requests/191)

[Ignore whitespace](https://github.com/euphorie/Euphorie/pull/507/files?diff=split&w=1) when viewing diff.

https://github.com/syslabcom/scrum/issues/1027
https://github.com/syslabcom/scrum/issues/712