### PR TITLE
Fix survey navigation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,10 @@ Changelog
 14.3.2 (unreleased)
 -------------------
 
+- Survey navigation: Fix class when navigation menu is active and disabled to
+  not render as "activedisabled".
+  [thet]
+
 - Upgrade Plone to 5.2.11.
   [thet]
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,10 @@ Changelog
 14.3.2 (unreleased)
 -------------------
 
+- Survey navigation: When survey is archived or otherwise disabled the report,
+  training and status menu items should still be active.
+  [thet]
+
 - Survey navigation: Fix class when navigation menu is active and disabled to
   not render as "activedisabled".
   [thet]

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -1190,7 +1190,7 @@ class WebHelpers(BrowserView):
             {
                 "active": active,
                 "disabled": disabled,
-                "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                 "id": "step-1",
                 "name": "preparation",
                 "href": f"{url}/@@start#content",
@@ -1208,7 +1208,7 @@ class WebHelpers(BrowserView):
                 {
                     "active": active,
                     "disabled": disabled,
-                    "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                    "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                     "id": "step-involve",
                     "name": "involve",
                     "href": f"{url}/@@involve#content",
@@ -1233,7 +1233,7 @@ class WebHelpers(BrowserView):
             {
                 "active": active,
                 "disabled": disabled,
-                "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                 "id": "step-2",
                 "name": "identification",
                 "href": f"{url}/@@identification#content",
@@ -1252,7 +1252,7 @@ class WebHelpers(BrowserView):
                 {
                     "active": active,
                     "disabled": disabled,
-                    "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                    "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                     "id": "step-4",
                     "name": "action-plan",
                     "href": f"{url}/@@actionplan#content",
@@ -1269,7 +1269,7 @@ class WebHelpers(BrowserView):
             {
                 "active": active,
                 "disabled": disabled,
-                "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                 "id": "step-5",
                 "name": "report",
                 "href": f"{url}/@@report#content",
@@ -1284,7 +1284,7 @@ class WebHelpers(BrowserView):
                 {
                     "active": active,
                     "disabled": disabled,
-                    "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                    "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                     "id": "step-6",
                     "name": "training",
                     "href": f"{url}/@@training#content",
@@ -1300,7 +1300,7 @@ class WebHelpers(BrowserView):
             {
                 "active": active,
                 "disabled": disabled,
-                "class": f'{"active" if active else ""}{"disabled" if disabled else ""}',  # noqa: E501
+                "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                 "id": "status",
                 "name": "status",
                 "href": f"{url}/@@status#content",

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -1265,6 +1265,8 @@ class WebHelpers(BrowserView):
 
         # TODO: check if guest.
         active = section == "report"
+        # The following menu items should be active even if can_edit is False.
+        disabled = (section in ("", "preparation") and is_new_session)
         data.append(
             {
                 "active": active,

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -1266,7 +1266,7 @@ class WebHelpers(BrowserView):
         # TODO: check if guest.
         active = section == "report"
         # The following menu items should be active even if can_edit is False.
-        disabled = (section in ("", "preparation") and is_new_session)
+        disabled = section in ("", "preparation") and is_new_session
         data.append(
             {
                 "active": active,


### PR DESCRIPTION
- Survey navigation: When survey is archived or otherwise disabled the report,
  training and status menu items should still be active.

- Survey navigation: Fix class when navigation menu is active and disabled to
  not render as "activedisabled".