### PR TITLE
Keep session URL usable when tool is updated

### DIFF
--- a/src/euphorie/client/adapters/session_traversal.py
+++ b/src/euphorie/client/adapters/session_traversal.py
@@ -7,6 +7,7 @@ from OFS.Traversable import Traversable
 from plone.memoize.instance import memoizedproperty
 from sqlalchemy.orm.exc import NoResultFound
 from zExceptions import NotFound
+from zExceptions import Redirect
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -63,7 +64,10 @@ class SessionTraversal(SimpleHandler):
         new_session_id = self.get_redirect(session_id)
         if new_session_id:
             new_traversed_session = self.factory(self.context, new_session_id)
-            # from zope.publisher.interfaces import Redirect
-            # raise Redirect(new_traversed_session.absolute_url())
-            return new_traversed_session
+            raise Redirect(
+                "/".join(
+                    [new_traversed_session.__of__(self.context).absolute_url()]
+                    + self.context.REQUEST.path
+                )
+            )
         return self.factory(self.context, session_id)

--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -879,6 +879,14 @@
       layer="euphorie.client.interfaces.IClientSkinLayer"
       />
 
+  <browser:page
+      name="index.html"
+      for="zExceptions.Redirect"
+      permission="zope2.Public"
+      class=".error.Redirect"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
   <!-- Report -->
   <browser:page
       name="report_view"

--- a/src/euphorie/client/browser/error.py
+++ b/src/euphorie/client/browser/error.py
@@ -33,3 +33,9 @@ class ErrorView(BrowserView):
 
 class NotFound(ErrorView):
     pass
+
+
+class Redirect(BrowserView):
+    def __call__(self):
+        exception = aq_inner(self.context)
+        return self.request.response.redirect(exception.location)

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -13,6 +13,7 @@ from euphorie.client.model import Module
 from euphorie.client.model import MODULE_WITH_RISK_OR_TOP5_FILTER
 from euphorie.client.model import Risk
 from euphorie.client.model import RISK_PRESENT_OR_TOP5_FILTER
+from euphorie.client.model import SessionRedirect
 from euphorie.client.model import SKIPPED_PARENTS
 from euphorie.client.model import SurveyTreeItem
 from euphorie.client.navigation import FindFirstQuestion
@@ -327,6 +328,11 @@ class Profile(SessionMixin, AutoExtensibleForm, EditForm):
             new_session = survey_session
         else:
             new_session = self.rebuild_session(survey, profile)
+            Session.add(
+                SessionRedirect(
+                    old_session_id=survey_session.id, new_session_id=new_session.id
+                )
+            )
 
         new_session.update_measure_types(survey)
         return new_session

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1211,8 +1211,7 @@ class SessionRedirect(BaseObject):
 
     __tablename__ = "session_redirect"
 
-    id = schema.Column(types.Integer(), primary_key=True, autoincrement=True)
-    old_session_id = schema.Column(types.Integer(), unique=True, nullable=False)
+    old_session_id = schema.Column(types.Integer(), primary_key=True, nullable=False)
     new_session_id = schema.Column(types.Integer(), nullable=False)
 
 

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1206,6 +1206,16 @@ class SurveySession(BaseObject):
         return completion_percentage
 
 
+class SessionRedirect(BaseObject):
+    """Mapping of old deleted sessions to their new rebuilt counterparts"""
+
+    __tablename__ = "session_redirect"
+
+    id = schema.Column(types.Integer(), primary_key=True, autoincrement=True)
+    old_session_id = schema.Column(types.Integer(), unique=True, nullable=False)
+    new_session_id = schema.Column(types.Integer(), nullable=False)
+
+
 class Company(BaseObject):
     """Information about a company."""
 
@@ -1476,6 +1486,7 @@ if not _instrumented:
     for cls in [
         SurveyTreeItem,
         SurveySession,
+        SessionRedirect,
         Module,
         Risk,
         ActionPlan,

--- a/src/euphorie/deployment/upgrade/alembic/versions/20230406070728_add_session_redirect.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/20230406070728_add_session_redirect.py
@@ -1,0 +1,35 @@
+"""Add session redirect
+
+Revision ID: 20230406070728
+Revises: 20220720110538
+Create Date: 2023-04-06 07:15:08.783635
+
+"""
+from alembic import op
+from euphorie.deployment.upgrade.utils import has_table
+
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20230406070728"
+down_revision = "20220720110538"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not has_table("session_redirect"):
+        op.create_table(
+            "session_redirect",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("old_session_id", sa.Integer(), nullable=False),
+            sa.Column("new_session_id", sa.Integer(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("old_session_id"),
+        )
+
+
+def downgrade():
+    if has_table("session_redirect"):
+        op.drop_table("session_redirect")

--- a/src/euphorie/deployment/upgrade/alembic/versions/20230406070728_add_session_redirect.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/20230406070728_add_session_redirect.py
@@ -22,11 +22,9 @@ def upgrade():
     if not has_table("session_redirect"):
         op.create_table(
             "session_redirect",
-            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
             sa.Column("old_session_id", sa.Integer(), nullable=False),
             sa.Column("new_session_id", sa.Integer(), nullable=False),
-            sa.PrimaryKeyConstraint("id"),
-            sa.UniqueConstraint("old_session_id"),
+            sa.PrimaryKeyConstraint("old_session_id"),
         )
 
 

--- a/src/euphorie/upgrade/deployment/v1/20230406070728_add_session_redirect/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20230406070728_add_session_redirect/upgrade.py
@@ -1,0 +1,9 @@
+from euphorie.deployment.upgrade.utils import alembic_upgrade_to
+from ftw.upgrade import UpgradeStep
+
+
+class AddSessionRedirect(UpgradeStep):
+    """Add session redirect."""
+
+    def __call__(self):
+        alembic_upgrade_to(self.target_version)


### PR DESCRIPTION
This currently keeps the URL with the old session ID. I'd rather do a redirect to the URL with the new ID but I can't figure out how to do that in a namespace traversal. `response.redirect()` just gives me a blank page, `raise Redirect` gives me a traceback. Any ideas?

syslabcom/scrum#833