### PR TITLE
Add a condition to display a note

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 14.3.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Do not display the note "The risk evaluation has been automatically done by the tool"
+  if there is an integrated action plan.
+  [ale-rt]
 
 
 14.3.3 (2023-04-12)

--- a/src/euphorie/client/browser/templates/webhelpers.pt
+++ b/src/euphorie/client/browser/templates/webhelpers.pt
@@ -581,7 +581,9 @@
       </tal:block>
 
       <tal:block condition="python:evaluation_method in ('top5', 'policy', 'fixed')">
-        <p i18n:translate="description_automatic_evaluation">The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan.</p>
+        <p tal:condition="not:webhelpers/integrated_action_plan"
+           i18n:translate="description_automatic_evaluation"
+        >The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan.</p>
       </tal:block>
     </div>
   </metal:risk_evaluation>


### PR DESCRIPTION
Do not display the note "The risk evaluation has been automatically done by the tool" if there is an integrated action plan