### PR TITLE
Ask for confirmation when following an organisation invite link

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 14.3.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Ask for confirmation when following an organisation invite link.
+  [reinhardt]
 
 
 14.3.3 (2023-04-12)

--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -496,6 +496,7 @@
       name="confirm-organisation-invite"
       for="euphorie.client.country.IClientCountry"
       class=".organisation.ConfirmInvite"
+      template="templates/confirm-organisation-invite.pt"
       permission="euphorie.client.ViewSurvey"
       layer="euphorie.client.interfaces.IClientSkinLayer"
       />

--- a/src/euphorie/client/browser/organisation.py
+++ b/src/euphorie/client/browser/organisation.py
@@ -360,9 +360,7 @@ class ConfirmInvite(BaseView):
         user = self.inviter
         if user is None:
             return ""
-        if not (user.last_name or user.first_name):
-            return user.loginname
-        return " ".join(filter(None, (user.first_name, user.last_name)))
+        return user.title
 
     @property
     def default_target_view(self):

--- a/src/euphorie/client/browser/templates/confirm-organisation-invite.pt
+++ b/src/euphorie/client/browser/templates/confirm-organisation-invite.pt
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      xmlns:meta="http://xml.zope.org/namespaces/meta"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
-      meta:interpolation="true"
       metal:use-macro="context/@@shell/macros/shell"
       i18n:domain="euphorie"
 >

--- a/src/euphorie/client/browser/templates/confirm-organisation-invite.pt
+++ b/src/euphorie/client/browser/templates/confirm-organisation-invite.pt
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:meta="http://xml.zope.org/namespaces/meta"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      meta:interpolation="true"
+      metal:use-macro="context/@@shell/macros/shell"
+      i18n:domain="euphorie"
+>
+
+  <body>
+    <metal:slot fill-slot="content">
+
+      <div class="pat-scroll-box"
+           id="content-pane"
+      >
+        <div id="application-content">
+
+          <div class="portlet"
+               id="portlet-accept-membership"
+          >
+            <div class="content">
+              <div class="portlet-body"
+                   tal:define="
+                     organisation view/organisation;
+                   "
+              >
+                <figure class="portlet-logo">
+                  <img alt=""
+                       src="${here/absolute_url}/@@organisation-logo/${organisation/organisation_id}?q=${organisation/image_filename}"
+                       tal:condition="organisation/image_filename|nothing"
+                  />
+                </figure>
+                <article class="pat-rich">
+                  <p i18n:translate="description_confirm_organisation_invite">
+                    <tal:user i18n:name="user">${view/organisation_admin_name}</tal:user>
+                     has invited you to join this userʼs organisation. Once you&rsquo;ve accepted your membership, you can collaborate on risk assessments.
+                  </p>
+                </article>
+                <form class="pat-inject button-bar"
+                      action="${request/URL}"
+                      method="POST"
+                >
+                  <button class="pat-button default accept"
+                          name="submit"
+                          type="submit"
+                          value="accept"
+                          i18n:translate=""
+                  >Accept</button>
+                  <button class="pat-button decline"
+                          name="submit"
+                          type="submit"
+                          value="decline"
+                          i18n:translate=""
+                  >Decline</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </metal:slot>
+
+  </body>
+</html>

--- a/src/euphorie/client/browser/templates/confirm-organisation-invite.pt
+++ b/src/euphorie/client/browser/templates/confirm-organisation-invite.pt
@@ -34,7 +34,7 @@
                 </figure>
                 <article class="pat-rich">
                   <p i18n:translate="description_confirm_organisation_invite">
-                    <tal:user i18n:name="user">${view/organisation_admin_name}</tal:user>
+                    <tal:user i18n:name="user">${view/inviter_fullname}</tal:user>
                      has invited you to join this userʼs organisation. Once you&rsquo;ve accepted your membership, you can collaborate on risk assessments.
                   </p>
                 </article>

--- a/src/euphorie/client/tests/test_organisations.py
+++ b/src/euphorie/client/tests/test_organisations.py
@@ -1,6 +1,8 @@
+from contextlib import contextmanager
 from euphorie.client.model import Organisation
 from euphorie.client.model import Session
 from euphorie.client.tests.utils import addAccount
+from euphorie.client.utils import getRequest
 from euphorie.testing import EuphorieIntegrationTestCase
 from plone import api
 from Products.statusmessages.interfaces import IStatusMessage
@@ -19,6 +21,15 @@ class TestOrganisations(EuphorieIntegrationTestCase):
             title="Acme",
         )
         Session.add(self.organisation)
+
+    @contextmanager
+    def _get_view(self, *args, post=False, **kwargs):
+        with super()._get_view(*args, **kwargs) as view:
+            if post:
+                request = getRequest()
+                request.method = "POST"
+                request.form["submit"] = "accept"
+            yield view
 
     def test_add_user_panel(self):
         with api.env.adopt_user("admin"):
@@ -88,7 +99,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
 
         with api.env.adopt_user(user=account2):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 # Calling without a token returns a not found
                 with self.assertRaises(NotFound):
@@ -108,7 +119,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
         # Check that account1 will not consume its own token
         with api.env.adopt_user(user=self.account):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 view.publishTraverse(None, token)()
                 self.assertEqual(
@@ -123,7 +134,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
         # Check that account2 can consume a good token
         with api.env.adopt_user(user=account2):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 view.publishTraverse(None, token)()
                 self.assertEqual(
@@ -148,7 +159,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
         # Check that account2 cannot consume a good token more than once
         with api.env.adopt_user(user=account2):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 view.publishTraverse(None, token)()
                 self.assertEqual(
@@ -164,7 +175,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
         # The same token can be used from account 3
         with api.env.adopt_user(user=account3):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 view.publishTraverse(None, token)()
                 # We need to flush the data to the database
@@ -190,7 +201,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
         # Account 1 can accept
         with api.env.adopt_user(user=account1):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 view.publishTraverse(None, token)()
 
@@ -204,7 +215,7 @@ class TestOrganisations(EuphorieIntegrationTestCase):
         # Check that account3 cannot consume an expired token
         with api.env.adopt_user(user=account3):
             with self._get_view(
-                "confirm-organisation-invite", self.portal.client.eu
+                "confirm-organisation-invite", self.portal.client.eu, post=True
             ) as view:
                 view.publishTraverse(None, token)()
                 self.assertEqual(


### PR DESCRIPTION
Note that this removes the permission check on the organisation logo view because the design implies that a user should see the logo even if they're not yet a member of the organisation.

syslabcom/scrum#594