### PR TITLE
Add step “Consultancy” to session

### DIFF
--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -888,6 +888,25 @@
       layer="euphorie.client.interfaces.IClientSkinLayer"
       />
 
+  <!-- Consultancy -->
+  <browser:page
+      name="consultancy"
+      for="euphorie.client.adapters.session_traversal.ITraversedSurveySession"
+      permission="euphorie.client.ViewSurvey"
+      class=".consultancy.Consultancy"
+      template="templates/consultancy.pt"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
+  <browser:page
+      name="panel-request-validation"
+      for="euphorie.client.adapters.session_traversal.ITraversedSurveySession"
+      class=".consultancy.PanelRequestValidation"
+      template="templates/panel-request-validation.pt"
+      permission="euphorie.client.ViewSurvey"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
   <!-- Report -->
   <browser:page
       name="report_view"

--- a/src/euphorie/client/browser/consultancy.py
+++ b/src/euphorie/client/browser/consultancy.py
@@ -1,0 +1,57 @@
+from euphorie.client.browser.base import BaseView
+from euphorie.client.model import Account
+from euphorie.client.model import OrganisationMembership
+from plone import api
+from plone.memoize.view import memoize
+from Products.Five import BrowserView
+
+
+class Consultancy(BrowserView):
+    """ """
+
+    variation_class = "variation-risk-assessment"
+
+    @property
+    @memoize
+    def webhelpers(self):
+        return api.content.get_view("webhelpers", self.context, self.request)
+
+    @property
+    def organisation(self):
+        return self.webhelpers.traversed_session.session.account.organisation
+
+    def __call__(self):
+        if not self.webhelpers.can_view_session:
+            return self.request.response.redirect(self.webhelpers.client_url)
+        return self.index()
+
+
+class PanelRequestValidation(BaseView):
+    """ """
+
+    default_target_view = "@@consultancy"
+
+    @property
+    @memoize
+    def organisation(self):
+        return self.webhelpers.traversed_session.session.account.organisation
+
+    def consultants(self):
+        if not self.organisation:
+            return []
+        return (
+            self.sqlsession.query(Account)
+            .join(
+                OrganisationMembership,
+                OrganisationMembership.member_id == Account.id,
+            )
+            .filter(OrganisationMembership.owner_id == self.organisation.owner_id)
+            .filter(OrganisationMembership.member_role == "consultant")
+            .order_by(Account.loginname)
+            .all()
+        )
+
+    def handle_POST(self):
+        """Handle the POST request."""
+        # TODO: register the consultant for the session
+        self.redirect()

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -1256,9 +1256,12 @@ class ActionPlanView(RiskBase):
             context, dbsession=self.session, filter=self.risk_filter
         )
         if next_question is None:
-            # We ran out of questions, proceed to the report
-            url = "{session_url}/@@report".format(
-                session_url=self.webhelpers.traversed_session.absolute_url()
+            # We ran out of questions, proceed to the next phase
+            url = "{session_url}/{next_view_name}".format(
+                session_url=self.webhelpers.traversed_session.absolute_url(),
+                next_view_name="@@consultancy"
+                if self.webhelpers.use_consultancy_phase
+                else "@@report",
             )
         else:
             url = "{session_url}/{path}/@@actionplan".format(

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      id="consultancy"
+      metal:use-macro="context/@@shell/macros/shell"
+      tal:define="
+        webhelpers nocall:context/@@webhelpers;
+      "
+      i18n:domain="euphorie"
+>
+
+  <body>
+    <metal:slot fill-slot="content">
+      <div class="pat-scroll-box"
+           id="content-pane"
+      >
+        <metal:call use-macro="webhelpers/macros/toolbar" />
+        <tal:block replace="tile:statusmessages" />
+
+        <article class="pat-rich"
+                 id="page-intro"
+        >
+          <h1 i18n:translate="label_consultancy">
+            Consultancy
+          </h1>
+
+          <p i18n:translate="message_find_consultants">
+            You have the option to request assistance in completing a risk assessment or to have a risk analysis performed by you, validated by an OSH consultant. An OSH consultant can give your risk assessment an offical validation mark.
+          </p>
+
+        </article>
+
+        <tal:comment replace="nothing">
+        TODO: depend on validation state
+          <p class="pat-message success"
+             i18n:translate="message_session_validated"
+          >
+            <a href="#"
+               i18n:name="consultant"
+            >Michel Moulin</a>
+             has reviewed and validated this risk assessment.
+          </p>
+          <p class="pat-message info"
+             i18n:translate="message_session_under_review"
+          >
+				This risk assessment is currently under review by
+            <a href="#"
+               i18n:name="consultant"
+            >Michel Moulin</a>.
+          </p>
+        </tal:comment>
+        <div class="button-bar pat-bumper"
+             id="nav-bar"
+        >
+          <a class="pat-modal pat-button default"
+             href="${here/absolute_url}/@@panel-request-validation#document-content"
+             data-pat-modal="class: medium panel"
+             i18n:translate="label_request_validation_imp"
+          >Request validation</a>
+        </div>
+
+        <ul class="link-list">
+          <li>
+            <a class="pat-inject"
+               href="${webhelpers/country_url}/consultants-countries"
+               data-pat-inject="history: record; source: #content; target: #content"
+               i18n:translate=""
+            >Find an OSH consultant.</a>
+          </li>
+          <li tal:define="
+                organisation view/organisation;
+              "
+              tal:condition="organisation"
+          >
+            <a class="pat-modal"
+               href="${webhelpers/country_url}/@@panel-add-user-to-organisation/${organisation/organisation_id}#document-content"
+               data-pat-modal="class: small panel"
+               i18n:translate=""
+            >Add an OSH consultant to your organisation.</a>
+          </li>
+          <li>
+            <a class="pat-inject"
+               href="${webhelpers/country_url}/++resource++euphorie.resources/oira/help/${webhelpers/help_language}/pages/3-carrying-out-a-risk-assessment.html"
+               data-pat-inject="history: record; source: #content; target: #content"
+               i18n:translate=""
+            >Learn more about consultancy.</a>
+          </li>
+        </ul>
+
+        <tal:block replace="tile:client-analytics" />
+
+      </div></metal:slot>
+  </body>
+</html>

--- a/src/euphorie/client/browser/templates/panel-request-validation.pt
+++ b/src/euphorie/client/browser/templates/panel-request-validation.pt
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/@@modal-template/macros/shell"
+      i18n:domain="euphorie"
+>
+
+  <body>
+    <metal:slot fill-slot="content">
+      <div class="pat-modal medium panel"
+           id="document-content"
+      >
+        <h1 class="panel-class-panel"
+            i18n:translate="label_request_validation"
+        >
+          Request validation
+        </h1>
+
+        <form class="pat-inject"
+              id="organisation-edit-form"
+              action="${request/getURL}#content"
+              method="POST"
+        >
+          <div class="panel-body"
+               id="modal-panel-body"
+          >
+            <div class="container">
+              <article class="pat-rich">
+                <p i18n:translate="">
+              Click on 'Send validation request' to ask the selected OiRA consultant to review and validate your risk assessment.
+                </p>
+              </article>
+              <fieldset class="vertical">
+                <fieldset class="pat-checklist radio">
+                  <!-- <legend>OiRA Consultant</legend> -->
+                  <label tal:repeat="consultant view/consultants">
+                    ${consultant/title}
+                    <input checked="${python: 'checked' if repeat.consultant.start else None}"
+                           name="consultant"
+                           type="radio"
+                           value="${consultant/id}"
+                    />
+                  </label>
+                </fieldset>
+              </fieldset>
+
+              <p class="pat-message warning icon-attention"
+                 i18n:translate="message_warning_locking_after_validation"
+              >
+                After your consultant has validated this risk assessment, it will be locked. Should you want to edit the risk assessment again, then you may always make a duplicate of this assessment at a later time.
+              </p>
+
+              <div class="button-bar">
+                <button class="close-panel pat-button default"
+                        type="submit"
+                        i18n:translate="label_send_validation_request_imp"
+                >Send validation request</button>
+                <button class="close-panel pat-button"
+                        type="button"
+                        i18n:translate="label_cancel"
+                >Cancel</button>
+              </div>
+            </div>
+          </div>
+        </form>
+
+      </div>
+    </metal:slot>
+  </body>
+</html>

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -65,6 +65,7 @@ NAME_TO_PHASE = {
     "customization": "identification",
     "actionplan": "actionplan",
     "report": "report",
+    "consultancy": "consultancy",
     "status": "status",
     "help": "help",
     "new-email": "useraction",
@@ -160,6 +161,13 @@ class WebHelpers(BrowserView):
     def use_involve_phase(self):
         return api.portal.get_registry_record(
             "euphorie.use_involve_phase", default=False
+        )
+
+    @property
+    @memoize
+    def use_consultancy_phase(self):
+        return api.portal.get_registry_record(
+            "euphorie.use_consultancy_phase", default=False
         )
 
     @property
@@ -1260,6 +1268,23 @@ class WebHelpers(BrowserView):
                         _("label_action_plan", default="Action Plan")
                     ),
                     "has_tree": active,
+                }
+            )
+
+        if self.use_consultancy_phase:
+            active = section == "consultancy"
+            data.append(
+                {
+                    "active": active,
+                    "disabled": disabled,
+                    "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
+                    "id": "step-consultancy",
+                    "name": "consultancy",
+                    "href": f"{url}/@@consultancy#content",
+                    "title": api.portal.translate(
+                        _("label_consultancy", default="Consultancy")
+                    ),
+                    "has_tree": False,
                 }
             )
 

--- a/src/euphorie/client/tests/test_webhelpers.py
+++ b/src/euphorie/client/tests/test_webhelpers.py
@@ -670,6 +670,76 @@ class TestWebhelpers(EuphorieIntegrationTestCase):
                                 self.assertEqual(nav_tree[4]["disabled"], False)
                                 self.assertEqual(nav_tree[5]["disabled"], False)
 
+    def test_survey_tree_data__consultancy(self):
+        """Test the survey navigation tree data when consultancy is active."""
+
+        # Setup basic content.
+
+        account = addAccount("foo", password="secret")
+
+        with api.env.adopt_user("admin"):
+            addSurvey(self.portal, BASIC_SURVEY)
+
+        survey_session = model.SurveySession(
+            id=1,
+            title="Dummy session",
+            zodb_path="nl/ict/software-development",
+            account=account,
+        )
+        model.Session.add(survey_session)
+
+        traversed_session = self.portal.client.nl.ict[
+            "software-development"
+        ].restrictedTraverse("++session++1")
+
+        # Tests
+        with mock.patch(
+            "euphorie.client.browser.webhelpers.WebHelpers.use_consultancy_phase",
+            new_callable=mock.PropertyMock,
+        ) as use_training_module:
+            use_training_module.return_value = True
+            with mock.patch(
+                "euphorie.client.browser.webhelpers.WebHelpers.is_new_session",
+                new_callable=mock.PropertyMock,
+            ) as is_new_session:
+                is_new_session.return_value = False
+                with mock.patch(
+                    "euphorie.client.browser.webhelpers.WebHelpers.get_phase",
+                    return_value="preparation",
+                ):
+                    is_new_session.return_value = False
+                    with api.env.adopt_user(user=account):
+                        with self._get_view("webhelpers", traversed_session) as view:
+                            nav_tree = view.survey_tree_data
+
+                            self.assertEqual(nav_tree[0]["id"], "step-1")
+                            self.assertEqual(nav_tree[1]["id"], "step-2")
+                            self.assertEqual(nav_tree[2]["id"], "step-4")
+                            self.assertEqual(nav_tree[3]["id"], "step-consultancy")
+                            self.assertEqual(nav_tree[4]["id"], "step-5")
+                            self.assertEqual(nav_tree[5]["id"], "status")
+
+                            self.assertTrue("@@start" in nav_tree[0]["href"])
+                            self.assertTrue("@@identification" in nav_tree[1]["href"])
+                            self.assertTrue("@@actionplan" in nav_tree[2]["href"])
+                            self.assertTrue("@@consultancy" in nav_tree[3]["href"])
+                            self.assertTrue("@@report" in nav_tree[4]["href"])
+                            self.assertTrue("@@status" in nav_tree[5]["href"])
+
+                            self.assertEqual(nav_tree[0]["active"], True)
+                            self.assertEqual(nav_tree[1]["active"], False)
+                            self.assertEqual(nav_tree[2]["active"], False)
+                            self.assertEqual(nav_tree[3]["active"], False)
+                            self.assertEqual(nav_tree[4]["active"], False)
+                            self.assertEqual(nav_tree[5]["active"], False)
+
+                            self.assertEqual(nav_tree[0]["disabled"], False)
+                            self.assertEqual(nav_tree[1]["disabled"], False)
+                            self.assertEqual(nav_tree[2]["disabled"], False)
+                            self.assertEqual(nav_tree[3]["disabled"], False)
+                            self.assertEqual(nav_tree[4]["disabled"], False)
+                            self.assertEqual(nav_tree[5]["disabled"], False)
+
 
 class TestWebhelpersUnit(TestCase):
     def get_webhelpers(self, path):

--- a/src/euphorie/deployment/profiles/default/registry.xml
+++ b/src/euphorie/deployment/profiles/default/registry.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <registry xmlns:i18n="http://xml.zope.org/namespaces/i18n">
   <record field="default_language"
           interface="plone.i18n.interfaces.ILanguageSchema"
@@ -205,6 +206,14 @@
   <record name="euphorie.use_involve_phase">
     <field type="plone.registry.field.Bool">
       <title>use involve phase</title>
+      <default>False</default>
+      <missing_value>False</missing_value>
+      <required>False</required>
+    </field>
+  </record>
+  <record name="euphorie.use_consultancy_phase">
+    <field type="plone.registry.field.Bool">
+      <title>use consultancy phase</title>
       <default>False</default>
       <missing_value>False</missing_value>
       <required>False</required>

--- a/src/euphorie/upgrade/deployment/v1/20230421104953_add_use_consultancy_phase_feature_switch/registry.xml
+++ b/src/euphorie/upgrade/deployment/v1/20230421104953_add_use_consultancy_phase_feature_switch/registry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <record name="euphorie.use_consultancy_phase">
+    <field type="plone.registry.field.Bool">
+      <title>use consultancy phase</title>
+      <default>False</default>
+      <missing_value>False</missing_value>
+      <required>False</required>
+    </field>
+  </record>
+</registry>

--- a/src/euphorie/upgrade/deployment/v1/20230421104953_add_use_consultancy_phase_feature_switch/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20230421104953_add_use_consultancy_phase_feature_switch/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddUseConsultancyPhaseFeatureSwitch(UpgradeStep):
+    """Add use_consultancy_phase feature switch."""
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The new step is by default deactivated by the feature switch `euphorie.use_consultancy_phase`.

The following PRs build on this one and on one another:

* implement validation request https://github.com/euphorie/Euphorie/pull/536
* actual validation by consultant https://github.com/euphorie/Euphorie/pull/537
* refactor & fixes https://github.com/euphorie/Euphorie/pull/538

If you prefer you can review and merge the whole package (#538) and disregard the other PRs.

To do in further PRs:

* populate link “Find an OSH consultant”

syslabcom/scrum#1105