### PR TITLE
Split up conflicting labels for etranslate import/export

### DIFF
--- a/src/euphorie/content/browser/export.py
+++ b/src/euphorie/content/browser/export.py
@@ -163,7 +163,7 @@ class IExportSurveySchema(Interface):
     )
     is_etranslate_compatible = schema.Bool(
         title=_(
-            "label_is_etranslate_compatible",
+            "label_export_etranslate_compatible",
             default="Export in eTranslate compatible XML",
         ),
         description=_(

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -4378,6 +4378,11 @@ msgstr "Знания и умения"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4504,8 +4509,7 @@ msgstr "Уводен текст"
 msgid "label_involve"
 msgstr "Включване"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4368,6 +4368,11 @@ msgstr "Expertesa"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4494,8 +4499,7 @@ msgstr "Text d'introducció"
 msgid "label_involve"
 msgstr "Implicació"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4262,6 +4262,11 @@ msgstr "Odbornost"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4388,8 +4393,7 @@ msgstr "Úvodní text"
 msgid "label_involve"
 msgstr "Zapojení"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -3908,6 +3908,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4034,8 +4039,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -4293,6 +4293,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4419,8 +4424,7 @@ msgstr "Einführungstext"
 msgid "label_involve"
 msgstr "Einbeziehen"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -4492,6 +4492,11 @@ msgstr "Εμπειρία/Εξειδίκευση"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4618,8 +4623,7 @@ msgstr "Εισαγωγικό κείμενο"
 msgid "label_involve"
 msgstr "Συμμετοχή των εργαζομένων"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3899,6 +3899,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4025,8 +4030,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -4378,6 +4378,11 @@ msgstr "Competencias"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4504,8 +4509,7 @@ msgstr "Texto introductorio"
 msgid "label_involve"
 msgstr "Implicación"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -3907,6 +3907,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4033,8 +4038,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3812,6 +3812,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -3941,8 +3946,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4347,6 +4347,11 @@ msgstr "Asiantuntemus"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4473,8 +4478,7 @@ msgstr "Johdantoteksti"
 msgid "label_involve"
 msgstr "Osallistuminen ja yhteistyö"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -4462,6 +4462,11 @@ msgstr "Expertise"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4588,8 +4593,7 @@ msgstr "Texte d'introduction "
 msgid "label_involve"
 msgstr "Impliquer"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4338,6 +4338,11 @@ msgstr "Ekspertiza"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4464,8 +4469,7 @@ msgstr "Uvodni tekst"
 msgid "label_involve"
 msgstr "Uključite"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4423,6 +4423,11 @@ msgstr "Szakértelem"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4549,8 +4554,7 @@ msgstr "Bevezető szöveg"
 msgid "label_involve"
 msgstr "Bevonás"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:42+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4241,6 +4241,11 @@ msgstr "Sérþekking"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4367,8 +4372,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4377,6 +4377,11 @@ msgstr "Competenza"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4503,8 +4508,7 @@ msgstr "Testo di introduzione"
 msgid "label_involve"
 msgstr "Processo di VR"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4320,6 +4320,11 @@ msgstr "Kompetencija"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4446,8 +4451,7 @@ msgstr "Įvado tekstas"
 msgid "label_involve"
 msgstr "Įtraukti"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4314,6 +4314,11 @@ msgstr "Ekspertīze"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4440,8 +4445,7 @@ msgstr "Ievadteksts"
 msgid "label_involve"
 msgstr "Iesaiste"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4377,6 +4377,11 @@ msgstr "Kompetenza"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4503,8 +4508,7 @@ msgstr "Test ta' Introduzzjoni"
 msgid "label_involve"
 msgstr "Involvi"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -4379,6 +4379,11 @@ msgstr "Benodigde kennis en vereisten"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4505,8 +4510,7 @@ msgstr "Inleidende tekst"
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4394,6 +4394,11 @@ msgstr "Expertise"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4520,8 +4525,7 @@ msgstr "Inleidingtekst"
 msgid "label_involve"
 msgstr "Participatie"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -3905,6 +3905,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4031,8 +4036,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -3984,6 +3984,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4110,8 +4115,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4346,6 +4346,11 @@ msgstr "Perícia"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4472,8 +4477,7 @@ msgstr "Texto de introdução"
 msgid "label_involve"
 msgstr "Envolvimento"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -3912,6 +3912,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4038,8 +4043,7 @@ msgstr ""
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4341,6 +4341,11 @@ msgstr "Znalosti"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4467,8 +4472,7 @@ msgstr "Úvodný text"
 msgid "label_involve"
 msgstr "Zahrnúť"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4307,6 +4307,11 @@ msgstr "Strokovnost"
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4433,8 +4438,7 @@ msgstr "Uvodno besedilo"
 msgid "label_involve"
 msgstr "Vključevanje"
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-21 04:44+0000\n"
+"POT-Creation-Date: 2023-04-21 06:11+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -4088,6 +4088,11 @@ msgstr ""
 msgid "label_export_as_plain_text"
 msgstr ""
 
+#. Default: "Export in eTranslate compatible XML"
+#: euphorie/content/browser/export.py:165
+msgid "label_export_etranslate_compatible"
+msgstr ""
+
 #. Default: "Add an extra measure"
 #: euphorie/client/browser/templates/webhelpers.pt:1101
 msgid "label_extra_add_measure"
@@ -4214,8 +4219,7 @@ msgstr "Introduktionstext"
 msgid "label_involve"
 msgstr ""
 
-#. Default: "Export in eTranslate compatible XML"
-#: euphorie/content/browser/export.py:165
+#. Default: "Import XML translation from eTranslate"
 #: euphorie/content/browser/upload.py:196
 msgid "label_is_etranslate_compatible"
 msgstr ""


### PR DESCRIPTION
Label `label_is_etranslate_compatible` has conflicting defaults, compare `content/browser/upload.py` and `content/browser/export.py`