### PR TITLE
Fix the translation in the title attribute of listed assessments

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 14.3.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix the translation in the title attribute of listed assessments
+  [ale-rt]
 
 
 14.3.4 (2023-04-26)

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -442,6 +442,11 @@ class Assessments(BrowserView):
             order_by=order_by,
         )
 
+    def get_archived_label(self, session):
+        if not session.is_archived:
+            return ""
+        return api.portal.translate(_("Archived"))
+
 
 class Surveys(BrowserView, SurveyTemplatesMixin):
     @property

--- a/src/euphorie/client/browser/templates/assessments.pt
+++ b/src/euphorie/client/browser/templates/assessments.pt
@@ -125,9 +125,8 @@
                     "
                 >
                   <li class="row ${python:'archived' if session.is_archived else None}"
-                      title="${python:'Archived' if session.is_archived else None}"
+                      title="${python: view.get_archived_label(session)}"
                       tal:repeat="session sessions"
-                      i18n:attributes="title"
                   >
 
                     <h4 class="name field">


### PR DESCRIPTION
Fixes this weird msgid: https://github.com/euphorie/Euphorie/blob/2cdd6a50d2e6966ef631c1ec0115323f149760dc/src/euphorie/deployment/locales/euphorie.pot#L49