### PR TITLE
Validation: Record status of validation

### DIFF
--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -893,7 +893,7 @@
       name="consultancy"
       for="euphorie.client.adapters.session_traversal.ITraversedSurveySession"
       permission="euphorie.client.ViewSurvey"
-      class=".consultancy.Consultancy"
+      class=".consultancy.ConsultancyView"
       template="templates/consultancy.pt"
       layer="euphorie.client.interfaces.IClientSkinLayer"
       />

--- a/src/euphorie/client/browser/consultancy.py
+++ b/src/euphorie/client/browser/consultancy.py
@@ -2,6 +2,7 @@ from AccessControl import Unauthorized
 from euphorie.client import MessageFactory as _
 from euphorie.client.browser.base import BaseView
 from euphorie.client.model import Account
+from euphorie.client.model import Consultancy
 from euphorie.client.model import OrganisationMembership
 from euphorie.client.utils import CreateEmailTo
 from plone import api
@@ -36,7 +37,7 @@ class ConsultancyBaseView(BaseView):
         )
 
 
-class Consultancy(ConsultancyBaseView):
+class ConsultancyView(ConsultancyBaseView):
     """ """
 
     variation_class = "variation-risk-assessment"
@@ -109,7 +110,11 @@ class PanelRequestValidation(ConsultancyBaseView):
 
     def handle_POST(self):
         """Handle the POST request."""
-        self.context.session.consultant = self.consultant
+        consultancy = Consultancy(
+            account=self.consultant,
+            session=self.context.session,
+        )
+        self.context.session.consultancy = consultancy
         self.notify_consultant()
         self.redirect()
 
@@ -184,6 +189,7 @@ class PanelValidateRiskAssessment(ConsultancyBaseView):
     def handle_POST(self):
         """Handle the POST request."""
         if self.request.form.get("approved", False):
+            self.context.session.consultancy.status = "validated"
             # TODO: lock session
             self.notify_admins()
         self.redirect()

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -16,7 +16,9 @@
       <div class="pat-scroll-box"
            id="content-pane"
            tal:define="
-             consultant context/session/consultant|nothing;
+             consultant context/session/consultancy/account|nothing;
+             status context/session/consultancy/status|nothing;
+             is_validated python:status == 'validated';
              current_user webhelpers/get_current_account;
              role_consultant python: consultant and current_user == consultant;
            "
@@ -42,19 +44,17 @@
         </article>
 
         <tal:role_user tal:condition="not:role_consultant">
-          <tal:comment replace="nothing">
-        TODO: session validated (i.e. locked)
-            <p class="pat-message success"
-               i18n:translate="message_session_validated"
-            >
-              <a href="#"
-                 i18n:name="consultant"
-              >Michel Moulin</a>
+          <p class="pat-message success"
+             tal:condition="python:consultant and is_validated"
+             i18n:translate="message_session_validated"
+          >
+            <a href="mailto:${consultant/email}"
+               i18n:name="consultant"
+            >${consultant/title}</a>
              has reviewed and validated this risk assessment.
-            </p>
-          </tal:comment>
+          </p>
           <p class="pat-message info"
-             tal:condition="consultant"
+             tal:condition="python:consultant and not is_validated"
              i18n:translate="message_session_under_review"
           >
 				This risk assessment is currently under review by
@@ -74,8 +74,8 @@
                i18n:translate="label_request_validation_imp"
             >Request validation</a>
             <a class="pat-modal pat-button default"
-               data-pat-modal="class: medium panel"
                disabled="disabled"
+               data-pat-modal="class: medium panel"
                tal:condition="not:view/consultants"
                i18n:translate="label_request_validation_imp"
             >Request validation</a>

--- a/src/euphorie/deployment/upgrade/alembic/versions/20230502091628_upgrade_consultancy_table.py
+++ b/src/euphorie/deployment/upgrade/alembic/versions/20230502091628_upgrade_consultancy_table.py
@@ -1,0 +1,30 @@
+"""Upgrade consultancy table
+
+Revision ID: 20230502091628
+Revises: 20230421141443
+Create Date: 2023-05-02 09:24:29.093386
+
+"""
+from alembic import op
+from euphorie.deployment.upgrade.utils import has_column
+
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20230502091628"
+down_revision = "20230421141443"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not has_column("consultancy", "status"):
+        op.add_column(
+            "consultancy", sa.Column("status", sa.Unicode(length=255), nullable=True)
+        )
+
+
+def downgrade():
+    if has_column("consultancy", "status"):
+        op.drop_column("consultancy", "status")

--- a/src/euphorie/upgrade/deployment/v1/20230502091628_upgrade_consultancy_table/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20230502091628_upgrade_consultancy_table/upgrade.py
@@ -1,0 +1,9 @@
+from euphorie.deployment.upgrade.utils import alembic_upgrade_to
+from ftw.upgrade import UpgradeStep
+
+
+class UpgradeConsultancyTable(UpgradeStep):
+    """Upgrade consultancy table."""
+
+    def __call__(self):
+        alembic_upgrade_to(self.target_version)


### PR DESCRIPTION
Original plan was to treat a locked session with a consultant assigned as validated, but we need to support locking sessions independently of validation status.

This also means that the sqlalchemy declaration via `Table` doesn't work any more because the association needs the extra column `status`.

https://github.com/syslabcom/scrum/issues/1105