### PR TITLE
Hide elements for requesting validation and adding users from non-admins

### DIFF
--- a/src/euphorie/client/browser/consultancy.py
+++ b/src/euphorie/client/browser/consultancy.py
@@ -22,6 +22,17 @@ class ConsultancyBaseView(BaseView):
         return self.context.session.account.organisation
 
     @property
+    def is_admin(self):
+        organisation_view = api.content.get_view(
+            name="organisation",
+            context=self.webhelpers.country_obj,
+            request=self.request,
+        )
+        return organisation_view.get_member_role_id(
+            self.organisation, self.webhelpers.get_current_account()
+        ) in ["admin", "owner"]
+
+    @property
     def consultants(self):
         if not self.organisation:
             return []
@@ -99,17 +110,6 @@ class PanelRequestValidation(ConsultancyBaseView):
             subject=subject,
         )
         logger.info("Sent validation request email to %s", self.consultant.email)
-
-    @property
-    def is_admin(self):
-        organisation_view = api.content.get_view(
-            name="organisation",
-            context=self.webhelpers.country_obj,
-            request=self.request,
-        )
-        return organisation_view.get_member_role_id(
-            self.organisation, self.webhelpers.get_current_account()
-        ) in ["admin", "owner"]
 
     def handle_POST(self):
         """Handle the POST request."""

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -65,7 +65,7 @@
 
           <div class="button-bar pat-bumper"
                id="nav-bar"
-               tal:condition="not:consultant"
+               tal:condition="python:not consultant and view.is_admin"
           >
             <a class="pat-modal pat-button default"
                href="${here/absolute_url}/@@panel-request-validation#document-content"
@@ -125,6 +125,7 @@
             <a class="pat-modal"
                href="${webhelpers/country_url}/@@panel-add-user-to-organisation/${organisation/organisation_id}#document-content"
                data-pat-modal="class: small panel"
+               tal:condition="view/is_admin"
                i18n:translate=""
             >Add an OSH consultant to your organisation.</a>
           </li>


### PR DESCRIPTION
It might make sense to hide the whole consultancy form, or only display a note that an admin can do the consultancy stuff, but hiding the buttons if a user can't use them is already a step in the right direction.

syslabcom/scrum#1105