### PR TITLE
Fix some bits in the email top the consultant

### DIFF
--- a/src/euphorie/client/browser/consultancy.py
+++ b/src/euphorie/client/browser/consultancy.py
@@ -9,6 +9,7 @@ from plone import api
 from plone.memoize.view import memoize
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
+import html
 import logging
 
 
@@ -67,11 +68,13 @@ class PanelRequestValidation(ConsultancyBaseView):
         consultant = self.consultant
         requester = self.webhelpers.get_current_account()
         session = self.context
-        body = self.email_template(
-            consultant=self.consultant.first_name or consultant.title,
-            requester=requester.title,
-            assessment_title=session.title,
-            assessment_link=f"{session.absolute_url()}/@@start",
+        body = html.unescape(
+            self.email_template(
+                consultant=self.consultant.first_name or consultant.title,
+                requester=requester.title,
+                assessment_title=session.title,
+                assessment_link=f"{session.absolute_url()}/@@start",
+            )
         )
         subject = api.portal.translate(
             _(

--- a/src/euphorie/client/browser/templates/notify-request-validation.pt
+++ b/src/euphorie/client/browser/templates/notify-request-validation.pt
@@ -1,7 +1,6 @@
 <tal:root xmlns:i18n="http://xml.zope.org/namespaces/i18n"
           xmlns:meta="http://xml.zope.org/namespaces/meta"
           xmlns:tal="http://xml.zope.org/namespaces/tal"
-          meta:interpolation="true"
           i18n:domain="euphorie"
 ><tal:span i18n:translate="email_request_validation_header">Dear
     <tal:span replace="options/consultant"


### PR DESCRIPTION
I am resurrecting #545 because I still see that the mail sent looks like:
```
Dear b@example.com,
  Ale requested to validate the risk assessment &lsquo;COVID-19 revision&rsquo;.

  Please click on the link below to visit the risk assessment. If you approve of the contents of the risk assessment, then please click on &lsquo;Validate&rsquo; in the section &lsquo;Consultancy&rsquo; to give the risk assessment an official validated status.

  http://localhost:9110/Plone/client/eu/covid-19/covid-19-revision/++session++2/@@start
```

That happens because zpretty escaped the quote characters.
Either we make zpretty ignore that file or we change zpretty to not do that substitution or we do it like proposed in this PR.