### PR TITLE
Improvements on the locking story

### DIFF
--- a/src/euphorie/client/browser/consultancy.py
+++ b/src/euphorie/client/browser/consultancy.py
@@ -256,7 +256,6 @@ class PanelValidateRiskAssessment(ConsultancyBaseView):
             )
             self.sqlsession.add(event)
             self.context.session.consultancy.status = "validated"
-            # TODO: lock session
             self.notify_admins()
         self.redirect()
 

--- a/src/euphorie/client/browser/locking.py
+++ b/src/euphorie/client/browser/locking.py
@@ -34,6 +34,20 @@ class LockingMenu(BrowserView):
         """Return whether the session is locked."""
         return self.context.session.is_locked
 
+    def is_validated(self):
+        """Return whether the session is locked."""
+        consultancy = self.context.session.consultancy
+        if consultancy and consultancy.status == "validated":
+            return True
+        return self.context.session.consultancy
+
+    def show_actions(self):
+        """Return whether we should show the actions in the menu."""
+        if self.is_locked:
+            return self.webhelpers.can_unlock_session
+        else:
+            return self.webhelpers.can_lock_session
+
     @property
     def state(self):
         """Return the state of the session."""

--- a/src/euphorie/client/browser/templates/locking_menu.pt
+++ b/src/euphorie/client/browser/templates/locking_menu.pt
@@ -14,6 +14,7 @@
            language view/portal/plone_portal_state/language;
            last_modifier session/last_modifier;
            last_locking_event view/last_locking_event;
+           is_locked python:session.is_locked;
          "
     >
       <div class="pat-message notice"
@@ -49,7 +50,7 @@
           <tal:i18n i18n:name="date">${python:toLocalizedTime(session.modified, long_format=1)}</tal:i18n>.
         </p>
       </div>
-      <tal:can_publish condition="webhelpers/can_lock_session">
+      <tal:can_publish condition="view/show_actions">
         <ul class="menu"
             tal:switch="view/state"
         >

--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -1064,6 +1064,9 @@ class WebHelpers(BrowserView):
     @property
     @memoize
     def can_unlock_session(self):
+        session = self.traversed_session.session
+        if session.is_validated:
+            return False
         return self.can_lock_session
 
     @property

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -818,10 +818,23 @@ class SurveySession(BaseObject):
         return query.first()
 
     @property
+    def is_validated(self):
+        """Check if the session is validated."""
+        query = (
+            Session.query(SessionEvent)
+            .filter(
+                SessionEvent.action == "validated",
+                SessionEvent.session_id == self.id,
+            )
+            .order_by(SessionEvent.time.desc())
+        )
+        # TODO: There should be something to remove the validation at a certain point
+        return bool(query.count())
+
+    @property
     def is_locked(self):
         """Check if the session is locked."""
-        consultancy = self.consultancy
-        if consultancy and consultancy.status == "validated":
+        if self.is_validated:
             return True
 
         event = self.last_locking_event


### PR DESCRIPTION
- Do not use the consultancy status to check if a session is locked
- Only show the actions in the locking menu if the session is not validated and if the user has the proper permissions