### PR TITLE
Fix selected measure text spanning whole page instead of bein shown in training module.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,10 @@ Changelog
 15.0.0 (unreleased)
 -------------------
 
+- Fix selected measure text spanning whole page instead of bein shown in training module.
+  Ref: scrum-1205 item 2)
+  [thet]
+
 - Align with prototype to fix form style issues.
   Ref: scrum-1205
   [thet]

--- a/src/euphorie/client/browser/templates/webhelpers.pt
+++ b/src/euphorie/client/browser/templates/webhelpers.pt
@@ -638,11 +638,12 @@
   <metal:training_configuration define-macro="training_configuration">
     <div class="pat-collapsible risk-module form-panel"
          id="page-module-training"
+         style="${python:'' if webhelpers.display_training_module else 'display: none;'}"
          data-pat-collapsible="store: local; scroll-selector: self; scroll-offset: 120px"
          tal:define="
            training_view nocall:here/@@training_slide;
          "
-         tal:condition="webhelpers/display_training_module"
+         tal:condition="webhelpers/use_training_module"
     >
       <h3 class="form-separation-header"
           i18n:translate="menu_training"


### PR DESCRIPTION
Ref: scrum-1205 item 2)