### PR TITLE
Duplication: Tools Section

### DIFF
--- a/src/euphorie/client/browser/configure.zcml
+++ b/src/euphorie/client/browser/configure.zcml
@@ -615,6 +615,14 @@
       />
 
   <browser:page
+      name="assessments.json"
+      for="euphorie.content.survey.ISurvey"
+      class=".country.AssessmentsJson"
+      permission="zope2.View"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
+  <browser:page
       name="default_introduction"
       for="*"
       class=".survey.DefaultIntroductionView"
@@ -997,6 +1005,14 @@
       name="view"
       for="euphorie.client.sector.IClientSector"
       class=".sector.SectorView"
+      permission="zope2.View"
+      layer="euphorie.client.interfaces.IClientSkinLayer"
+      />
+
+  <browser:page
+      name="assessments.json"
+      for="euphorie.client.sector.IClientSector"
+      class=".country.AssessmentsJson"
       permission="zope2.View"
       layer="euphorie.client.interfaces.IClientSkinLayer"
       />

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -63,8 +63,14 @@
                   </p>
                 </fieldset>
 
+                <input name="survey"
+                       type="hidden"
+                       value="${request/survey}"
+                       tal:condition="request/survey|nothing"
+                />
                 <label class="pat-depends tool-list-many"
                        data-pat-depends="condition: action=new"
+                       tal:condition="python:not view.my_context == 'survey' and not request.get('survey', None)"
                 >
                   <select class="pat-autosuggest"
                           name="survey"
@@ -121,7 +127,7 @@
               <button class="pat-button default pat-depends close-panel"
                       name="next"
                       type="submit"
-                      data-pat-depends="condition: (action=new and survey) or (action=clone and session); action: enable"
+                      data-pat-depends="condition: (action=new${python:' and survey' if not view.my_context == 'survey' else ''}) or (action=clone and session); action: enable"
                       i18n:translate="button_start_session"
               >Start risk assessment</button>
               <button class="pat-button close-panel"

--- a/src/euphorie/client/browser/templates/surveys.pt
+++ b/src/euphorie/client/browser/templates/surveys.pt
@@ -219,9 +219,9 @@
                   <p class="button-bar"
                      tal:condition="not:is_anonymous"
                   >
-                    <a class="default small pat-button pat-inject"
-                       href="${sector/absolute_url}/@@new-session.html?survey=${tool_id}&amp;action=new"
-                       data-pat-inject="history: record"
+                    <a class="default small pat-button pat-modal"
+                       href="${sector/absolute_url}/${tool_id}/@@new-session.html#document-content"
+                       data-pat-modal="class: panel small"
                        i18n:translate="button_start_session"
                     >Start risk assessment</a>
                     <a class="small pat-button pat-inject"

--- a/src/euphorie/client/browser/templates/tool_sessions.pt
+++ b/src/euphorie/client/browser/templates/tool_sessions.pt
@@ -97,9 +97,10 @@
             <p class="button-bar"
                tal:condition="not:is_anonymous"
             >
-              <a class="default pat-button pat-inject"
+              <a class="default pat-button pat-modal"
                  id="button-new-session"
-                 href="${here/absolute_url}/@@new-session.html?action=new"
+                 href="${here/absolute_url}/@@new-session.html#document-content"
+                 data-pat-modal="class: panel small"
                  tal:condition="not:is_anonymous"
                  i18n:translate="button_start_session"
               >Start risk assessment</a>


### PR DESCRIPTION
Also use updated modal when starting a new session from the tools section

Note: there is one quirk - when calling the new-session modal on a sector (which does not happen in the current code) and passing the tool (survey) as a request parameter, you can select all sessions from the sector, not only those from the tool. Not fixing because the current code does not do that and sectors mostly only have one tool.

syslabcom/scrum#1137