### PR TITLE
Call configure_mappers() in instrumentation

### DIFF
--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -1641,6 +1641,7 @@ if not _instrumented:
         OrganisationMembership,
     ]:
         instrument_declarative(cls, metadata._decl_registry, metadata)
+    orm.configure_mappers()
     _instrumented = True
 
 schema.Index("tree_session_path", SurveyTreeItem.session_id, SurveyTreeItem.path)


### PR DESCRIPTION
fixes `AttributeError: strategy` in many queries

```
2023-06-16 07:37:50,799 ERROR   [Zope.SiteErrorLog:252][waitress-2] 1686893870.79906680.901494409626681 http://oira.local:4080/Plone2/client/eu/test-guy/risk-titles-1141/++session++55690/@@oira-report.docx
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 280, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module euphorie.client.docx.views, line 168, in __call__
  Module euphorie.client.docx.views, line 43, in get_payload
  Module euphorie.client.docx.views, line 291, in get_data
  Module euphorie.client.docx.views, line 260, in get_sorted_nodes
  Module euphorie.client.docx.views, line 67, in get_session_nodes
  Module sqlalchemy.orm.query, line 2773, in all
  Module sqlalchemy.engine.result, line 1476, in all
  Module sqlalchemy.engine.result, line 401, in _allrows
  Module sqlalchemy.engine.result, line 1389, in _fetchall_impl
  Module sqlalchemy.engine.result, line 1813, in _fetchall_impl
  Module sqlalchemy.orm.loading, line 151, in chunks
  Module sqlalchemy.orm.loading, line 151, in <listcomp>
  Module sqlalchemy.orm.loading, line 1269, in polymorphic_instance
  Module sqlalchemy.util._collections, line 746, in __missing__
  Module sqlalchemy.orm.loading, line 1252, in configure_subclass_mapper
  Module sqlalchemy.orm.loading, line 796, in _instance_processor
  Module sqlalchemy.orm.interfaces, line 657, in create_row_processor
  Module sqlalchemy.util.langhelpers, line 1244, in __getattr__
  Module sqlalchemy.util.langhelpers, line 1218, in _fallback_getattr
AttributeError: strategy
```

Sometimes it is masked by other errors like `zExceptions.NotFound: zExceptions.NotFound: completion_percentage`