### PR TITLE
Use aliases in exists queries

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -81,6 +81,10 @@ Changelog
 - Use SQLAlchemy 1.4.
   [ale-rt]
 
+- Add some alias in exists query. Remove the need to delete from the scope the aliased instances by using factory methods.
+  Fixes #609.
+  [ale-rt]
+
 - Use Plone 5.2.12
 
 


### PR DESCRIPTION
Add some alias in exists query.
Remove the need to delete from the scope the aliased instances by using factory methods.

Fixes #609.