### PR TITLE
Makefile: No dependency for target `pot`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ docs:: bin/sphinx-build
 clean::
 	rm -rf docs/.build
 
-pot: bin/i18ndude
+pot:
 	i18ndude rebuild-pot --exclude="generated prototype examples illustrations help" --pot $(EUPHORIE_POT) src/euphorie --create euphorie
 	$(MAKE) $(MFLAGS) $(EUPHORIE_PO_FILES)
 


### PR DESCRIPTION
I'd like to be able to run `make pot` without running buildout first. I can take care of installing i18ndude myself.