### PR TITLE
Remove the Message-Id header

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,10 @@ Changelog
 15.0.1 (unreleased)
 -------------------
 
+- No longer try to add a Message-Id header in the sent email because it might fail.
+  It will be added anyway.
+  [ale-rt]
+
 - Use NuPlone 2.2.0
   [ale-rt]
 

--- a/src/euphorie/client/utils.py
+++ b/src/euphorie/client/utils.py
@@ -72,7 +72,6 @@ def CreateEmailTo(sender_name, sender_email, recipient, subject, body):
     mail["From"] = emailutils.formataddr((sender_name, sender_email))
     mail["To"] = recipient
     mail["Subject"] = Header(subject.encode("utf-8"), "utf-8")
-    mail["Message-Id"] = emailutils.make_msgid()
     mail["Date"] = emailutils.formatdate(localtime=True)
     mail.set_param("charset", "utf-8")
     if isinstance(body, str):


### PR DESCRIPTION
It causes this error:

```
Module euphorie.client.browser.organisation, line 445, in
notify_inviter
  Module <decorator-gen-3>, line 2, in send_email
  Module plone.api.validation, line 81, in wrapped
  Module plone.api.portal, line 198, in send_email
  Module Products.MailHost.MailHost, line 215, in send
  Module Products.MailHost.MailHost, line 337, in _send
  Module zope.sendmail.delivery, line 141, in send
ValueError: Malformed Message-Id header
```