### PR TITLE
Remove broken lock icon from tool info page

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 15.0.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed glitch in sessions list on tool info page
+  Ref: scrum-1555
+  [reinhardt]
 
 
 15.0.3 (2023-09-05)

--- a/src/euphorie/client/browser/templates/tool_sessions.pt
+++ b/src/euphorie/client/browser/templates/tool_sessions.pt
@@ -171,12 +171,6 @@
                     </span>
                   </p>
                   <p class="field icons">
-                    <a class="locking-menu iconified icon-${python:session.published and 'published' or 'unpublished'} pat-tooltip"
-                       href="${session/absolute_url}/@@locking_view#locking-menu"
-                       data-pat-tooltip="source: ajax; position-list: tr"
-                       tal:condition="webhelpers/use_locking_feature"
-                       i18n:translate="label_locked"
-                    >Locked</a>
                     <a class="icon more-menu iconified icon-ellipsis pat-tooltip inactive"
                        href="${session/absolute_url}/@@more_menu#more-menu"
                        data-pat-tooltip="source: ajax; position-list: tr"


### PR DESCRIPTION
Compare proto: https://oira.cornelis.amsterdam/tools/commerce-de-gros-no-alimentaire

syslabcom/scrum#1555