### PR TITLE
More short report tweaks.

### DIFF
--- a/src/euphorie/client/docx/compiler.py
+++ b/src/euphorie/client/docx/compiler.py
@@ -1082,8 +1082,8 @@ class DocxCompilerShort(DocxCompilerFullTable):
 
     def merge_module_rows(self, row_module, row_risk):
         """Override to not remove the horizontal borders between the unmerged cells."""
-        for idx in range(1):
-            first_cell = row_module.cells[idx]
-            last_cell = row_risk.cells[idx]
-            self.set_cell_border(last_cell)
-            first_cell.merge(last_cell)
+        idx = 0
+        first_cell = row_module.cells[idx]
+        last_cell = row_risk.cells[idx]
+        self.set_cell_border(last_cell)
+        first_cell.merge(last_cell)

--- a/src/euphorie/client/docx/compiler.py
+++ b/src/euphorie/client/docx/compiler.py
@@ -1079,3 +1079,11 @@ class DocxCompilerShort(DocxCompilerFullTable):
                 style="Measure Indent",
             )
             paragraph.runs[0].italic = True
+
+    def merge_module_rows(self, row_module, row_risk):
+        """Override to not remove the horizontal borders between the unmerged cells."""
+        for idx in range(1):
+            first_cell = row_module.cells[idx]
+            last_cell = row_risk.cells[idx]
+            self.set_cell_border(last_cell)
+            first_cell.merge(last_cell)


### PR DESCRIPTION
Keep top/bottom cell borders between risks of same module.

syslabcom/scrum#1295