### PR TITLE
Fix error when freshly installing a Plone site

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changelog
 15.1.0 (unreleased)
 -------------------
 
+- Fix error when freshly installing a Plone site where `getNonInstallableProfiles` is missing.
+  Ref: https://github.com/plone/Products.CMFPlone/issues/3862
+  [thet]
 - Updated styles.
 - Short report tweaks
   Ref: scrum-1295

--- a/src/euphorie/deployment/products.py
+++ b/src/euphorie/deployment/products.py
@@ -9,5 +9,8 @@ except ImportError:
 
 @implementer(INonInstallable)
 class HideEuphorieProducts:
+    def getNonInstallableProfiles(self):
+        return []
+
     def getNonInstallableProducts(self):
         return ["euphorie.content", "euphorie.client"]


### PR DESCRIPTION
Fix error when freshly installing a Plone site where `getNonInstallableProfiles` is missing.

Ref: https://github.com/plone/Products.CMFPlone/issues/3862