### PR TITLE
Fix sidebar error when there is no root group.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 15.0.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix sidebar error when there is no root group.
+  [thet]
 
 
 15.0.7 (2023-10-12)

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -323,7 +323,7 @@ class SessionBrowserNavigator(BrowserView):
         base_query = Session.query(self.group_model).order_by(
             self.group_model.short_name
         )
-        return base_query.filter(self.group_model.group_id == groupid).one()
+        return base_query.filter(self.group_model.group_id == groupid).one_or_none()
 
     @property
     @memoize


### PR DESCRIPTION
Fix an error with a fresh database and no sessions yet.

The sidebar error led to other errors like the "Fremdfirmenkoordination" dropdown not being usable.

This was the traceback:
```

2023-10-20 12:21:35,852 ERROR   [Zope.SiteErrorLog:252][waitress-1] 1697797295.85126830.0008442311837014715 http://localhost:9090/Plone/client/de/view
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 280, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module daimler.oira.client.browser.country, line 89, in __call__
  Module euphorie.client.browser.country, line 274, in __call__
zExceptions.unauthorized.Unauthorized: Unauthorized()
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/login.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/NuPlone/plonetheme/nuplone/skin/templates/error_unauthorized.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/daimler.oira/src/daimler/oira/tiles/templates/messages.pt
2023-10-20 12:21:59,232 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1697797319.23241420.5394803103709703 http://localhost:9090/Plone/client/de/view
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 280, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module daimler.oira.client.browser.country, line 89, in __call__
  Module euphorie.client.browser.country, line 274, in __call__
zExceptions.unauthorized.Unauthorized: Unauthorized()
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/login.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/NuPlone/plonetheme/nuplone/skin/templates/error_unauthorized.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/daimler.oira/src/daimler/oira/tiles/templates/messages.pt
2023-10-20 12:22:09,921 ERROR   [Zope.SiteErrorLog:252][waitress-2] 1697797329.9211610.36549024149135856 http://localhost:9090/Plone/client/de/preferences
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 264, in publish
  Module ZPublisher.BaseRequest, line 644, in traverse
  Module ZPublisher.HTTPResponse, line 1040, in unauthorized
zExceptions.unauthorized.Unauthorized: You are not authorized to access this resource.
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/login.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/login.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/preferences.pt
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/daimler.oira/src/daimler/oira/client/browser/templates/session-browser-sidebar.pt
2023-10-20 12:22:48,075 ERROR   [euphorie.client.browser.error:24][waitress-2] Error at <ClientCountry at /Plone/client/de>
Traceback (most recent call last):
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Chameleon-3.10.2-py3.8-linux-x86_64.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/var/cache/ef4f6c8b0164b1ab42eb0fae586b7abf.py", line 3465, in render
    render_aside_browser(__stream, econtext.copy(), rcontext, __i18n_domain)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/var/cache/ef4f6c8b0164b1ab42eb0fae586b7abf.py", line 252, in render_aside_browser
    __value = _static_139757468027296('path', 'view/get_root_group', econtext=econtext)(_static_139757468026672(econtext, __zt_tmp))
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/zope.tales-5.2-py3.8.egg/zope/tales/expressions.py", line 250, in __call__
    return self._eval(econtext)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/PageTemplates/Expressions.py", line 225, in _eval
    return render(ob, econtext.vars)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/PageTemplates/Expressions.py", line 155, in render
    ob = ob()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/plone.memoize-3.0.0-py3.8.egg/plone/memoize/view.py", line 59, in memogetter
    cache[key] = func(*args, **kwargs)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/country.py", line 326, in get_root_group
    return base_query.filter(self.group_model.group_id == groupid).one()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/SQLAlchemy-1.4.48-py3.8-linux-x86_64.egg/sqlalchemy/orm/query.py", line 2870, in one
    return self._iter().one()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/SQLAlchemy-1.4.48-py3.8-linux-x86_64.egg/sqlalchemy/engine/result.py", line 1522, in one
    return self._only_one_row(
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/SQLAlchemy-1.4.48-py3.8-linux-x86_64.egg/sqlalchemy/engine/result.py", line 562, in _only_one_row
    raise exc.NoResultFound(
sqlalchemy.exc.NoResultFound: No row was found when one was required

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 176, in transaction_pubevents
    yield
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 385, in publish_module
    response = _publish(request, new_mod_info)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 280, in publish
    result = mapply(obj,
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/ZPublisher/mapply.py", line 85, in mapply
    return debug(object, args, context)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 63, in call_object
    return obj(*args)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/daimler.oira/src/daimler/oira/client/browser/country.py", line 385, in __call__
    return super().__call__()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/zope.browserpage-4.4.0-py3.8.egg/zope/browserpage/simpleviewclass.py", line 41, in __call__
    return self.index(*args, **kw)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/Five/browser/pagetemplatefile.py", line 126, in __call__
    return self.__func__(__self__, *args, **kw)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/Five/browser/pagetemplatefile.py", line 58, in __call__
    s = self.pt_render(
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/zope.pagetemplate/src/zope/pagetemplate/pagetemplate.py", line 135, in pt_render
    return self._v_program(
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/PageTemplates/engine.py", line 378, in __call__
    return template.render(**kwargs)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/z3c.pt-3.3.1-py3.8.egg/z3c/pt/pagetemplate.py", line 176, in render
    return base_renderer(**context)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Chameleon-3.10.2-py3.8-linux-x86_64.egg/chameleon/zpt/template.py", line 302, in render
    return super(PageTemplate, self).render(**_kw)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Chameleon-3.10.2-py3.8-linux-x86_64.egg/chameleon/template.py", line 215, in render
    raise_with_traceback(exc, tb)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Chameleon-3.10.2-py3.8-linux-x86_64.egg/chameleon/utils.py", line 53, in raise_with_traceback
    raise exc
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Chameleon-3.10.2-py3.8-linux-x86_64.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/var/cache/ef4f6c8b0164b1ab42eb0fae586b7abf.py", line 3465, in render
    render_aside_browser(__stream, econtext.copy(), rcontext, __i18n_domain)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/var/cache/ef4f6c8b0164b1ab42eb0fae586b7abf.py", line 252, in render_aside_browser
    __value = _static_139757468027296('path', 'view/get_root_group', econtext=econtext)(_static_139757468026672(econtext, __zt_tmp))
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/zope.tales-5.2-py3.8.egg/zope/tales/expressions.py", line 250, in __call__
    return self._eval(econtext)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/PageTemplates/Expressions.py", line 225, in _eval
    return render(ob, econtext.vars)
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/Zope-4.8.10-py3.8.egg/Products/PageTemplates/Expressions.py", line 155, in render
    ob = ob()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/plone.memoize-3.0.0-py3.8.egg/plone/memoize/view.py", line 59, in memogetter
    cache[key] = func(*args, **kwargs)
  File "/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/country.py", line 326, in get_root_group
    return base_query.filter(self.group_model.group_id == groupid).one()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/SQLAlchemy-1.4.48-py3.8-linux-x86_64.egg/sqlalchemy/orm/query.py", line 2870, in one
    return self._iter().one()
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/SQLAlchemy-1.4.48-py3.8-linux-x86_64.egg/sqlalchemy/engine/result.py", line 1522, in one
    return self._only_one_row(
  File "/home/_thet/repos-config/dotfiles-thet/dot.buildout/eggs/SQLAlchemy-1.4.48-py3.8-linux-x86_64.egg/sqlalchemy/engine/result.py", line 562, in _only_one_row
    raise exc.NoResultFound(
sqlalchemy.exc.NoResultFound: sqlalchemy.exc.NoResultFound: No row was found when one was required

 - Expression: " view/get_root_grou"
 - Filename:   ... oira/client/browser/templates/session-browser-sidebar.pt
 - Location:   (line 16: col 23)
 - Source:     root_group view/get_root_group;
                         ^^^^^^^^^^^^^^^^^^^
 - Arguments:  template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x7f3cdf082f10>
               options: {}
               args: ()
               nothing: None
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7f3cffb185b0>
               request: <WSGIRequest, URL=http://localhost:9090/Plone/client/de/@@session-browser-sidebar>
               view: <Products.Five.browser.metaconfigure.SimpleViewClass from /home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/daimler.oira/src/daimler/oira/client/browser/templates/session-browser-sidebar.pt object at 0x7f3cdf0141f0>
               context: <ClientCountry at /Plone/client/de>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x7f3cdf0140a0>
               here: <ClientCountry at /Plone/client/de>
               container: <ClientCountry at /Plone/client/de>
               root: <Application at >
               traverse_subpath: []
               user: <euphorie.client.model.Account object at 0x7f3cdf02fcd0>
               default: <DEFAULT>
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7f3cdf037dc0>
               loop: {}
               target_language: None
               translate: <function BaseTemplate.render.<locals>.translate at 0x7f3cdf03d3a0>
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/error.pt
2023-10-20 12:22:48,111 ERROR   [Zope.SiteErrorLog:252][waitress-2] 1697797368.10849210.37449913125821943 http://localhost:9090/Plone/client/de/@@session-browser-sidebar
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 280, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module daimler.oira.client.browser.country, line 385, in __call__
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 58, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.utils, line 53, in raise_with_traceback
  Module chameleon.template, line 192, in render
  Module ef4f6c8b0164b1ab42eb0fae586b7abf, line 3465, in render
  Module ef4f6c8b0164b1ab42eb0fae586b7abf, line 252, in render_aside_browser
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module plone.memoize.view, line 59, in memogetter
  Module euphorie.client.browser.country, line 326, in get_root_group
  Module sqlalchemy.orm.query, line 2870, in one
  Module sqlalchemy.engine.result, line 1522, in one
  Module sqlalchemy.engine.result, line 562, in _only_one_row
sqlalchemy.exc.NoResultFound: sqlalchemy.exc.NoResultFound: No row was found when one was required

 - Expression: " view/get_root_grou"
 - Filename:   ... oira/client/browser/templates/session-browser-sidebar.pt
 - Location:   (line 16: col 23)
 - Source:     root_group view/get_root_group;
                         ^^^^^^^^^^^^^^^^^^^
 - Arguments:  template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x7f3cdf082f10>
               options: {}
               args: ()
               nothing: None
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7f3cffb185b0>
               request: <WSGIRequest, URL=http://localhost:9090/Plone/client/de/@@session-browser-sidebar>
               view: <Products.Five.browser.metaconfigure.SimpleViewClass from /home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/daimler.oira/src/daimler/oira/client/browser/templates/session-browser-sidebar.pt object at 0x7f3cdf0141f0>
               context: <ClientCountry at /Plone/client/de>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x7f3cdf0140a0>
               here: <ClientCountry at /Plone/client/de>
               container: <ClientCountry at /Plone/client/de>
               root: <Application at >
               traverse_subpath: []
               user: <euphorie.client.model.Account object at 0x7f3cdf02fcd0>
               default: <DEFAULT>
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7f3cdf037dc0>
               loop: {}
               target_language: None
               translate: <function BaseTemplate.render.<locals>.translate at 0x7f3cdf03d3a0>
zope.pagetemplate filename: $/home/_thet/data/dev/syslab/REPOS/oira/daimler.buildout/src/Euphorie/src/euphorie/client/browser/templates/user-menu.pt
```