### PR TITLE
Notifications: translation fixes and updates

### DIFF
--- a/src/euphorie/client/notifications/notification__ra_not_modified.py
+++ b/src/euphorie/client/notifications/notification__ra_not_modified.py
@@ -27,16 +27,25 @@ class Email(BaseNotificationEmail):
 You have not modified your risk assessment for ${reminder_days} days. Please \
 remember to keep your risk assessment up to date.
 With this link you can access the risk assessment.""",
+            msgid_plural="notification_mail_body__ra_not_modified__plural",
+            default_plural="""\
+You have not modified your risk assessments for ${reminder_days} days. Please \
+remember to keep your risk assessments up to date.
+With these links you can access the risk assessments.""",
             mapping={
                 "reminder_days": self.reminder_days,
             },
+            number=len(self.sessions),
         )
 
     @property
     def translatable_subject(self):
         return _(
             "notification_mail_subject__ra_not_modified",
-            default="Reminder: Update of risk assessment",
+            default="Reminder: Update of risk assessment (${num} open)",
+            mapping={
+                "num": len(self.sessions),
+            },
         )
 
     @property

--- a/src/euphorie/client/tests/test_notifications.py
+++ b/src/euphorie/client/tests/test_notifications.py
@@ -103,5 +103,6 @@ class NotificationsSendingTests(EuphorieIntegrationTestCase):
         mail = mail_fixture.storage[0][0][0]
         self.assertIn(self.account.email, mail.get("To"))
         self.assertEqual(
-            mail_fixture.storage[0][1]["subject"], "Reminder: Update of risk assessment"
+            mail_fixture.storage[0][1]["subject"],
+            "Reminder: Update of risk assessment (1 open)",
         )

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr "Приемане"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Добавяне на Модул"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Добавяне на Профилиращ въпрос"
@@ -188,7 +188,7 @@ msgstr "Почти готово&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Получи се грешка при изпращане на имейл потвърждението."
 
@@ -278,7 +278,7 @@ msgstr "Страна-кандидат"
 msgid "Certificate"
 msgstr "Cертификат"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Промяна на имейл адрес"
 
@@ -310,7 +310,7 @@ msgstr "Затвори"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Потвърждаване на промяна на OiRA имейл адрес"
 
@@ -370,7 +370,7 @@ msgstr "Лиценз Криейтив комънс"
 msgid "Decline"
 msgstr "Отхвърляне"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Изтриване на акаунт"
@@ -429,11 +429,11 @@ msgid "Edit"
 msgstr "Редактиране"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Редактиране на ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Редактиране на Профилиращ въпрос"
 
@@ -449,7 +449,7 @@ msgstr "Промяна на организацията"
 msgid "Edit training card"
 msgstr "Редактиране на картата за обучение"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Имейл адрес/име на акаунт"
 
@@ -564,7 +564,7 @@ msgstr "Искам да споделя следното с вас"
 msgid "Identifier"
 msgstr "Идентификатор"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 "Невалиден формат на файла на изображението. Моля, използвайте PNG, JPEG или "
 "GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Невалидна парола"
 
@@ -601,7 +601,7 @@ msgstr "Невалидна парола"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgstr "Официално лого на OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgid "Pass information to the people concerned."
 msgstr "Информиране на заинтересованите лица."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Паролата не е еднаква/ равностойна със зададената"
@@ -1086,13 +1086,13 @@ msgid "Run slideshow"
 msgstr "Пускане на слайдшоу"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Запазване"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Запазване на промените"
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Съобщение за еднократна поява"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Стандарт"
 
@@ -1187,7 +1187,7 @@ msgstr "Започнете въпросите"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Подмодул"
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Нямаше направени промени, които да бъдат запазени."
 
@@ -1294,7 +1294,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Този имейл адрес не е наличен."
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Без отговор"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Качване"
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1529,16 +1529,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Приключихте с обучителните слайдове!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Вашият имейл адрес беше актуализиран."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Вашата парола за потвърждение"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Вашата парола беше променена успешно."
 
@@ -1852,7 +1852,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Отменяне"
@@ -2518,7 +2518,7 @@ msgstr ""
 "'${email}', когато кликнете върху връзката за потвърждаване по-долу."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Моля, потвърдете новия си имейл адрес, като кликнете върху връзката в имейл "
@@ -2601,7 +2601,7 @@ msgid "error_invalid_login"
 msgstr "Името за вход може да се състои само от малки букви и цифри."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Моля, качете валиден XML файл"
 
@@ -2808,7 +2808,7 @@ msgid "filename_report_timeline"
 msgstr "Времева скала за ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2996,7 +2996,7 @@ msgid "header_launch"
 msgstr "Официално стартиране на проекта – септември 2011 г."
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Правни източници и източници от политики"
 
@@ -3621,6 +3621,11 @@ msgstr "1. Подготовка"
 msgid "help_help_introduction"
 msgstr "Обща информация за оценка на риска"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3777,7 +3782,7 @@ msgstr ""
 "Това е паролата, която Ви е необходима за вход в тази среда за редактиране."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Ако не посочите име, то ще бъде взето от файла за въвеждане."
 
@@ -3839,7 +3844,7 @@ msgstr ""
 "OiRA инструмента в клиентите."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Ако не посочите име, то ще бъде взето от въведените данни."
 
@@ -4441,7 +4446,7 @@ msgstr "Мерки, които вече са изпълнени"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4481,7 +4486,7 @@ msgid "label_file_caption"
 msgstr "Заглавен текст"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Име"
 
@@ -4559,6 +4564,11 @@ msgstr "5. Доклад"
 msgid "label_help_sessions"
 msgstr "Как да извършите оценка на риска"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4608,7 +4618,7 @@ msgid "label_involve"
 msgstr "Включване"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4630,7 +4640,7 @@ msgid "label_language"
 msgstr "Език"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Фамилия"
 
@@ -4688,7 +4698,7 @@ msgid "label_login"
 msgstr "Вход"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Име за вход"
 
@@ -4709,7 +4719,7 @@ msgid "label_logo_selection"
 msgstr "Кое лого бихте желали да поставите в горния ляв ъгъл?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4786,13 +4796,13 @@ msgstr "Този OiRA инструмент отговори ли на нужди
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Желана парола"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Паролата отново"
 
@@ -4883,7 +4893,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Текуща парола"
 
@@ -4925,7 +4935,7 @@ msgstr "Паролата отново"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Вече въведени мерки Планирани мерки"
 
@@ -4954,7 +4964,7 @@ msgid "label_print_tool_preview"
 msgstr "Преглед на инструмента преди печат"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5164,7 +5174,7 @@ msgid "label_sector_description"
 msgstr "Моля, предоставете описание на Вашия сектор"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Име на сектор."
 
@@ -5331,7 +5341,7 @@ msgid "label_survey_title"
 msgstr "Име на версия"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Име на импортирания OiRA инструмент"
 
@@ -5450,12 +5460,12 @@ msgid "label_update"
 msgstr "Актуализация"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML файл"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Име за версията на OiRA инструмента"
 
@@ -5718,7 +5728,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Не можете да изтриете единствената версия на OiRA инструмента."
 
@@ -5786,7 +5796,7 @@ msgstr ""
 "организацията."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Не можете да изтриете версия на OiRA инструмента, която е публикувана. Моля, "
@@ -5969,7 +5979,7 @@ msgid "navigation_help"
 msgstr "Помощ"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Излизане"
@@ -6052,32 +6062,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6598,17 +6603,17 @@ msgid "title_about"
 msgstr "За нас"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Изтриване на акаунт"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Смяна на парола"
 
@@ -6648,12 +6653,12 @@ msgid "title_help_unpublished"
 msgstr "Премахнете този OiRA инструмент от онлайн клиента."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Лични данни"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Предпочитания"
 
@@ -6755,7 +6760,7 @@ msgstr ""
 "инструмент?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Успешно импортиран OiRA инстрмент"
 

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,7 +116,7 @@ msgstr "Acceptar"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Afegir Mòdul"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Afegir Pregunta de perfil"
@@ -191,7 +191,7 @@ msgstr "Gairebé acabat&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "S'ha produït un error en enviar el correu electrònic de confirmació."
 
@@ -277,7 +277,7 @@ msgstr "País candidat "
 msgid "Certificate"
 msgstr "Certificat"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Canviar l'adreça electrònica"
 
@@ -309,7 +309,7 @@ msgstr "Tancar"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Confirmar el canvi de l'adreça electrònica d'OiRA"
 
@@ -370,7 +370,7 @@ msgstr "Llicència de Creative Commons"
 msgid "Decline"
 msgstr "Rebutjar"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Suprimir el compte"
@@ -429,11 +429,11 @@ msgid "Edit"
 msgstr "Editar"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Editar ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Editar Pregunta de perfil"
 
@@ -449,7 +449,7 @@ msgstr "Editar l’organització"
 msgid "Edit training card"
 msgstr "Editar el contingut de la formació"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Adreça electrònica/nom del compte"
 
@@ -563,7 +563,7 @@ msgstr "Voldria compartir el següent enllaç"
 msgid "Identifier"
 msgstr "Identificador"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 "El format de fitxer de l’imatge no és vàlid. Si us plau, utilitzeu PNG, JPEG "
 "o GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Contrasenya no vàlida"
 
@@ -600,7 +600,7 @@ msgstr "Contrasenya no vàlida"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -795,7 +795,7 @@ msgstr "Logotip oficial de l'OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgid "Pass information to the people concerned."
 msgstr "Enviar informació a les persones concernides."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Les contrasenyes no coincideixen"
@@ -1085,13 +1085,13 @@ msgid "Run slideshow"
 msgstr "Iniciar la presentació"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Desar"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Desar els canvis"
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Localització única"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Estàndard"
 
@@ -1185,7 +1185,7 @@ msgstr "Començar amb les preguntes"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Submòdul"
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "No hi ha cap canvi per desar."
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Aquesta adreça electrònica no està disponible."
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "No respost"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Pujar"
 
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1518,16 +1518,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Ha acabat la presentación de la formació!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "S'ha actualitzat l'adreça electrònica."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Contrasenya de confirmació"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "La contrasenya s'ha modificat correctament."
 
@@ -1839,7 +1839,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Cancel·lar"
@@ -2504,7 +2504,7 @@ msgstr ""
 "${email} quan faci clic a l'enllaç de confirmació que trobarà a continuació."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Confirmi l'adreça electrònica nova fent clic a l'enllaç que s'enviarà d'aquí "
@@ -2589,7 +2589,7 @@ msgstr ""
 "nombres."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Pugi un fitxer XML vàlid"
 
@@ -2797,7 +2797,7 @@ msgid "filename_report_timeline"
 msgstr "Pla d'acció per a ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2986,7 +2986,7 @@ msgid "header_launch"
 msgstr "Llançament oficial del projecte: setembre del 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Referències legals i de la política"
 
@@ -3614,6 +3614,11 @@ msgstr "1. Preparació"
 msgid "help_help_introduction"
 msgstr "Informació general sobre l'avaluació de riscos"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3770,7 +3775,7 @@ msgstr ""
 "d'edició."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Si no especifica cap títol, s'agafarà del fitxer d'entrada."
 
@@ -3835,7 +3840,7 @@ msgstr ""
 "l'eina OiRA dels clients."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Si no especifica cap títol, s'agafarà de la introducció."
 
@@ -4433,7 +4438,7 @@ msgstr "Mesura implementada"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Mesures ja implementades"
 
@@ -4473,7 +4478,7 @@ msgid "label_file_caption"
 msgstr "Llegenda del contingut"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Nom"
 
@@ -4551,6 +4556,11 @@ msgstr "5. Informe"
 msgid "label_help_sessions"
 msgstr "Preparant la seva avaluació de riscos"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4600,7 +4610,7 @@ msgid "label_involve"
 msgstr "Implicació"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4622,7 +4632,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Cognom"
 
@@ -4680,7 +4690,7 @@ msgid "label_login"
 msgstr "Inici de sessió"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Nom d'inici de sessió"
 
@@ -4701,7 +4711,7 @@ msgid "label_logo_selection"
 msgstr "Quin logotip vol mostrar a la cantonada superior esquerra?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4776,13 +4786,13 @@ msgstr "L’eina OiRA ha respost a les seves necessitats?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Contrasenya desitjada"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Repetiu la contrasenya"
 
@@ -4873,7 +4883,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Contrasenya actual"
 
@@ -4915,7 +4925,7 @@ msgstr "Repetiu la contrasenya"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Mesures planificades"
 
@@ -4944,7 +4954,7 @@ msgid "label_print_tool_preview"
 msgstr "Imprimir l'eina"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5153,7 +5163,7 @@ msgid "label_sector_description"
 msgstr "Proporcioni una descripció del seu sector"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Títol del sector."
 
@@ -5319,7 +5329,7 @@ msgid "label_survey_title"
 msgstr "Nom de versió "
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Títol de l'eina OiRA importada"
 
@@ -5437,12 +5447,12 @@ msgid "label_update"
 msgstr "Actualitzar"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Fitxer XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Nom de la versió de l'eina OiRA"
 
@@ -5701,7 +5711,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "No es pot suprimir la versió única de l'eina OiRA."
 
@@ -5768,7 +5778,7 @@ msgstr ""
 "l'organització."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "No es pot suprimir una versió de l'eina OiRA que estigui publicada. Abans "
@@ -5952,7 +5962,7 @@ msgid "navigation_help"
 msgstr "Ajuda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Tancar la sessió"
@@ -6035,32 +6045,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6577,17 +6582,17 @@ msgid "title_about"
 msgstr "Quant a"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Suprimir el compte"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Canviar la contrasenya"
 
@@ -6627,12 +6632,12 @@ msgid "title_help_unpublished"
 msgstr "Elimini aquesta eina OiRA del client en línia."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Dades personals"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Preferències"
 
@@ -6731,7 +6736,7 @@ msgid "unpublish_confirm"
 msgstr "Està segur que vol despublicar aquesta eina OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "L'eina OiRA s'ha importat correctament"
 

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,7 +108,7 @@ msgstr "Přijmout"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Přidat Modul"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Přidat Profilová otázka"
@@ -183,7 +183,7 @@ msgstr "Téměř hotovo&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Při odesílání potvrzujícího e-mailu se vyskytla chyba."
 
@@ -269,7 +269,7 @@ msgstr "Kandidátská země"
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Změnit e-mailovou adresu"
 
@@ -301,7 +301,7 @@ msgstr "Zavřít"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Potvrďte změnu e-mailové adresy OiRA"
 
@@ -357,7 +357,7 @@ msgstr "Licence Creative Commons"
 msgid "Decline"
 msgstr "Odmítnout"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Zrušit účet"
@@ -416,11 +416,11 @@ msgid "Edit"
 msgstr "Upravit"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Editovat ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Editovat Profilová otázka"
 
@@ -436,7 +436,7 @@ msgstr "Upravit organizaci"
 msgid "Edit training card"
 msgstr "Upravte kartu školení"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-mailová adresa/název účtu"
 
@@ -552,7 +552,7 @@ msgstr "Chci se s vámi podělit o následující informace"
 msgid "Identifier"
 msgstr "Identifikátor"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -579,7 +579,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Neplatný formát obrázku. Použijte PNG, JPEG nebo GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Neplatné heslo"
 
@@ -587,7 +587,7 @@ msgstr "Neplatné heslo"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -779,7 +779,7 @@ msgstr "Oficiální logo OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr ""
 "osobám a stranám,"
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Heslo neodpovídá"
@@ -1068,13 +1068,13 @@ msgid "Run slideshow"
 msgstr "Spustit prezentaci"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Uložit"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Uložit změny"
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Upozornění o jediném výskytu"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1167,7 +1167,7 @@ msgstr "Spusťte otázky"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Dílčí modul"
 
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Nebyly uloženy žádné změny."
 
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Tato e-mailová adresa není k dispozici."
 
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1354,7 +1354,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Nezodpovězeno"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Nahrát"
 
@@ -1485,7 +1485,7 @@ msgstr " "
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1493,16 +1493,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Máte hotové tréninkové snímky!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Vaše e-mailová adresa byla aktualizována."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Vaše heslo pro potvrzení"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Vaše heslo bylo úspěšně změněno."
 
@@ -1787,7 +1787,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Zrušit"
@@ -2441,7 +2441,7 @@ msgstr ""
 "kliknete na potvrzující odkaz níže."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Prosím potvrďte svou novou e-mailovou adresu kliknutím na odkaz v e-mailu, "
@@ -2523,7 +2523,7 @@ msgid "error_invalid_login"
 msgstr "Přihlašovací jméno se může skládat pouze z malých písmen a čísel."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Prosím nahrajte platný soubor XML"
 
@@ -2726,7 +2726,7 @@ msgid "filename_report_timeline"
 msgstr "Akční plán ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2913,7 +2913,7 @@ msgid "header_launch"
 msgstr "Oficiální spuštění projektu - září 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Odkazy na právní předpisy a postupy"
 
@@ -3533,6 +3533,11 @@ msgstr "1. Příprava"
 msgid "help_help_introduction"
 msgstr "Všeobecné informace o vyhodnocení rizik"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3680,7 +3685,7 @@ msgstr ""
 "Toto je heslo, které potřebujete k přihlášení do tohoto editačního prostředí."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Pokud nespecifikujete název, bude použit ze vstupního souboru."
 
@@ -3742,7 +3747,7 @@ msgstr ""
 "u klientů."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Pokud nespecifikujete název, bude použit ze vstupu."
 
@@ -4326,7 +4331,7 @@ msgstr "Opatření již je zavedeno."
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Již provedená opatření"
 
@@ -4366,7 +4371,7 @@ msgid "label_file_caption"
 msgstr "Popisek obsahu"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Jméno"
 
@@ -4444,6 +4449,11 @@ msgstr "5. Zpráva"
 msgid "label_help_sessions"
 msgstr "Provedení vlastního hodnocení rizik"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4493,7 +4503,7 @@ msgid "label_involve"
 msgstr "Zapojení"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4515,7 +4525,7 @@ msgid "label_language"
 msgstr "Jazyk"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Příjmení"
 
@@ -4573,7 +4583,7 @@ msgid "label_login"
 msgstr "Přihlášení"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Přihlašovací jméno"
 
@@ -4594,7 +4604,7 @@ msgid "label_logo_selection"
 msgstr "Které logo byste chtěl/a zobrazit v levém horním rohu?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4671,13 +4681,13 @@ msgstr "Splnil nástroj OIRA Vaše očekávání?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Nové heslo"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Heslo znovu"
 
@@ -4768,7 +4778,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Současné heslo"
 
@@ -4810,7 +4820,7 @@ msgstr "Heslo znovu"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Plánovaná opatření"
 
@@ -4839,7 +4849,7 @@ msgid "label_print_tool_preview"
 msgstr "Tisk náhledu nástroje"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5046,7 +5056,7 @@ msgid "label_sector_description"
 msgstr "Uveďte prosím popis vašeho sektoru"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Název sektoru."
 
@@ -5212,7 +5222,7 @@ msgid "label_survey_title"
 msgstr "Název verze"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Název importovaného nástroje OiRA"
 
@@ -5331,12 +5341,12 @@ msgid "label_update"
 msgstr "Aktualizovat"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Soubor XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Název pro verzi nástroje OiRA"
 
@@ -5594,7 +5604,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Nemůžete odstranit jedinou verzi nástroje OiRA."
 
@@ -5660,7 +5670,7 @@ msgstr ""
 "Členové mohou prohlížet a upravovat všechna hodnocení rizik organizace."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Nelze odstranit verzi nástroje OiRA, která je publikována. Prosíme, nejprve "
@@ -5843,7 +5853,7 @@ msgid "navigation_help"
 msgstr "Nápověda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Odhlášení"
@@ -5926,32 +5936,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6465,17 +6470,17 @@ msgid "title_about"
 msgstr "Co je projekt OiRA (Online interaktivní vyhodnocení rizik)"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Zrušit účet"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Změnit heslo"
 
@@ -6515,12 +6520,12 @@ msgid "title_help_unpublished"
 msgstr "Odstraňte tento nástroj OiRA z online klienta."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Osobní údaje"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Předvolby"
 
@@ -6617,7 +6622,7 @@ msgid "unpublish_confirm"
 msgstr "Jste si jist/a, že chcete zrušit publikování tohoto nástroje OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Úspěšně importovaný nástroj OiRA"
 

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -399,11 +399,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -842,7 +842,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1015,13 +1015,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1411,16 +1411,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2230,7 +2230,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2309,7 +2309,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2489,7 +2489,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2672,7 +2672,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3282,6 +3282,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3401,7 +3406,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3455,7 +3460,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -3974,7 +3979,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4014,7 +4019,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4092,6 +4097,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4141,7 +4151,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4163,7 +4173,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4221,7 +4231,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4242,7 +4252,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4317,13 +4327,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4414,7 +4424,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4456,7 +4466,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4485,7 +4495,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4692,7 +4702,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4858,7 +4868,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -4974,12 +4984,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5226,7 +5236,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5277,7 +5287,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5454,7 +5464,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5537,32 +5547,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6040,17 +6045,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6090,12 +6095,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6185,7 +6190,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr "Maßnahme hinzufügen"
 msgid "Add Module"
 msgstr "Modul hinzufügen"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Profilfrage hinzufügen"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Beim Versenden der Bestätigungs-E-Mail ist ein Fehler aufgetreten."
 
@@ -279,7 +279,7 @@ msgstr "Kandidatenland"
 msgid "Certificate"
 msgstr "Zertifikat"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "E-Mail-Adresse ändern"
 
@@ -311,7 +311,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Änderung der OiRA-E-Mail-Adresse bestätigen"
 
@@ -374,7 +374,7 @@ msgstr "Creative Commons-Lizenz"
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Konto löschen"
@@ -435,11 +435,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "${name} bearbeiten"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Profilfrage bearbeiten"
 
@@ -455,7 +455,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr "Unterweisungskarte bearbeiten"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-Mail-Adresse/Kontoname"
 
@@ -569,7 +569,7 @@ msgstr "Ich würde Ihnen gerne folgendes Tool empfehlen"
 msgid "Identifier"
 msgstr "Kennung"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr "OiRA-Tool importieren"
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Falsches Dateiformat für das Bild. Bitte verwenden Sie PNG oder JPEG."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Ungültiges Passwort"
 
@@ -604,7 +604,7 @@ msgstr "Ungültiges Passwort"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr "Sie haben anscheinend eine Präsentationsfolie übersehen"
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr "OiRA-Tool"
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr "OiRA-Tool Import"
 
@@ -902,7 +902,7 @@ msgid "Pass information to the people concerned."
 msgstr "Informationen an betroffene Personen weitergeben."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1090,13 +1090,13 @@ msgid "Run slideshow"
 msgstr "Bildschirmpräsentation"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Speichern"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Änderungen speichern"
@@ -1165,7 +1165,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Aufforderung bei einem Standort"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1191,7 +1191,7 @@ msgstr "Fragenteil starten"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Untermodul"
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 "Es wurden keine Änderungen vorgenommen, die noch gespeichert werden müssen."
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr "Dieses Zertifikat wurde erstellt für"
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Diese E-Mail-Adresse ist nicht verfügbar."
 
@@ -1345,7 +1345,7 @@ msgstr ""
 "Hier muss der Endnutzer gefragt werden, ob das Profil für sie/ihn anwendbar "
 "ist."
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Nicht beantwortet"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr "Sie sollten die Unterweisung vom Start beginnen"
 
@@ -1531,16 +1531,16 @@ msgstr "Sie sollten die Unterweisung vom Start beginnen"
 msgid "You're done with the training slides!"
 msgstr "Sie sind fertig mit der Unterweisung!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Ihre E-Mail-Adresse wurde aktualisiert."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Ihr Passwort zur Bestätigung"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Ihr Passwort wurde erfolgreich geändert."
 
@@ -1851,7 +1851,7 @@ msgstr "Ja, GBU archivieren"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Abbrechen"
@@ -2446,7 +2446,7 @@ msgstr ""
 "geändert, wenn Sie auf den untenstehenden Bestätigungslink klicken."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Bitte bestätigen Sie Ihre neue E-Mail-Adresse, indem Sie auf den Link in der "
@@ -2529,7 +2529,7 @@ msgid "error_invalid_login"
 msgstr "Ein Anmeldename darf nur Kleinbuchstaben und Zahlen enthalten."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Laden Sie eine gültige XML-Datei hoch."
 
@@ -2721,7 +2721,7 @@ msgid "filename_report_timeline"
 msgstr "Aktionsplan für ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr "Inhalte der GBU-Vorlage ${title}"
 
@@ -2910,7 +2910,7 @@ msgid "header_launch"
 msgstr "Offizielle Einführung des Projektes – September 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Rechtliche und politische Referenzen"
 
@@ -3541,6 +3541,11 @@ msgstr "1. Vorbereitung"
 msgid "help_help_introduction"
 msgstr "Allgemeine Informationen zur Gefährdungsbeurteilung"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3702,7 +3707,7 @@ msgstr ""
 "Dieses Passwort benötigen Sie, um sich in dieser Editorumgebung anzumelden."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 "Wenn Sie keinen Namen angeben, wird ein Name aus der Eingabedatei übernommen."
@@ -3767,7 +3772,7 @@ msgstr ""
 "den Clients angezeigt."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 "Wenn Sie keinen Namen angeben, wird ein Name aus der Eingabedatei übernommen."
@@ -4360,7 +4365,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4400,7 +4405,7 @@ msgid "label_file_caption"
 msgstr "Bezeichnung"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4478,6 +4483,11 @@ msgstr "Bericht"
 msgid "label_help_sessions"
 msgstr "Sitzungen"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4527,7 +4537,7 @@ msgid "label_involve"
 msgstr "Einbeziehen"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4549,7 +4559,7 @@ msgid "label_language"
 msgstr "Sprache"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4607,7 +4617,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Anmeldename"
 
@@ -4628,7 +4638,7 @@ msgid "label_logo_selection"
 msgstr "Welches Logo soll in der Ecke oben links angezeigt werden?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4704,13 +4714,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Gewünschtes Passwort"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4803,7 +4813,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Aktuelles Passwort"
 
@@ -4845,7 +4855,7 @@ msgstr "Wiederholung Passwort"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4874,7 +4884,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5083,7 +5093,7 @@ msgid "label_sector_description"
 msgstr "Bitte geben Sie eine Beschreibung Ihrer Branche ein."
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Name der Branche"
 
@@ -5253,7 +5263,7 @@ msgid "label_survey_title"
 msgstr "Versionsname"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Name des importierten OiRA-Tools"
 
@@ -5370,12 +5380,12 @@ msgid "label_update"
 msgstr "Aktualisieren"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML-Datei"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Name der OiRA-Tool-Version"
 
@@ -5644,7 +5654,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Diese OiRA-Tool Version kann nicht gelöscht werden, da sie die einzige ist. "
@@ -5697,7 +5707,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Sie können kein Tool löschen, das schon veröffentlicht ist. Bitte ziehen Sie "
@@ -5880,7 +5890,7 @@ msgid "navigation_help"
 msgstr "Hilfe"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Abmelden"
@@ -5963,32 +5973,42 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
-msgstr "Sie haben vor ${reminder_days} Tagen Ihre Gefährdungsbeurteilung zuletzt bearbeitet (bzw. schreibgeschützt). Bitte denken Sie daran, Ihre Gefährdungsbeurteilung aktuell zu halten.\nMit diesem Link gelangen Sie zur Gefährdungsbeurteilung."
+msgstr ""
+"Sie haben vor ${reminder_days} Tagen Ihre Gefährdungsbeurteilung zuletzt "
+"bearbeitet (bzw. schreibgeschützt). Bitte denken Sie daran, Ihre "
+"Gefährdungsbeurteilung aktuell zu halten.\n"
+"Mit diesem Link gelangen Sie zur Gefährdungsbeurteilung."
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr "Erinnerung: Aktualisierung der Gefährdungsbeurteilung"
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
-msgstr "Hallo ${full_name},\n\n${main_text}\n\n${session_links}\n\nMit freundlichen Grüßen\nIhr OiRA Team\n\n**Dies ist eine automatisch generierte Mail. Wenn Sie keine Mails von OiRA erhalten möchten, können Sie dies [hier einstellen](${preferences_link})**"
-
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
 msgstr ""
+"Hallo ${full_name},\n"
+"\n"
+"${main_text}\n"
+"\n"
+"${session_links}\n"
+"\n"
+"Mit freundlichen Grüßen\n"
+"Ihr OiRA Team\n"
+"\n"
+"**Dies ist eine automatisch generierte Mail. Wenn Sie keine Mails von OiRA "
+"erhalten möchten, können Sie dies [hier einstellen](${preferences_link})**"
 
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6508,17 +6528,17 @@ msgid "title_about"
 msgstr "Informationen"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Konto löschen"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Password ändern"
 
@@ -6558,12 +6578,12 @@ msgid "title_help_unpublished"
 msgstr "Dieses OiRA-Tool vom Online-Client entfernen"
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6666,7 +6686,7 @@ msgstr ""
 "möchten?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA-Tool erfolgreich importiert."
 

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -127,7 +127,7 @@ msgstr "ΑποδοχήF"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Προσθήκη Μονάδα"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Προσθήκη Ερώτηση προφίλ"
@@ -202,7 +202,7 @@ msgstr "Σχεδόν ολοκληρώσατε&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Σημειώθηκε ένα σφάλμα κατά την αποστολή του email επιβεβαίωσης."
 
@@ -296,7 +296,7 @@ msgstr "Υποψήφια χώρα "
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Αλλαγή διεύθυνσης email "
 
@@ -328,7 +328,7 @@ msgstr "Κλείσιμο"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Επιβεβαιώστε την αλλαγή της διεύθυνσης email OiRA"
 
@@ -389,7 +389,7 @@ msgstr "Άδεια χρήσης Creative Commons"
 msgid "Decline"
 msgstr "Απόρριψη"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Διαγραφή λογαριασμού"
@@ -450,11 +450,11 @@ msgid "Edit"
 msgstr "Επεξεργασία"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Επεξεργασία ${name} "
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Επεξεργασία Ερώτηση προφίλ"
 
@@ -470,7 +470,7 @@ msgstr "Επεξεργασία “επιχείρησης/οργανισμού”
 msgid "Edit training card"
 msgstr "Επεξεργασία εκπαιδευτικού υλικού"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Διεύθυνση email/όνομα λογαριασμού "
 
@@ -593,7 +593,7 @@ msgstr "Θέλω να μοιραστώ μαζί σας τα παρακάτω"
 msgid "Identifier"
 msgstr "Αναγνωριστικό"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 "Μη αποδεκτός τύπος αρχείου εικόνας. Αποδεκτοί τύποι αρχείων εικόνας PNG, "
 "JPEG ή GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Μη αποδεκτός κωδικός πρόσβασης"
 
@@ -630,7 +630,7 @@ msgstr "Μη αποδεκτός κωδικός πρόσβασης"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -825,7 +825,7 @@ msgstr "Επίσημο λογότυπο του OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -933,7 +933,7 @@ msgid "Pass information to the people concerned."
 msgstr "Διαβίβαση πληροφοριών στους ενδιαφερόμενους."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Ο κωδικός πρόσβασης δεν αντιστοιχεί στην τιμή επιβεβαίωσης"
@@ -1123,13 +1123,13 @@ msgid "Run slideshow"
 msgstr "Έναρξη παρουσίασης"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Αποθήκευση"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Αποθήκευση αλλαγών"
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Ειδοποίηση για περισσότερες από μία εμφανίσεις"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Πρότυπο"
 
@@ -1224,7 +1224,7 @@ msgstr "Έναρξη ερωτήσεων"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Επιμέρους ενότητα"
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Δεν υπάρχουν αλλαγές για αποθήκευση."
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Αυτή η διεύθυνση email δεν είναι διαθέσιμη."
 
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Υπό εξέταση κίνδυνος"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Ανέβασμα (Upload)"
 
@@ -1561,7 +1561,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1569,16 +1569,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Ολοκληρώσατε με το εκπαιδευτικό υλικό!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Η διεύθυνση email σας έχει αλλάξει. "
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Ο κωδικός πρόσβασής σας για επιβεβαίωση"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Η αλλαγή του κωδικού πρόσβασής σας ολοκληρώθηκε με επιτυχία."
 
@@ -1900,7 +1900,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Άκυρο"
@@ -2584,7 +2584,7 @@ msgstr ""
 "αλλάξουν σε '${email}' όταν κάνετε κλικ στο σύνδεσμο επιβεβαίωσης παρακάτω."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Παρακαλώ επιβεβαιώστε τη νέα σας διεύθυνση email κάνοντας κλικ στο email που "
@@ -2676,7 +2676,7 @@ msgstr ""
 "αριθμούς."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Παρακαλώ ανεβάστε ένα αποδεκτό αρχείο XML"
 
@@ -2895,7 +2895,7 @@ msgid "filename_report_timeline"
 msgstr "Σχέδιο Δράσης ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -3086,7 +3086,7 @@ msgid "header_launch"
 msgstr "Επίσημη παρουσίαση του έργου – Σεπτέμβριος 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Νομικές αναφορές και αναφορές πολιτικής"
 
@@ -3729,6 +3729,11 @@ msgstr "1. Προετοιμασία"
 msgid "help_help_introduction"
 msgstr "Γενικές πληροφορίες σχετικά με την αξιολόγηση κινδύνων"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3890,7 +3895,7 @@ msgstr ""
 "περιβάλλον του editor."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 "Εάν δεν ορίσετε έναν τίτλο, θα υιοθετηθεί από το αρχείο δεδομένων που θα "
@@ -3959,7 +3964,7 @@ msgstr ""
 "προεπισκόπηση του Εργαλείου OiRA στους πελάτες. "
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Εάν δεν ορίσετε τίτλο, θα υιοθετηθεί από τα δεδομένα που θα εισάγετε."
 
@@ -4568,7 +4573,7 @@ msgstr "Μέτρο που έχει ήδη εφαρμοστεί"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Μέτρα σε εφαρμογή"
 
@@ -4608,7 +4613,7 @@ msgid "label_file_caption"
 msgstr "Λεζάντα περιεχομένου"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Όνομα"
 
@@ -4686,6 +4691,11 @@ msgstr "5. Έκθεση"
 msgid "label_help_sessions"
 msgstr "Εκπόνηση εκτίμησης κινδύνου"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4735,7 +4745,7 @@ msgid "label_involve"
 msgstr "Συμμετοχή των εργαζομένων"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4757,7 +4767,7 @@ msgid "label_language"
 msgstr "Γλώσσα"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Επώνυμο"
 
@@ -4815,7 +4825,7 @@ msgid "label_login"
 msgstr "Σύνδεση"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Όνομα σύνδεσης"
 
@@ -4836,7 +4846,7 @@ msgid "label_logo_selection"
 msgstr "Ποιο λογότυπο θέλετε να εμφανίζεται στην επάνω αριστερή γωνία;"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4913,13 +4923,13 @@ msgstr "Το εργαλείο OiRA εξυπηρετεί τις ανάγκες τ
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Επιθυμητός κωδικός πρόσβασης"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Επανάληψη κωδικού πρόσβασης"
 
@@ -5010,7 +5020,7 @@ msgid "label_oira_consultants"
 msgstr "Πάροχοι συμβουλευτικών υπηρεσιών για την ΕΑΥ"
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Τρέχων κωδικός πρόσβασης "
 
@@ -5052,7 +5062,7 @@ msgstr "Επανάληψη κωδικού πρόσβασης"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Σχεδιαζόμενα μέτρα προς εφαρμογή"
 
@@ -5081,7 +5091,7 @@ msgid "label_print_tool_preview"
 msgstr "εκτύπωση του περιεχομένου του εργαλείου"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5292,7 +5302,7 @@ msgid "label_sector_description"
 msgstr "Παρέχετε μια περιγραφή του τομέα σας"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Τίτλος του τομέα."
 
@@ -5462,7 +5472,7 @@ msgid "label_survey_title"
 msgstr "Όνομα έκδοσης"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Τίτλος εισαχθέντος εργαλείου OiRA"
 
@@ -5582,12 +5592,12 @@ msgid "label_update"
 msgstr "Ενημέρωση"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Αρχείο XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Όνομα για την έκδοση του Εργαλείου OiRA"
 
@@ -5864,7 +5874,7 @@ msgstr ""
 "χαρακτηρισμό επικύρωσης."
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Δεν μπορείτε να διαγράψετε τη μοναδική έκδοση εργαλείου OiRA."
 
@@ -5951,7 +5961,7 @@ msgstr ""
 "Εκτίμησης Κινδύνου της επιχείρησης ή του οργανισμού σας."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr "Δεν μπορείτε να διαγράψετε ένα εργαλείο OiRA που έχει δημοσιευτεί."
 
@@ -6165,7 +6175,7 @@ msgid "navigation_help"
 msgstr "Βοήθεια"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Αποσύνδεση"
@@ -6248,32 +6258,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6811,17 +6816,17 @@ msgid "title_about"
 msgstr "Σχετικά"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Διαγραφή λογαριασμού "
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Αλλαγή κωδικού πρόσβασης"
 
@@ -6861,12 +6866,12 @@ msgid "title_help_unpublished"
 msgstr "Αφαιρέστε αυτό το Εργαλείο OiRA από τον online πελάτη."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Προσωπικά στοιχεία"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Επιλογές"
 
@@ -6969,7 +6974,7 @@ msgstr ""
 "OiRA; "
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Η εισαγωγή του εργαλείου OiRA ολοκληρώθηκε με επιτυχία"
 

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -101,7 +101,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -164,7 +164,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -395,11 +395,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -838,7 +838,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1011,13 +1011,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1407,16 +1407,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1664,7 +1664,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2224,7 +2224,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2303,7 +2303,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3276,6 +3276,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3395,7 +3400,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3445,7 +3450,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -3969,7 +3974,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4009,7 +4014,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4087,6 +4092,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4136,7 +4146,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4158,7 +4168,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4216,7 +4226,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4237,7 +4247,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4312,13 +4322,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4409,7 +4419,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4451,7 +4461,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4480,7 +4490,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4687,7 +4697,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4853,7 +4863,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -4969,12 +4979,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5221,7 +5231,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5272,7 +5282,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5449,7 +5459,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5532,32 +5542,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6039,17 +6044,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6089,12 +6094,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6184,7 +6189,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr "Aceptar"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr "Agregar Medida"
 msgid "Add Module"
 msgstr "Agregar Módulo"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Agregar Pregunta de perfil"
@@ -190,7 +190,7 @@ msgstr "A punto de acabar&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Se ha producido un error al enviar el correo de confirmación."
 
@@ -278,7 +278,7 @@ msgstr "País candidato"
 msgid "Certificate"
 msgstr "Certificado"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Cambiar dirección de correo electrónico"
 
@@ -310,7 +310,7 @@ msgstr "Cerrar"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Confirmar cambio de dirección de correo electrónico OiRA"
 
@@ -370,7 +370,7 @@ msgstr "Licencia Creative Commons"
 msgid "Decline"
 msgstr "Rechazar"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Borrar cuenta"
@@ -429,11 +429,11 @@ msgid "Edit"
 msgstr "Editar"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Editar ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Editar Pregunta de perfil"
 
@@ -449,7 +449,7 @@ msgstr "Editar la organización"
 msgid "Edit training card"
 msgstr "Editar el contenido de la formación"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Dirección de correo electrónico/nombre de la cuenta"
 
@@ -563,7 +563,7 @@ msgstr "Deseo compartir el siguiente enlace"
 msgid "Identifier"
 msgstr "Identificador"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Formato de archivo inválido para imagen. Por favor utilice PNG, JPEG o GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Contraseña no válida"
 
@@ -599,7 +599,7 @@ msgstr "Contraseña no válida"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -795,7 +795,7 @@ msgstr "Logotipo oficial OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgid "Pass information to the people concerned."
 msgstr "Transmitir información a las personas interesadas."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Las contraseñas no coinciden"
@@ -1086,13 +1086,13 @@ msgid "Run slideshow"
 msgstr "Iniciar la presentación"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Guardar"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Guardar cambios"
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Aviso de ocurrencia único"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Estándar"
 
@@ -1186,7 +1186,7 @@ msgstr "Comenzar con las preguntas"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Submódulo"
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Ningún cambio que guardar."
 
@@ -1293,7 +1293,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "La dirección de correo electrónico no está disponible."
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Sin respuesta"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Cargar"
 
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1521,16 +1521,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "¡Ha acabado la presentación de la formación!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Su dirección de correo electrónico se ha actualizado."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Contraseña de confirmación"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Su contraseña se ha cambiado correctamente."
 
@@ -1841,7 +1841,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Cancelar"
@@ -2515,7 +2515,7 @@ msgstr ""
 "cambiarán a '${email}' al hacer clic en el enlace de confirmación siguiente."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Confirme su nueva dirección de correo electrónico haciendo clic en el enlace "
@@ -2598,7 +2598,7 @@ msgid "error_invalid_login"
 msgstr "El nombre de login sólo puede tener minúsculas y números."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Cargue un archivo XML válido"
 
@@ -2805,7 +2805,7 @@ msgid "filename_report_timeline"
 msgstr "Plan de acción ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2992,7 +2992,7 @@ msgid "header_launch"
 msgstr "Lanzamiento oficial del proyecto – Septiembre de 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Referencias legales y de políticas"
 
@@ -3620,6 +3620,11 @@ msgstr "1. Preparación"
 msgid "help_help_introduction"
 msgstr "Información general sobre la evaluación de riesgos"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3775,7 +3780,7 @@ msgstr ""
 "editor."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Si no especifica un título se tomará del archivo de entrada."
 
@@ -3839,7 +3844,7 @@ msgstr ""
 "previa de la herramienta OiRA en los clientes."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Si no especifica un título se tomará del texto introducido."
 
@@ -4442,7 +4447,7 @@ msgstr "Medida ya aplicada"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Medidas ya implantadas"
 
@@ -4482,7 +4487,7 @@ msgid "label_file_caption"
 msgstr "Leyenda de contenido"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Nombre"
 
@@ -4560,6 +4565,11 @@ msgstr "5. Informe"
 msgid "label_help_sessions"
 msgstr "Sesiones"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4609,7 +4619,7 @@ msgid "label_involve"
 msgstr "Implicación"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4631,7 +4641,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Apellido"
 
@@ -4689,7 +4699,7 @@ msgid "label_login"
 msgstr "Iniciar sesión"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Nombre de login"
 
@@ -4710,7 +4720,7 @@ msgid "label_logo_selection"
 msgstr "¿Qué logotipo desea mostrar en la esquina superior izquierda?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4787,13 +4797,13 @@ msgstr "Ha satisfecho la herramienta OiRA sus necesidades?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Contraseña deseada"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Repita la contraseña"
 
@@ -4884,7 +4894,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Contraseña actual"
 
@@ -4926,7 +4936,7 @@ msgstr "Repita la contraseña"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Medidas planificadas"
 
@@ -4955,7 +4965,7 @@ msgid "label_print_tool_preview"
 msgstr "Imprimir la herramienta"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5164,7 +5174,7 @@ msgid "label_sector_description"
 msgstr "Introduzca una descripción del sector"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Título del sector"
 
@@ -5332,7 +5342,7 @@ msgid "label_survey_title"
 msgstr "Nombre de la versión"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Título de la herramienta OiRA importada"
 
@@ -5450,12 +5460,12 @@ msgid "label_update"
 msgstr "Actualizar"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Archivo XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Nombre de la versión de la herramienta OiRA"
 
@@ -5713,7 +5723,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "No puede borrar la única versión de la herramienta OiRA."
 
@@ -5781,7 +5791,7 @@ msgstr ""
 "la organización."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "No se puede eliminar una herramienta OiRA que está publicada. Por favor, "
@@ -5965,7 +5975,7 @@ msgid "navigation_help"
 msgstr "Ayuda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Cerrar sessión"
@@ -6048,32 +6058,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6594,17 +6599,17 @@ msgid "title_about"
 msgstr "Información sobre"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Borrar cuenta"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Cambiar contraseña"
 
@@ -6644,12 +6649,12 @@ msgid "title_help_unpublished"
 msgstr "Elimine esta herramienta OiRA del cliente online."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Datos personales"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Preferencias"
 
@@ -6749,7 +6754,7 @@ msgstr ""
 "¿Está seguro de que desea retirar la publicación de esta herramienta OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Herramienta OiRA importada con éxito"
 

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -399,11 +399,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -842,7 +842,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1015,13 +1015,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1411,16 +1411,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2230,7 +2230,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2309,7 +2309,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2489,7 +2489,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2672,7 +2672,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3282,6 +3282,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3401,7 +3406,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3454,7 +3459,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -3973,7 +3978,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4013,7 +4018,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4091,6 +4096,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4140,7 +4150,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4162,7 +4172,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4220,7 +4230,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4241,7 +4251,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4316,13 +4326,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4413,7 +4423,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4455,7 +4465,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4484,7 +4494,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4691,7 +4701,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4857,7 +4867,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -4973,12 +4983,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5225,7 +5235,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5276,7 +5286,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5453,7 +5463,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5536,32 +5546,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6039,17 +6044,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6089,12 +6094,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6184,7 +6189,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -85,7 +85,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -148,7 +148,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -368,11 +368,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -388,7 +388,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -522,7 +522,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -716,7 +716,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -956,13 +956,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45
+#: euphorie/content/browser/module.py:20
 #: euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
@@ -1113,7 +1113,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1129,7 +1129,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1312,16 +1312,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1569,7 +1569,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2129,7 +2129,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2208,7 +2208,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2388,7 +2388,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/docx/compiler.py:364
-#: euphorie/content/browser/survey.py:311
+#: euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3187,6 +3187,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3308,7 +3313,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3358,7 +3363,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -3880,7 +3885,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -3922,7 +3927,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4000,6 +4005,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4050,7 +4060,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4072,7 +4082,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4130,7 +4140,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148
+#: euphorie/content/browser/upload.py:149
 #: euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
@@ -4152,7 +4162,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4228,13 +4238,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4325,7 +4335,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4367,7 +4377,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4396,7 +4406,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4603,7 +4613,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4769,7 +4779,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -4885,12 +4895,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5137,7 +5147,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5188,7 +5198,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5366,7 +5376,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5449,32 +5459,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -5954,17 +5959,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6004,12 +6009,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6099,7 +6104,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr "Hyväksy"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Lisää Moduuli"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Lisää Profiilikysymys"
@@ -190,7 +190,7 @@ msgstr "Melkein valmista&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Virhe vahvistusviestin lähetyksessä."
 
@@ -278,7 +278,7 @@ msgstr "Ehdokasvaltio"
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Vaihda sähköpostiosoite"
 
@@ -310,7 +310,7 @@ msgstr "Sulje"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Vahvista OiRA-sähköpostiosoitteen muutos"
 
@@ -367,7 +367,7 @@ msgstr "Creative Commons -lisenssi"
 msgid "Decline"
 msgstr "Hylkää"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Poista tili"
@@ -426,11 +426,11 @@ msgid "Edit"
 msgstr "Muokkaa"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Muokkaa ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Muokkaa Profiilikysymys"
 
@@ -446,7 +446,7 @@ msgstr "Muokkaa organisaation tietoja"
 msgid "Edit training card"
 msgstr "Muokkaa koulutusmateriaalia"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Sähköpostiosoite/tilinimi"
 
@@ -560,7 +560,7 @@ msgstr "Haluan jakaa seuraavan kanssasi"
 msgid "Identifier"
 msgstr "Tunniste"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 "Tarkista kuvan tiedostomuoto. Tallennettavan kuvan tulee olla PNG-, JPEG- "
 "tai GIF-muodossa."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Väärä salasana"
 
@@ -597,7 +597,7 @@ msgstr "Väärä salasana"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr "Virallinen OiRA-logo"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -893,7 +893,7 @@ msgid "Pass information to the people concerned."
 msgstr "Välitä tiedot asianomaisille henkilöille."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Salasanat eivät vastaa toisiaan"
@@ -1086,13 +1086,13 @@ msgid "Run slideshow"
 msgstr "Katso diaesitys"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Tallenna"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Tallenna muutokset"
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Yksittäinen esiintyminen lyhyesti"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Vakio"
 
@@ -1187,7 +1187,7 @@ msgstr "Vastaa kysymyksiin"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Alamoduulit"
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Tallennettavia muutoksia ei ollut."
 
@@ -1294,7 +1294,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Tämä sähköposti ei ole käytettävissä."
 
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "vastaus puuttuu"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Lähetys"
 
@@ -1516,7 +1516,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1524,16 +1524,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Olet nyt tutustunut koulutusmateriaaliin!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Sähköpostiosoitteesi on päivitetty."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Salasanasi vahvistusta varten"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Salasanasi on muutettu."
 
@@ -1841,7 +1841,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Peruuta"
@@ -2505,7 +2505,7 @@ msgstr ""
 "'${email}', kun napautat alla olevaa hyväksymislinkkiä."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Vahvista uusi sähköpostiosoitteesi napauttamalla linkkiä sähköpostissa, joka "
@@ -2589,7 +2589,7 @@ msgid "error_invalid_login"
 msgstr "Kirjautumisnimessä saa olla vain pieniä kirjaimia ja numeroita."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Lähetä kelvollinen XML-tiedosto"
 
@@ -2797,7 +2797,7 @@ msgid "filename_report_timeline"
 msgstr "Toimintasuunnitelma ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgid "header_launch"
 msgstr "Projektin virallinen julkistaminen – syyskuussa 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Oikeudelliset ja toimintaperiaatteita koskevat viitteet"
 
@@ -3611,6 +3611,11 @@ msgstr "1. Suunnittelu"
 msgid "help_help_introduction"
 msgstr "Yleisiä tietoja riskinarvioinnista"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3763,7 +3768,7 @@ msgstr ""
 "Tarvitset tämän salasanan, jotta voit kirjautua tähän editointiympäristöön."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Jos et anna nimitystä, se otetaan syötetiedostosta."
 
@@ -3825,7 +3830,7 @@ msgstr ""
 "työkalun yleiskatsauksessa."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Jos et anna nimitystä, se otetaan syötteestä."
 
@@ -4416,7 +4421,7 @@ msgstr "Toimenpide on jo toteutettu"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Käytössä olevat toimenpiteet"
 
@@ -4456,7 +4461,7 @@ msgid "label_file_caption"
 msgstr "Sisällön otsikko"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Etunimi"
 
@@ -4534,6 +4539,11 @@ msgstr "5. Raportti"
 msgid "label_help_sessions"
 msgstr "Riskien arvioinnin toteuttaminen"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4583,7 +4593,7 @@ msgid "label_involve"
 msgstr "Osallistuminen ja yhteistyö"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4605,7 +4615,7 @@ msgid "label_language"
 msgstr "Kieli"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Sukunimi"
 
@@ -4663,7 +4673,7 @@ msgid "label_login"
 msgstr "Sisäänkirjautuminen"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Kirjautumisnimi"
 
@@ -4684,7 +4694,7 @@ msgid "label_logo_selection"
 msgstr "Minkä logon haluat näkyvän vasemmassa yläkulmassa?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4761,13 +4771,13 @@ msgstr "Vastasiko tämä OiRA –riskinarviointi tarpeitasi?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Anna salasana"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Toista salasana"
 
@@ -4858,7 +4868,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Nykyinen salasana"
 
@@ -4900,7 +4910,7 @@ msgstr "Toista salasana"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Suunnitellut toimenpiteet"
 
@@ -4929,7 +4939,7 @@ msgid "label_print_tool_preview"
 msgstr "Tulosta arviointilomake"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5137,7 +5147,7 @@ msgid "label_sector_description"
 msgstr "Anna toimialasi kuvaus"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Toimialan nimitys"
 
@@ -5303,7 +5313,7 @@ msgid "label_survey_title"
 msgstr "Version nimi"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Tuodun OiRA-työkalun otsikko"
 
@@ -5421,12 +5431,12 @@ msgid "label_update"
 msgstr "Päivitys"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML-tiedosto"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "OiRA-työkaluversion nimi"
 
@@ -5687,7 +5697,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Tämä on OiRA-työkalun ainoa versio, minkä vuoksi sitä ei voi poistaa. "
@@ -5757,7 +5767,7 @@ msgstr ""
 "riskinarviointeja."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Et voi poistaa julkaistua OiRA-työkaluversiota. Peruuta sen julkaisu ensin."
@@ -5938,7 +5948,7 @@ msgid "navigation_help"
 msgstr "Ohjeet"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Kirjaudu ulos"
@@ -6021,32 +6031,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6570,17 +6575,17 @@ msgid "title_about"
 msgstr "Tietoja"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Poista tili"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Vaihda salasana"
 
@@ -6620,12 +6625,12 @@ msgid "title_help_unpublished"
 msgstr "Poista tämä OiRA-työkalu online-asiakkaasta."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Henkilötiedot"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Asetukset "
 
@@ -6725,7 +6730,7 @@ msgid "unpublish_confirm"
 msgstr "Haluatko varmasti peruuttaa tämän OiRA-työkalun julkaisun?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA-työkalun tuonti onnistui"
 

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -123,7 +123,7 @@ msgstr "Accepter"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Ajouter Module"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Ajouter Question de profil"
@@ -198,7 +198,7 @@ msgstr "Vous avez presque terminé&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Une erreur s’est produite lors de l’envoi de l’email de confirmation."
 
@@ -286,7 +286,7 @@ msgstr "Pays candidat"
 msgid "Certificate"
 msgstr "Attestation"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Changer mon adresse email"
 
@@ -318,7 +318,7 @@ msgstr "Fermer"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Confirmer le changement d’adresse email OiRA"
 
@@ -380,7 +380,7 @@ msgstr "Licence Creative Commons "
 msgid "Decline"
 msgstr "Refuser"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Supprimer mon compte"
@@ -439,11 +439,11 @@ msgid "Edit"
 msgstr "Modifier"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Editer ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Editer Question de profil"
 
@@ -459,7 +459,7 @@ msgstr "Modifier un établissement"
 msgid "Edit training card"
 msgstr "Editer une séquence"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Adresse email/nom de compte"
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "Identifier"
 msgstr "Identifiant"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Le format de l’image est non valide. Veuillez utiliser : PNG, JPEG, GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Mot de passe invalide"
 
@@ -612,7 +612,7 @@ msgstr "Mot de passe invalide"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr "Logo officiel d’OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -903,7 +903,7 @@ msgid "Pass information to the people concerned."
 msgstr "Faire circuler l’information aux personnes concernées."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1090,13 +1090,13 @@ msgid "Run slideshow"
 msgstr "Lancer le diaporama"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Sauvegarder"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Sauvegarder les modifications"
@@ -1165,7 +1165,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Message-guide d’une occurrence unique"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1191,7 +1191,7 @@ msgstr "Commencez les questions"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Sous-module"
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Aucun changement à enregistrer."
 
@@ -1298,7 +1298,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Cette adresse email n’est pas disponible."
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1381,7 +1381,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Sans réponse"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Télécharger"
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1530,16 +1530,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Vous avez terminé avec les diapositives de formation !"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Votre adresse email a été actualisée."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Votre mot de passe à confirmer "
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Votre mot de passe a été changé avec succès."
 
@@ -1866,7 +1866,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annuler "
@@ -2547,7 +2547,7 @@ msgstr ""
 "'${email}' lorsque vous cliquerez sur le lien de confirmation ci-dessous."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Veuillez confirmer votre nouvelle adresse email en cliquant sur le lien dans "
@@ -2637,7 +2637,7 @@ msgstr ""
 "des chiffres."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Veuillez télécharger un fichier XML valide"
 
@@ -2859,7 +2859,7 @@ msgid "filename_report_timeline"
 msgstr "Plan d’action ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -3047,7 +3047,7 @@ msgid "header_launch"
 msgstr "Lancement officiel du projet – septembre 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Références juridiques et techniques"
 
@@ -3681,6 +3681,11 @@ msgstr "1. Préparation"
 msgid "help_help_introduction"
 msgstr "Informations sur l’évaluation des risques"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3840,7 +3845,7 @@ msgstr ""
 "d’édition. "
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 "Si vous ne choisissez pas de titre, celui-ci sera tiré du fichier en lecture."
@@ -3906,7 +3911,7 @@ msgstr ""
 "l’outil OiRA dans les clients."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Si vous ne spécifiez pas de titre, il sera pris dans l’entrée."
 
@@ -4536,7 +4541,7 @@ msgstr "Mesure déjà en place"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Des mesures déjà mises en place"
 
@@ -4576,7 +4581,7 @@ msgid "label_file_caption"
 msgstr "Légende du contenu"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Prénom"
 
@@ -4654,6 +4659,11 @@ msgstr "5. Rapport"
 msgid "label_help_sessions"
 msgstr "Réaliser votre évaluation en ligne"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4703,7 +4713,7 @@ msgid "label_involve"
 msgstr "Impliquer"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4725,7 +4735,7 @@ msgid "label_language"
 msgstr "Langue"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Nom"
 
@@ -4783,7 +4793,7 @@ msgid "label_login"
 msgstr "Connexion"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Nom d’utilisateur"
 
@@ -4804,7 +4814,7 @@ msgid "label_logo_selection"
 msgstr "Quel logo souhaitez-vous afficher en haut à gauche ? "
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4882,13 +4892,13 @@ msgstr "Cet outil OiRA a-t-il répondu à votre besoin ? "
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Mot de passe souhaité"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Répétez le mot de passe"
 
@@ -4981,7 +4991,7 @@ msgid "label_oira_consultants"
 msgstr "Services externes"
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Mot de passe actuel"
 
@@ -5023,7 +5033,7 @@ msgstr "Répétez le mot de passe"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Mesures prévues"
 
@@ -5052,7 +5062,7 @@ msgid "label_print_tool_preview"
 msgstr "Imprimer le contenu d’un outil"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5259,7 +5269,7 @@ msgid "label_sector_description"
 msgstr "Veuillez fournir une description de votre secteur "
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Titre du secteur."
 
@@ -5425,7 +5435,7 @@ msgid "label_survey_title"
 msgstr "Nom de version"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Titre de l’Outil OiRA importé"
 
@@ -5544,12 +5554,12 @@ msgid "label_update"
 msgstr "Mise à jour "
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Fichier XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Nom de la version de l’outil OiRA"
 
@@ -5814,7 +5824,7 @@ msgstr ""
 "verrouillée et reçoit un statut officiel de validation."
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Vous ne pouvez pas effacer la seule version de l’Outil OiRA."
 
@@ -5890,7 +5900,7 @@ msgid "message_member_see_all"
 msgstr "Les membres peuvent consulter et modifier l’évaluation des risques."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Vous ne pouvez pas supprimer une version de l’outil OiRA qui a été mise en "
@@ -6090,7 +6100,7 @@ msgid "navigation_help"
 msgstr "Aide"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Déconnexion"
@@ -6173,32 +6183,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6725,17 +6730,17 @@ msgid "title_about"
 msgstr "À propos"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Supprimer mon compte"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Modifier le mot de passe"
 
@@ -6775,12 +6780,12 @@ msgid "title_help_unpublished"
 msgstr "Supprimer cet outil OiRA des clients en ligne."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Données personnelles"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Préférences"
 
@@ -6880,7 +6885,7 @@ msgid "unpublish_confirm"
 msgstr "Êtes-vous sûr de ne pas vouloir publier cet outil OiRA ?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Outil OiRA importé avec succès"
 

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,7 +111,7 @@ msgstr "Prihvati"
 msgid "Action plan (Excel spreadsheet)"
 msgstr "Plan mjera (proračunska tablica Excel)"
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr "Dodajte %s"
 
@@ -123,7 +123,7 @@ msgstr "Dodaj mjeru"
 msgid "Add Module"
 msgstr "Dodaj modul"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Dodaj pitanje o profilu"
@@ -186,7 +186,7 @@ msgstr "Skoro je gotovo&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Došlo je do pogreške prilikom slanja e-pošte potvrde."
 
@@ -275,7 +275,7 @@ msgstr "Država kandidat"
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Promijeni adresu e-pošte"
 
@@ -307,7 +307,7 @@ msgstr "Zatvorite"
 msgid "Comments"
 msgstr "Komentari"
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Potvrdite promjenu OiRA adrese e-pošte"
 
@@ -367,7 +367,7 @@ msgstr "Creative Commons licenca"
 msgid "Decline"
 msgstr "Odbij"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Izbriši račun"
@@ -427,11 +427,11 @@ msgid "Edit"
 msgstr "Uredi"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Uredi ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Uredi pitanje o profilu"
 
@@ -447,7 +447,7 @@ msgstr "Uredi organizaciju"
 msgid "Edit training card"
 msgstr "Uredi karticu za osposobljavanje"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Adresa e-pošte / naziv račun"
 
@@ -561,7 +561,7 @@ msgstr "Želim s vama podijeliti sljedeće"
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr "Uvoz verzije OiRA alata"
 
@@ -588,7 +588,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nevažeći format slike. Molimo koristite PNG, JPEG ili GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Nevažeća lozinka"
 
@@ -596,7 +596,7 @@ msgstr "Nevažeća lozinka"
 msgid "Invalid security token, try to request a new one"
 msgstr "Nevažeći sigurnosni token, pokušajte zatražiti novi"
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgstr "Službeni OiRA logotip"
 msgid "OiRA Tool"
 msgstr "OiRA alat"
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr "Uvoz OiRA alata"
 
@@ -886,7 +886,7 @@ msgid "Pass information to the people concerned."
 msgstr "Prosljeđivanje informacija osobama kojih se to tiče."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Zaporka nije u skladu sa prethodno potvrđenom"
@@ -1071,13 +1071,13 @@ msgid "Run slideshow"
 msgstr "Pokreni dijaprojekciju"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Spremi"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Spremi promjene"
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Iniciranje jednog događaja"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Uobičajen"
 
@@ -1171,7 +1171,7 @@ msgstr "Kreni s pitanjima"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr "Pokretanje probne sesije nije dostupno u ovoj OiRA aplikaciji."
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Podmodul"
 
@@ -1265,7 +1265,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr "Nema dovoljno podataka za prelazak u fazu prepoznavanja"
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Nema promjena za spremanje."
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Ova adresa e-pošte nije dostupna."
 
@@ -1321,7 +1321,7 @@ msgstr ""
 "Ovim se pitanjem od korisnika mora zatražiti da odgovori odnosi li se ovaj "
 "profil na njih."
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr "Ovaj zahtjev ne može biti obrađen. "
 
@@ -1366,7 +1366,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Neodgovoren"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Prijenos"
 
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1510,16 +1510,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Završili ste sa slajdovima osposobljavanja!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Adresa vaše e-pošte je ažurirana."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Vaša lozinka za potvrdu"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Vaša lozinka je uspješno promijenjena."
 
@@ -1825,7 +1825,7 @@ msgstr "Da, arhiviraj sesiju"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Odustani"
@@ -2491,7 +2491,7 @@ msgstr ""
 "'${email}' kada kliknete na donju poveznicu za potvrdu."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Potvrdite svoju novu adresu e-pošte klikom na ovu poveznicu u e-pošti koja "
@@ -2574,7 +2574,7 @@ msgid "error_invalid_login"
 msgstr "Ime za prijavu može sadržavati samo mala slova i brojeve."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Prenesite valjanu XML datoteku"
 
@@ -2779,7 +2779,7 @@ msgid "filename_report_timeline"
 msgstr "Plan mjera za ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2966,7 +2966,7 @@ msgid "header_launch"
 msgstr "Službeno pokretanje projekta – rujna 2011."
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Propisi i dodatne informacije"
 
@@ -3596,6 +3596,11 @@ msgstr "1. Priprema"
 msgid "help_help_introduction"
 msgstr "Opće informacije o procjeni rizika"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3747,7 +3752,7 @@ msgid "help_sector_password"
 msgstr "Ovo je lozinka potrebna za prijavu u ovaj uređivač okruženja."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Ako ne navedete naziv, on će se uzeti iz ulazne datoteke."
 
@@ -3811,7 +3816,7 @@ msgstr ""
 "klijenta."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Ako ne navedete naziv, on će se uzeti iz ulazne datoteke."
 
@@ -4401,7 +4406,7 @@ msgstr "Već provedena mjera"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Provedene mjere"
 
@@ -4441,7 +4446,7 @@ msgid "label_file_caption"
 msgstr "Naslov sadržaja"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Ime"
 
@@ -4519,6 +4524,11 @@ msgstr "5. Završni dokumenti"
 msgid "label_help_sessions"
 msgstr "Izvršite svoju procjenu rizika"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4568,7 +4578,7 @@ msgid "label_involve"
 msgstr "Uključite"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4590,7 +4600,7 @@ msgid "label_language"
 msgstr "Jezik"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Prezime"
 
@@ -4648,7 +4658,7 @@ msgid "label_login"
 msgstr "Prijava"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Ime za prijavu"
 
@@ -4669,7 +4679,7 @@ msgid "label_logo_selection"
 msgstr "Koji biste logotip željeli prikazati u gornjem lijevom kutu?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4746,13 +4756,13 @@ msgstr "Je li ovaj OiRA alat zadovoljio vaše potrebe?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Željena lozinka"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Ponavljanje zaporke"
 
@@ -4843,7 +4853,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Trenutačna lozinka"
 
@@ -4885,7 +4895,7 @@ msgstr "Ponavljanje zaporke"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Planirane mjere"
 
@@ -4914,7 +4924,7 @@ msgid "label_print_tool_preview"
 msgstr "Ispišite pregled alata"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5122,7 +5132,7 @@ msgid "label_sector_description"
 msgstr "Unesite opis svojeg sektora"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Naziv sektora."
 
@@ -5288,7 +5298,7 @@ msgid "label_survey_title"
 msgstr "Naziv verzije"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Naziv uvezenog OiRA alata"
 
@@ -5407,12 +5417,12 @@ msgid "label_update"
 msgstr "Ažuriraj"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML datoteka"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Naziv za verziju OiRA alata"
 
@@ -5672,7 +5682,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Ovo je jedina verzija OiRA alata i zato se ne može obrisati. Želite li možda "
@@ -5742,7 +5752,7 @@ msgid "message_member_see_all"
 msgstr "Članovi mogu pregledati i urediti sve procjene rizika organizacije."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Ne možete izbrisati objavljenu verziju OiRA alata. Prvo poništite objavu."
@@ -5924,7 +5934,7 @@ msgid "navigation_help"
 msgstr "Pomoć"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Odjava"
@@ -6007,32 +6017,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6547,17 +6552,17 @@ msgid "title_about"
 msgstr "O"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Brisanje računa"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Promjena lozinke"
 
@@ -6597,12 +6602,12 @@ msgid "title_help_unpublished"
 msgstr "Ukloni ovaj OiRA alat s mrežnog klijenta."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Osobni podaci"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Postavke"
 
@@ -6701,7 +6706,7 @@ msgid "unpublish_confirm"
 msgstr "Jeste li sugurni da želite poništiti objavu ovog OiRA alata?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Uspješno ste uvezli OiRA alat"
 

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr "Elfogad"
 msgid "Action plan (Excel spreadsheet)"
 msgstr "Intézkedési terv (Excel táblázat)"
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr "Hozzáad %s"
 
@@ -125,7 +125,7 @@ msgstr "Intézkedés hozzáadása"
 msgid "Add Module"
 msgstr "Modul hozzáadása"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Profilkérdés hozzáadása"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "A visszaigazoló e-mail elküldésekor hiba történt."
 
@@ -276,7 +276,7 @@ msgstr "Jelölt ország"
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "E-mailcím megváltoztatása"
 
@@ -308,7 +308,7 @@ msgstr "Bezár"
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "OiRA e-mailcím megváltoztatásának megerősítése"
 
@@ -368,7 +368,7 @@ msgstr "Creative Commons Licenc"
 msgid "Decline"
 msgstr "Elutasít"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Felhasználói fiók törlése"
@@ -427,11 +427,11 @@ msgid "Edit"
 msgstr "Szerkesztés"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "${name} szerkesztése"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Profilkérdés szerkesztése"
 
@@ -447,7 +447,7 @@ msgstr "Szervezet szerkesztése"
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-mailcím/felhasználói fiók neve"
 
@@ -562,7 +562,7 @@ msgstr "Szeretném megosztani veletek a következőket"
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr "OiRA eszköz importálása"
 
@@ -590,7 +590,7 @@ msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Nem megfelelő képformátum. Kérem használjon PNG, JPEG vagy GIF formátumot."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Érvénytelen jelszó"
 
@@ -598,7 +598,7 @@ msgstr "Érvénytelen jelszó"
 msgid "Invalid security token, try to request a new one"
 msgstr "Érvénytelen biztonsági token, próbáljon meg egy újat kérni"
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr "Hivatalos OiRA Logo"
 msgid "OiRA Tool"
 msgstr "OiRA eszköz"
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr "OiRA eszköz importálás"
 
@@ -895,7 +895,7 @@ msgid "Pass information to the people concerned."
 msgstr "Adja át az információt az érintetteknek."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "A jelszó nem egyezik a megerősítő értékkel"
@@ -1081,13 +1081,13 @@ msgid "Run slideshow"
 msgstr "Diavetítés indítása"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Mentés"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Változások mentése"
@@ -1156,7 +1156,7 @@ msgstr "Egyszerű (csak az Általános megközelítés mutatása)"
 msgid "Single occurance prompt"
 msgstr "Egyszeri előfordulás adatbevitel"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr "Ebben az OiRA alkalmazásban nem lehetséges teszt indítása"
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Részmodul"
 
@@ -1278,7 +1278,7 @@ msgstr ""
 "Nem áll rendelkezésre elegendő információ ahhoz, hogy tovább lépjen az "
 "azonosítási fázisba"
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Nincsenek elmentésre váró változtatások."
 
@@ -1296,7 +1296,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Ez az e-mailcím nem elérhető."
 
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr "Megkérdezi a felhasználót, hogy ez a profil alkalmazható-e rájuk."
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr "Ez a kérés nem hajtható végre."
 
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Megválaszolatlan"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Feltöltés"
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Az e-mailcím frissítve lett."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Jelszó megerősítése"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "A jelszó megváltoztatása megtörtént."
 
@@ -1847,7 +1847,7 @@ msgstr "Igen, archiválja a fejezetet"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Mégse"
@@ -2529,7 +2529,7 @@ msgstr ""
 "ra/re változik, ha az alábbi megerősítő hivatkozásra kattint."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Kérjük, az új e-mailcímet a \"${email}\" címre néhány percen belül elküldött "
@@ -2613,7 +2613,7 @@ msgid "error_invalid_login"
 msgstr "A bejelentkezési név csak kisbetűkből és számokból állhat."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Kérjük, érvényes XML fájlt töltsön fel"
 
@@ -2826,7 +2826,7 @@ msgid "filename_report_timeline"
 msgstr "Cselekvési terv ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -3015,7 +3015,7 @@ msgid "header_launch"
 msgstr "A projekt hivatalos indítása – 2011. szeptember"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Hivatkozások jogszabályokra és szabályzatokra"
 
@@ -3663,6 +3663,11 @@ msgstr "1. Előkészítés"
 msgid "help_help_introduction"
 msgstr "Általános információk a kockázatértékelésről"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3826,7 +3831,7 @@ msgstr ""
 "Ez az a jelszó, amellyel bejelentkezhet ebbe a szerkesztői környezetbe."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Ha nem ad meg címet, akkor azt a bemeneti fájl adataiból vesszük át."
 
@@ -3890,7 +3895,7 @@ msgstr ""
 "áttekintésében a klienseken."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Ha nem ad meg címet, akkor azt a bemeneti adatokból vesszük át."
 
@@ -4489,7 +4494,7 @@ msgstr "Az intézkedés már bevezetésre került"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4529,7 +4534,7 @@ msgid "label_file_caption"
 msgstr "Tartalom felirat"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Keresztnév"
 
@@ -4607,6 +4612,11 @@ msgstr "5. Jelentés"
 msgid "label_help_sessions"
 msgstr "Kockázatértékelés végrehajtása"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4656,7 +4666,7 @@ msgid "label_involve"
 msgstr "Bevonás"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4678,7 +4688,7 @@ msgid "label_language"
 msgstr "Nyelv"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Vezetéknév"
 
@@ -4736,7 +4746,7 @@ msgid "label_login"
 msgstr "Bejelentkezés"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Bejelentkezési név"
 
@@ -4757,7 +4767,7 @@ msgid "label_logo_selection"
 msgstr "Melyik logót kívánja megjeleníteni a bal alsó sarokban? "
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4834,13 +4844,13 @@ msgstr "Megfelelő ez az OiRA eszköz az igényeinek?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Kívánt jelszó"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Jelszó újra"
 
@@ -4931,7 +4941,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Jelenlegi jelszó"
 
@@ -4973,7 +4983,7 @@ msgstr "Jelszó még egyszer"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -5002,7 +5012,7 @@ msgid "label_print_tool_preview"
 msgstr "Eszköz előnézet nyomtatása"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5211,7 +5221,7 @@ msgid "label_sector_description"
 msgstr "Kérjük adja meg az ágazata leírását"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Ágazat címe."
 
@@ -5377,7 +5387,7 @@ msgid "label_survey_title"
 msgstr "Verzió neve"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Importált OiRA eszköz címe"
 
@@ -5493,12 +5503,12 @@ msgid "label_update"
 msgstr "Frissítés"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML fájl"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Az OiRA eszköz verziójának neve"
 
@@ -5764,7 +5774,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Ez az OiRA eszköz egyetlen verziója, így nem törölhető. Esetleg magát az "
@@ -5836,7 +5846,7 @@ msgstr ""
 "kockázatértékelést."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Nem törölheti az OiRA eszköznek a közzétett verzióját. Előbb meg kell "
@@ -6019,7 +6029,7 @@ msgid "navigation_help"
 msgstr "Súgó"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Kijelentkezés"
@@ -6102,32 +6112,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6648,17 +6653,17 @@ msgid "title_about"
 msgstr "Névjegy"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Felhasználói fiók törlése"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Jelszó megváltoztatása"
 
@@ -6698,12 +6703,12 @@ msgid "title_help_unpublished"
 msgstr "Az OiRA eszköz eltávolítása az online kliensről."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Személyes adatok"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Beállítások"
 
@@ -6804,7 +6809,7 @@ msgid "unpublish_confirm"
 msgstr "Biztosan szeretné megszüntetni ennek az OiRA eszköznek a közzétételét?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Az OiRA eszközt sikerült importálni"
 

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,7 +108,7 @@ msgstr "Samþykkja"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr "Bæta við ráðstöfun til úrbóta"
 msgid "Add Module"
 msgstr "Bæta við flokki"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Bæta við spurningu um starfsemi"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Villa kom upp þegar verið var að senda staðfestingarpóst."
 
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Breyta tölvupóstfangi"
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Staðfestið breytt OiRA tölvupóstfang"
 
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Decline"
 msgstr "Hafna"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Eyða aðgangi"
@@ -424,11 +424,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Breyta ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Breyta spurningu um starfsemi"
 
@@ -444,7 +444,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Tölvupóstfang/Notendaheiti"
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Get ekki lesið myndskrá. Vinsamlegast notið PNG, JPEG eða GIF skrár."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Lykilorð ekki í lagi"
 
@@ -593,7 +593,7 @@ msgstr "Lykilorð ekki í lagi"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr "Opinbert merki OiRA (Logo)"
 msgid "OiRA Tool"
 msgstr "OiRA verkfæri"
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgid "Pass information to the people concerned."
 msgstr "Að koma upplýsingum til þeirra sem málið varðar."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Seinna lykilorðið stemmir ekki"
@@ -1073,13 +1073,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Vista"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Vista breytingar"
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Eitt tilvik"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "undirflokkur"
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgstr ""
 "Þessi spurning verður að kanna hvort þessi lýsing á starfsemi eigi við hjá "
 "honum"
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Ekki opnað"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr "&nbsp;"
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1498,16 +1498,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Tölvupóstfang þitt hefur verið uppfært"
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Vinsamlegast staðfestið með lykilorðinu"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Lykilorðinu hefur verið breytt."
 
@@ -1771,7 +1771,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Hætta við"
@@ -2416,7 +2416,7 @@ msgstr ""
 "þegar þú hefur hakað við staðfestingu hér fyrir neðan."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Vinsamlegast staðfestið nýtt tölvupóstfang með því að haka við krækjuna í "
@@ -2498,7 +2498,7 @@ msgid "error_invalid_login"
 msgstr "Notendanafn (login name) má aðeins innihalda lágstafi og tölustafi."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2713,7 +2713,7 @@ msgid "filename_report_timeline"
 msgstr "Aðgerðaáætlun fyrir ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2899,7 +2899,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Tilvísanir í önnur gögn s.s. lög, reglur og önnur opinber gögn"
 
@@ -3531,6 +3531,11 @@ msgstr "1. Undirbúningur"
 msgid "help_help_introduction"
 msgstr "Almennar upplýsingar um áhættumat"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3671,7 +3676,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 "Ef þú tiltekur ekki nafn hér, verður það tekið úr því sem hlaðið er niður"
@@ -3731,7 +3736,7 @@ msgstr ""
 "Nafn á OiRA verkfærinu. Nafnið er notað í yfirliti fyrir OiRA verkfærin."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 "Ef þú tiltekur ekki nafn hér, verður það tekið úr því sem hlaðið er niður"
@@ -4310,7 +4315,7 @@ msgstr "Núverandi ráðstöfun til úrbóta."
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4350,7 +4355,7 @@ msgid "label_file_caption"
 msgstr "Skýringartexti um innihald"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4428,6 +4433,11 @@ msgstr "5. Skýrsla"
 msgid "label_help_sessions"
 msgstr "Framkvæmd áhættumatsins"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4477,7 +4487,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4499,7 +4509,7 @@ msgid "label_language"
 msgstr "Tungumál"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4557,7 +4567,7 @@ msgid "label_login"
 msgstr "Skrá aðgang"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4578,7 +4588,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4655,13 +4665,13 @@ msgstr "Uppfyllti OiRA verkfærið væntingar þínar?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Nýtt lykilorð"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Endurtakið lykilorðið"
 
@@ -4752,7 +4762,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4794,7 +4804,7 @@ msgstr "Endurtakið lykilorðið"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4823,7 +4833,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5030,7 +5040,7 @@ msgid "label_sector_description"
 msgstr "Vinsamlegast setjið inn lýsingu á atvinnugreininni"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Heiti atvinnugreinar"
 
@@ -5196,7 +5206,7 @@ msgid "label_survey_title"
 msgstr "Heiti útgáfu"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Nýtt heiti afritaðs OiRA verkfæris"
 
@@ -5312,12 +5322,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Nafn á OiRA útgáfunni"
 
@@ -5571,7 +5581,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Þetta er eina gerðin af OiRA verkfærinu og er því ekki hægt að eyða henni. "
@@ -5627,7 +5637,7 @@ msgid "message_member_see_all"
 msgstr "Meðlimir geta séð og breytt öllum þáttum áhættumats fyrirtækisins."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Þú getur ekki eytt OiRA verkfæri sem búið er að birta. Þú þarft fyrst að "
@@ -5810,7 +5820,7 @@ msgid "navigation_help"
 msgstr "Aðstoð"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Útskráning"
@@ -5894,32 +5904,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6432,17 +6437,17 @@ msgid "title_about"
 msgstr "um"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Eyða aðgangi"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Skipta um lykilorð"
 
@@ -6484,12 +6489,12 @@ msgstr ""
 "notendum."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6589,7 +6594,7 @@ msgid "unpublish_confirm"
 msgstr "Ertu viss um að þú viljir draga til baka útgáfu á þessu OiRA verkfæri?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Upphleðsla á OiRA verkfærinu tókst"
 

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,7 +117,7 @@ msgstr "Accetta"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Aggiungere modulo"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Aggiungere domanda sul profilo"
@@ -192,7 +192,7 @@ msgstr "Quasi fatto&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "È avvenuto un errore durante l'invio del messaggio di conferma."
 
@@ -282,7 +282,7 @@ msgstr "Paese candidato"
 msgid "Certificate"
 msgstr "Attestato"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Modificare indirizzo e-mail"
 
@@ -315,7 +315,7 @@ msgstr "Chiudi"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Conferma modifica dell'indirizzo e-mail per lo strumento OiRA"
 
@@ -375,7 +375,7 @@ msgstr "Licenza Creative Commons"
 msgid "Decline"
 msgstr "Rifiuta"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Eliminare account"
@@ -434,11 +434,11 @@ msgid "Edit"
 msgstr "Modifica"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Modifica ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Modificare la domanda sul profilo"
 
@@ -454,7 +454,7 @@ msgstr "Modifica Organizzazione"
 msgid "Edit training card"
 msgstr "Modifica la scheda della formazione"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Indirizzo e-mail/nome dell'account"
 
@@ -569,7 +569,7 @@ msgstr "Vorrei condividere con voi ció che segue"
 msgid "Identifier"
 msgstr "Identificatore"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato dell'immagine non valido, per favore usa PNG, JPEG o GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Password non valida"
 
@@ -604,7 +604,7 @@ msgstr "Password non valida"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -797,7 +797,7 @@ msgstr "Logo ufficiale OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgid "Pass information to the people concerned."
 msgstr "Trasferire le informazioni alle persone interessate."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Le password non corrispondono"
@@ -1090,13 +1090,13 @@ msgid "Run slideshow"
 msgstr "Avvia lo slideshow"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Salvare"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Salvare le modifiche"
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Singola localizzazione"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1190,7 +1190,7 @@ msgstr "Inizia le domande"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Sotto-modulo"
 
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Non sono state salvate le modifiche."
 
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Questo indirizzo e-mail non è disponibile"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Non esaminato"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Caricare"
 
@@ -1516,7 +1516,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1524,16 +1524,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Hai terminato le slides per la formazione!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "L'indirizzo e-mail è stato aggiornato."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Inserire la password per la conferma"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "La password è stata modificata con successo."
 
@@ -1841,7 +1841,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annullare"
@@ -2519,7 +2519,7 @@ msgstr ""
 "in basso."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Confermare il nuovo indirizzo e-mail cliccando sul link nel messaggio e-mail "
@@ -2604,7 +2604,7 @@ msgstr ""
 "Il nome per il login può consistere solo di lettere minuscole e numeri."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Caricare un file XML valido"
 
@@ -2803,7 +2803,7 @@ msgid "filename_report_timeline"
 msgstr "Misure obbligatorie adottate e Programma di miglioramento per ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2994,7 +2994,7 @@ msgid "header_launch"
 msgstr "Lancio ufficiale del progetto – Settembre 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Riferimenti normativi"
 
@@ -3626,6 +3626,11 @@ msgstr "1. Presentazione"
 msgid "help_help_introduction"
 msgstr "Informazioni generali sulla valutazione dei rischi"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3780,7 +3785,7 @@ msgid "help_sector_password"
 msgstr "Questa è la password che necessitate per accedere a questo editor."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Se non si specifica il titolo, questo sarà preso dal file input."
 
@@ -3845,7 +3850,7 @@ msgstr ""
 "panoramica OiRA dei client."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Se non si specifica il titolo, sarà preso dall'input."
 
@@ -4440,7 +4445,7 @@ msgstr "Misura già attuata"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Misure già adottate"
 
@@ -4480,7 +4485,7 @@ msgid "label_file_caption"
 msgstr "Didascalia del contenuto"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Nome"
 
@@ -4558,6 +4563,11 @@ msgstr "5. Report"
 msgid "label_help_sessions"
 msgstr "Valutazione dei rischi"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4607,7 +4617,7 @@ msgid "label_involve"
 msgstr "Processo di VR"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4629,7 +4639,7 @@ msgid "label_language"
 msgstr "Lingua"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Cognome"
 
@@ -4687,7 +4697,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Nome di login"
 
@@ -4708,7 +4718,7 @@ msgid "label_logo_selection"
 msgstr "Quale logo le piacerebbe avere all'angolo sinistro in alto?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4783,13 +4793,13 @@ msgstr "Lo strumento OiRA soddisfa le vostre esigenze?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Password desiderata"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Ripetere password"
 
@@ -4892,7 +4902,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Password attuale"
 
@@ -4934,7 +4944,7 @@ msgstr "Ripetere password"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Misure programmate"
 
@@ -4963,7 +4973,7 @@ msgid "label_print_tool_preview"
 msgstr "Stampa l’elenco dei rischi"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5188,7 +5198,7 @@ msgid "label_sector_description"
 msgstr "Indicare una descrizione per il proprio settore"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Titolo del settore."
 
@@ -5358,7 +5368,7 @@ msgid "label_survey_title"
 msgstr "Nome della versione"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Titolo del tool OiRA importato"
 
@@ -5477,12 +5487,12 @@ msgid "label_update"
 msgstr "Aggiornamento"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "File XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Nome per versione dello strumento OiRA"
 
@@ -5745,7 +5755,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Questa è l'unica versione dello strumento OiRA e non è possibile "
@@ -5824,7 +5834,7 @@ msgstr ""
 "dell’organizzazione."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Non è possibile eliminare una versione di tool OiRA che è stata pubblicata. "
@@ -6007,7 +6017,7 @@ msgid "navigation_help"
 msgstr "Aiuto"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Disconnettere"
@@ -6090,32 +6100,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6658,17 +6663,17 @@ msgid "title_about"
 msgstr "Riguardo"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Eliminare account"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Cambia password"
 
@@ -6708,12 +6713,12 @@ msgid "title_help_unpublished"
 msgstr "Rimuovere lo strumento OiRA dal client online"
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Dettagli personali"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Impostazioni"
 
@@ -6810,7 +6815,7 @@ msgid "unpublish_confirm"
 msgstr "Sicuro di voler mettere non pubblicato questo strumento OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Tool OiRA importato con successo"
 

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr "Priimti"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Įkelti Modulį"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Įkelti Profilio klausimą"
@@ -188,7 +188,7 @@ msgstr "Beveik baigta"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Siunčiant patvirtinimo laišką įvyko klaida."
 
@@ -273,7 +273,7 @@ msgstr "Šalis kandidatė"
 msgid "Certificate"
 msgstr "Sertifikatą"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Keisti el. pašto adresą"
 
@@ -305,7 +305,7 @@ msgstr "Uždaryti"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Patvirtinti OiRA el. pašto adreso pakeitimą"
 
@@ -365,7 +365,7 @@ msgstr "„Creative Commons“ licencija"
 msgid "Decline"
 msgstr "Atmesti"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Šalinti paskyrą"
@@ -425,11 +425,11 @@ msgid "Edit"
 msgstr "Redaguoti"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Redaguoti ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Redaguoti Profilio klausimą"
 
@@ -445,7 +445,7 @@ msgstr "Redaguoti organizaciją"
 msgid "Edit training card"
 msgstr "Redaguoti mokymo kortelę"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "El. pašto adresas / paskyros pavadinimas"
 
@@ -557,7 +557,7 @@ msgstr "Noriu pasidalinti šia informacija su jumis"
 msgid "Identifier"
 msgstr "Identifikatorius"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -584,7 +584,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Netinkamas vaizdo failo formatas. Naudokite PNG, JEPG arba GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Neteisingas slaptažodis"
 
@@ -592,7 +592,7 @@ msgstr "Neteisingas slaptažodis"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -784,7 +784,7 @@ msgstr "Oficialus OiRA logotipas"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgid "Pass information to the people concerned."
 msgstr "Perduokite informaciją susijusiems asmenims."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Slaptažodis nesutampa su prieš tai įvestu slaptažodžiu"
@@ -1069,13 +1069,13 @@ msgid "Run slideshow"
 msgstr "Paleisti skaidrių demonstraciją"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Išsaugoti"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Išsaugoti keitinius"
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Vienkartinis raginimas"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standartinis"
 
@@ -1169,7 +1169,7 @@ msgstr "Pradėkite atsakinėti į klausimus"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Submodulis"
 
@@ -1260,7 +1260,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Jokie pakeitimai išsaugoti nebus."
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Šis el. pašto adresas yra negaliojantis."
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1356,7 +1356,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Neatsakyta"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Įkelti"
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1499,16 +1499,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Baigėte mokymo skaidres!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Jūsų el. pašto adresas buvo atnaujintas."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Patvirtinimui reikalingas jūsų slaptažodis"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Jūsų slaptažodis sėkmingai pakeistas."
 
@@ -1806,7 +1806,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Atšaukti"
@@ -2470,7 +2470,7 @@ msgstr ""
 "paskyros pavadinimas ${url} bus pakeistas į '${email}'."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Paspaudę laiške, kurį netrukus atsiųsime adresu \"${email}\", pateiktą "
@@ -2552,7 +2552,7 @@ msgid "error_invalid_login"
 msgstr "Prisijungimo vardą gali sudaryti tik mažosios raidės ir skaičiai."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Įkelkite tinkamą XML failą"
 
@@ -2757,7 +2757,7 @@ msgid "filename_report_timeline"
 msgstr "Prevencinių veiksmų planas ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2944,7 +2944,7 @@ msgid "header_launch"
 msgstr "Oficiali projekto paleidimo data – 2011 m. rugsėjo mėn."
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Nuorodos į teisės aktus"
 
@@ -3573,6 +3573,11 @@ msgstr "1. Paruošimas"
 msgid "help_help_introduction"
 msgstr "Bendroji rizikos vertinimo informacija"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3728,7 +3733,7 @@ msgid "help_sector_password"
 msgstr "Šiuo slaptažodžiu turite jungtis prie rengyklės aplinkos."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Pavadinimo nenurodžius, jis bus paimtas iš pradinio failo."
 
@@ -3792,7 +3797,7 @@ msgstr ""
 "priemonės apžvalgoje."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Pavadinimo nenurodžius, jis bus paimtas iš pradinio failo."
 
@@ -4384,7 +4389,7 @@ msgstr "Jau įdiegta priemonė"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Jau įgyvendintos priemonės"
 
@@ -4424,7 +4429,7 @@ msgid "label_file_caption"
 msgstr "Turinio pavadinimas"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Vardas"
 
@@ -4502,6 +4507,11 @@ msgstr "5. Ataskaita"
 msgid "label_help_sessions"
 msgstr "Atlikite rizikos vertinimą"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4551,7 +4561,7 @@ msgid "label_involve"
 msgstr "Įtraukti"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4573,7 +4583,7 @@ msgid "label_language"
 msgstr "Kalba"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Pavardė"
 
@@ -4631,7 +4641,7 @@ msgid "label_login"
 msgstr "Prisijungimo vardas"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Prisijungimo vardas"
 
@@ -4652,7 +4662,7 @@ msgid "label_logo_selection"
 msgstr "Kurį logotipą norėtumėte matyti viršutiniame kairiajame kampe?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4728,13 +4738,13 @@ msgstr "Ar ši OiRA priemonė atitiko jūsų lūkesčius?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Sugalvotas slaptažodis"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Pakartoti slaptažodį"
 
@@ -4825,7 +4835,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Dabartinis slaptažodis"
 
@@ -4867,7 +4877,7 @@ msgstr "Pakartoti slaptažodį"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Planuojamos priemonės"
 
@@ -4896,7 +4906,7 @@ msgid "label_print_tool_preview"
 msgstr "Spausdinti priemonės turinį peržiūrai"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5103,7 +5113,7 @@ msgid "label_sector_description"
 msgstr "Pateikite savo ekonominės veiklos aprašymą"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Ekonominės veiklos pavadinimas."
 
@@ -5269,7 +5279,7 @@ msgid "label_survey_title"
 msgstr "Versijos pavadinimas"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Įkeltos OiRA priemonės pavadinimas"
 
@@ -5388,12 +5398,12 @@ msgid "label_update"
 msgstr "Naujinti"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML failas"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "OiRA priemonės versijos pavadinimas"
 
@@ -5651,7 +5661,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Tai vienintelė OiRA priemonės versija, todėl jos pašalinti negalima. Ar "
@@ -5723,7 +5733,7 @@ msgstr ""
 "Nariai gali peržiūrėti ir redaguoti visus organizacijos rizikos vertinimus.f"
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Išleistos OiRA versijos pašalinti negalima. Pirmiausia pašalinkite "
@@ -5906,7 +5916,7 @@ msgid "navigation_help"
 msgstr "Pagalba"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Išsiregistruoti"
@@ -5989,32 +5999,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6530,17 +6535,17 @@ msgid "title_about"
 msgstr "Apie"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Šalinti paskyrą"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Keisti slaptažodį"
 
@@ -6580,12 +6585,12 @@ msgid "title_help_unpublished"
 msgstr "Šią OiRA priemonę iš internetinės programos pašalinkite."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Asmeninė informacija"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Pageidavimai"
 
@@ -6686,7 +6691,7 @@ msgid "unpublish_confirm"
 msgstr "Ar tikrai norite pašalinti publikuojamą OiRA priemonę?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA priemonė sėkmingai įkelta"
 

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -112,7 +112,7 @@ msgstr "Pieņemt"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Pievienot: Modulis"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Pievienot: Profila jautājums"
@@ -187,7 +187,7 @@ msgstr "Gandrīz pabeigts"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Sūtot apstiprinājuma e-pastu, radās kļūda."
 
@@ -272,7 +272,7 @@ msgstr "Kandidātvalsts"
 msgid "Certificate"
 msgstr "Sertifikāts"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Mainīt e-pasta adresi"
 
@@ -304,7 +304,7 @@ msgstr "Aizvērt"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Apstipriniet OiRA e-pasta adreses maiņu"
 
@@ -362,7 +362,7 @@ msgstr "\"Creative Commons\" licence"
 msgid "Decline"
 msgstr "Atteikt"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Dzēst kontu"
@@ -422,11 +422,11 @@ msgid "Edit"
 msgstr "Labot"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Rediģēt ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Rediģēt Profila jautājums"
 
@@ -442,7 +442,7 @@ msgstr "Labot organizāciju"
 msgid "Edit training card"
 msgstr "Labot apmācību lapu"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-pasta adrese / lietotājvārds"
 
@@ -556,7 +556,7 @@ msgstr "Es vēlos dalīties ar Jums šādos jaunumos"
 msgid "Identifier"
 msgstr "Identifikators"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -583,7 +583,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nepiemērots attēla faila formāts. Lūdzu izmantot PNG, JPEG vai GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Nederīga parole"
 
@@ -591,7 +591,7 @@ msgstr "Nederīga parole"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr "Oficiālais OiRA logotips"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgid "Pass information to the people concerned."
 msgstr "Nodot informāciju iesaistītajiem cilvēkiem."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Ievadītās paroles nesakrīt"
@@ -1072,13 +1072,13 @@ msgid "Run slideshow"
 msgstr "Rādīt slīdrādi"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Saglabāt"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Saglabāt izmaiņas"
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Vienreizēja uzvedne"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standarta"
 
@@ -1172,7 +1172,7 @@ msgstr "Sākt jautājumus"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Apakšmodulis"
 
@@ -1261,7 +1261,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Nebija nekādu saglabājamu izmaiņu."
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Šī e-pasta adrese nav pieejama."
 
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Neatbildēts"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Augšupielādēt"
 
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1504,16 +1504,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Jūs esat pabeidzis apmācības!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Jūsu e-pasta adrese ir atjaunināta."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Parole apstiprināšanai"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Jūsu parole ir veiksmīgi mainīta."
 
@@ -1818,7 +1818,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Atcelt"
@@ -2473,7 +2473,7 @@ msgstr ""
 "un konta nosaukums vietnē ${url} tiks mainīts uz '${email}'."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Lūdzu, apstipriniet jauno e-pasta adresi, noklikšķinot uz saites e-pasta "
@@ -2558,7 +2558,7 @@ msgid "error_invalid_login"
 msgstr "Pieteikumvārdā drīkst būt vienīgi mazie burti un cipari."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Lūdzu, augšupielādējiet derīgu XML failu."
 
@@ -2762,7 +2762,7 @@ msgid "filename_report_timeline"
 msgstr "Rīcības plāns ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2949,7 +2949,7 @@ msgid "header_launch"
 msgstr "Oficiāla projekta atklāšana – 2011. gada septembris"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Atsauces uz normatīvajiem aktiem"
 
@@ -3576,6 +3576,11 @@ msgstr "1. Sagatavošanās"
 msgid "help_help_introduction"
 msgstr "Vispārīga informācija par riska novērtēšanu"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3726,7 +3731,7 @@ msgstr ""
 "Šī ir parole, kas jums būs nepieciešama, lai pieteiktos rediģēšanas vidē."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Ja nenorādīsit nosaukumu, tas tiks izveidots no ievades faila."
 
@@ -3789,7 +3794,7 @@ msgstr ""
 "klientos."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Ja nenorādīsit nosaukumu, tas tiks izveidots no ievadītajiem datiem."
 
@@ -4381,7 +4386,7 @@ msgstr "Pasākums jau īstenots"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Jau ieviestie pasākumi"
 
@@ -4421,7 +4426,7 @@ msgid "label_file_caption"
 msgstr "Satura virsraksts"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Vārds"
 
@@ -4499,6 +4504,11 @@ msgstr "5. Pārskats"
 msgid "label_help_sessions"
 msgstr "Riska novērtējums"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4548,7 +4558,7 @@ msgid "label_involve"
 msgstr "Iesaiste"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4570,7 +4580,7 @@ msgid "label_language"
 msgstr "Valoda"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Uzvārds"
 
@@ -4628,7 +4638,7 @@ msgid "label_login"
 msgstr "Ienākt"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Pieteikumvārds"
 
@@ -4649,7 +4659,7 @@ msgid "label_logo_selection"
 msgstr "Kuru logotipu vēlaties rādīt kreisajā augšējā stūrī?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4724,13 +4734,13 @@ msgstr "Vai šis OiRA rīks atbilst Jūsu vajadzībām?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Jaunā parole"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Atkārtoti ievadiet paroli"
 
@@ -4821,7 +4831,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Esošā parole"
 
@@ -4863,7 +4873,7 @@ msgstr "Atkārtoti ievadiet paroli"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Plānotie pasākumi"
 
@@ -4892,7 +4902,7 @@ msgid "label_print_tool_preview"
 msgstr "Izdrukāt rīka priekšskatu"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5101,7 +5111,7 @@ msgid "label_sector_description"
 msgstr "Lūdzu, iesniedziet sava sektora aprakstu."
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Sektora nosaukums."
 
@@ -5267,7 +5277,7 @@ msgid "label_survey_title"
 msgstr "Versijas nosaukums"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Importētā OiRA rīka nosaukums"
 
@@ -5386,12 +5396,12 @@ msgid "label_update"
 msgstr "Atjaunināta"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML fails"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "OiRA rīka versijas nosaukums"
 
@@ -5651,7 +5661,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Jūs nevarat izdzēst vienīgo OiRA rīka versiju."
 
@@ -5718,7 +5728,7 @@ msgstr ""
 "novērtējumus."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Jūs nevarat izdzēst jau publicētu OiRA rīku. Lūdzu, vispirms atsauciet tā "
@@ -5901,7 +5911,7 @@ msgid "navigation_help"
 msgstr "Palīdzība"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Iziet"
@@ -5984,32 +5994,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6529,17 +6534,17 @@ msgid "title_about"
 msgstr "Informācija"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Konta dzēšana"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Mainīt paroli"
 
@@ -6579,12 +6584,12 @@ msgid "title_help_unpublished"
 msgstr "Šī OiRA rīka noņemšana no tiešsaistes klienta"
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Personīgie dati"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Izvēles"
 
@@ -6680,7 +6685,7 @@ msgid "unpublish_confirm"
 msgstr "Vai tiešām vēlaties atsaukt šī OiRA rīka publikāciju?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA rīka importēšana bija veiksmīga."
 

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,7 +118,7 @@ msgstr "Aċċetta"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Żid Modulu"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Żid Mistoqsija tal-profil"
@@ -193,7 +193,7 @@ msgstr "Kważi lest/a&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 "Seħħ żball waqt li kienet qed tintbagħat il-posta elettronika ta' konferma."
@@ -281,7 +281,7 @@ msgstr "Pajjiż kandidat"
 msgid "Certificate"
 msgstr "Ċertifikat"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Ibdel l-indirizz elettroniku"
 
@@ -313,7 +313,7 @@ msgstr "Għalaq"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Ikkonferma l-bidla tal-indirizz elettroniku tal-OiRA "
 
@@ -373,7 +373,7 @@ msgstr "Creative Commons License"
 msgid "Decline"
 msgstr "Irrifjuta"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Ħassar il-kont"
@@ -432,11 +432,11 @@ msgid "Edit"
 msgstr "Editja"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Editja l-${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "mistoqsija Editja l-Profil"
 
@@ -452,7 +452,7 @@ msgstr "Editja l-organizzazzjoni"
 msgid "Edit training card"
 msgstr "Editja l-karta tat-taħriġ"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Indirizz elettroniku/isem il-kont"
 
@@ -566,7 +566,7 @@ msgstr "Nixtieq naqsam dan miegħek"
 msgid "Identifier"
 msgstr "Identifikatur"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Format tal-istampa invalidu. Jekk jogħġbok uża PNG, JPEG jew GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Password invalida"
 
@@ -601,7 +601,7 @@ msgstr "Password invalida"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr "Logo Uffiċjali ta' OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgid "Pass information to the people concerned."
 msgstr "Għaddi informazzjoni lill-persuni kkonċernati."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Il-password ma taqbilx"
@@ -1083,13 +1083,13 @@ msgid "Run slideshow"
 msgstr "Ibda s-slideshow"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Issejvja"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Issejvja l-bidliet"
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Tfakkira ta’ okkorrenza unika"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1183,7 +1183,7 @@ msgstr "Ibda l-mistoqsijiet"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Modulu sekondarju"
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Ma kienx hemm bidliet x'jiġu ssejvjati."
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Dan l-indirizz elettroniku mhux disponibbli."
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Ma saritx żjara"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Tella'"
 
@@ -1516,7 +1516,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1524,16 +1524,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "I-islides tat-taħriġ lesti!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "L-indirizz elettroniku ġie aġġornat."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Il-password tiegħek għall-konferma"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Il-password tiegħek inbidlet."
 
@@ -1848,7 +1848,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Ikkanċella"
@@ -2520,7 +2520,7 @@ msgstr ""
 "'${email}' meta tikklikkja l-link ta' konferma hawn taħt."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Ikkonferma l-indirizz elettroniku l-ġdid tiegħek billi tikklikkja fuq il-"
@@ -2605,7 +2605,7 @@ msgstr ""
 "Isem tal-login jista' jkun magħmul biss minn ittri u numri mhux kapitali."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Tella' fajl XML validu"
 
@@ -2811,7 +2811,7 @@ msgid "filename_report_timeline"
 msgstr "Pjan ta' azzjoni ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgid "header_launch"
 msgstr "Tnedija uffiċjali tal-proġett – Settembru 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Referenzi legali u tal-politika"
 
@@ -3627,6 +3627,11 @@ msgstr "1. It-Tħejjija"
 msgid "help_help_introduction"
 msgstr "Informazzjoni ġenerali dwar il-valutazzjoni tar-riskji"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3780,7 +3785,7 @@ msgstr ""
 "Din hija l-password li għandek bżonn biex tilloggja f'din iż-żona tal-editur."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Jekk ma tispeċifikax titlu, jittieħed mill-fajl tal-input."
 
@@ -3843,7 +3848,7 @@ msgstr ""
 "Għodda tal-OiRA fil-klijenti."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Jekk ma tispeċifikax titlu, jittieħed mill-input."
 
@@ -4443,7 +4448,7 @@ msgstr "Il-miżura diġà implimentata"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Miżuri diġà mplimentati"
 
@@ -4483,7 +4488,7 @@ msgid "label_file_caption"
 msgstr "Titlu tal-kontenut"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Isem"
 
@@ -4561,6 +4566,11 @@ msgstr "5. Ir-Rapport"
 msgid "label_help_sessions"
 msgstr "Kif twettaq il-valutazzjoni tar-riskji"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4610,7 +4620,7 @@ msgid "label_involve"
 msgstr "Involvi"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4632,7 +4642,7 @@ msgid "label_language"
 msgstr "Lingwa"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Kunjom"
 
@@ -4690,7 +4700,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Isem tal-login"
 
@@ -4711,7 +4721,7 @@ msgid "label_logo_selection"
 msgstr "Liema logo tixtieq turi fir-rokna ta' fuq, fuq ix-xellug?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4788,13 +4798,13 @@ msgstr "Taħseb li din l-għodda OiRA laħqet il-ħtiġijiet tan-negozju tiegħe
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Password li tixtieq"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Erġa password"
 
@@ -4885,7 +4895,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Password Attwali"
 
@@ -4927,7 +4937,7 @@ msgstr "Erġa password"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Miżuri ppjanati"
 
@@ -4956,7 +4966,7 @@ msgid "label_print_tool_preview"
 msgstr "stampa l-kontenut tal-għodda"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5165,7 +5175,7 @@ msgid "label_sector_description"
 msgstr "Ipprovdi deskrizzjoni tas-settur tiegħek"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Titlu tas-settur."
 
@@ -5332,7 +5342,7 @@ msgid "label_survey_title"
 msgstr "Isem il-verżjoni"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Titlu tal-Għodda tal-OiRA impurtata"
 
@@ -5451,12 +5461,12 @@ msgid "label_update"
 msgstr "Aġġornament"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Fajl XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Isem għall-verżjoni tal-Għodda tal-OiRA"
 
@@ -5713,7 +5723,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Din hija l-unika verżjoni tal-Għodda tal-OiRA u għalhekk ma tistax "
@@ -5783,7 +5793,7 @@ msgstr ""
 "organizzazzjoni."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Ma tistax tħassar verżjoni tal-Għodda tal-OiRA li hija ppubblikata. L-ewwel "
@@ -5965,7 +5975,7 @@ msgid "navigation_help"
 msgstr "Għajnuna"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Illoggja 'l barra"
@@ -6048,32 +6058,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6596,17 +6601,17 @@ msgid "title_about"
 msgstr "Dwar"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Ħassar il-kont"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Ibdel il-password"
 
@@ -6646,12 +6651,12 @@ msgid "title_help_unpublished"
 msgstr "Neħħi din l-Għodda tal-OiRA mill-klijent onlajn."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Dettalji personali"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Preferenzi"
 
@@ -6753,7 +6758,7 @@ msgid "unpublish_confirm"
 msgstr "Żġur li tixtieq tneħħi din l-Għodda tal-OiRA mill-pubblikazzjoni?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "L-Għodda tal-OiRA ġiet importata"
 

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -109,7 +109,7 @@ msgstr "Aanvaarden"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Nieuw(e) Standaardmaatregel"
 msgid "Add Module"
 msgstr "Nieuw(e) Module"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Nieuw(e) Profielvraag"
@@ -184,7 +184,7 @@ msgstr "Bijna klaar&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Er is een fout opgetreden bij het versturen van de bevestings e-mail."
 
@@ -273,7 +273,7 @@ msgstr "Kandidaat lidstaat"
 msgid "Certificate"
 msgstr "Certificaat"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Wijzig e-mail adres"
 
@@ -305,7 +305,7 @@ msgstr "Sluiten"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Bevestig RI&E e-mail adres wijziging"
 
@@ -366,7 +366,7 @@ msgstr "Creative Commons License"
 msgid "Decline"
 msgstr "Weigeren"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Verwijder account"
@@ -425,11 +425,11 @@ msgid "Edit"
 msgstr "Toon"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Toon ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr "Toon organisatie"
 msgid "Edit training card"
 msgstr "Bewerk trainingskaart"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-mail adres/login naam"
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "Identifier"
 msgstr "Identificatie"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr "RI&E import"
 
@@ -588,7 +588,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Incorrect wachtwoord"
 
@@ -596,7 +596,7 @@ msgstr "Incorrect wachtwoord"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr "Officieel OiRA-logo"
 msgid "OiRA Tool"
 msgstr "RI&E"
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr "RI&E import"
 
@@ -898,7 +898,7 @@ msgid "Pass information to the people concerned."
 msgstr "informatie door te geven aan de betrokken personen."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Wachtwoord komt niet overeen met bevestigingswaarde"
@@ -1078,13 +1078,13 @@ msgid "Run slideshow"
 msgstr "Diavoorstelling tonen"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Opslaan"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Bewaar wijzigingen"
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standaard"
 
@@ -1178,7 +1178,7 @@ msgstr "Start de vragen"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Submodule"
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Er waren geen wijzigingen om op te slaan."
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Dit e-mail adres is niet beschikbaar."
 
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Niet bekeken"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Upload"
 
@@ -1490,7 +1490,7 @@ msgstr "U moet altijd een accurate en actuele RI&E hebben."
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1498,16 +1498,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "U bent klaar met de slides van de training!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Uw e-mailadres is gewijzigd."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Uw wachtwoord ter bevestiging"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Uw wachtwoord is aangepast."
 
@@ -1813,7 +1813,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annuleren"
@@ -2488,7 +2488,7 @@ msgstr ""
 "'${email}' als u op onderstande link klikt."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Bevestig uw nieuwe e-mail adres door te klikken op de link in de e-mail die "
@@ -2578,7 +2578,7 @@ msgid "error_invalid_login"
 msgstr "De gebruikersnaam mag alleen kleine letters en cijfers bevatten."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "S.v.p. een geldig XML-bestand uploaden."
 
@@ -2811,7 +2811,7 @@ msgid "filename_report_timeline"
 msgstr "Plan van aanpak ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgid "header_launch"
 msgstr "Officiële lancering van het project - September 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Wet- en regelgeving"
 
@@ -3634,6 +3634,11 @@ msgstr ""
 "Algemene inleiding voor de invuller. Deze tekst is niet bedoeld voor "
 "specifieke pagina's."
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3796,7 +3801,7 @@ msgid "help_sector_password"
 msgstr "Met dit wachtwoord kunt u inloggen op de beheeromgeving."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Als u geen titel opgeeft, wordt deze uit de import gehaald."
 
@@ -3861,7 +3866,7 @@ msgstr ""
 "gebruikers."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Als u geen titel opgeeft zal titel uit het bestand worden overgenomen."
 
@@ -4455,7 +4460,7 @@ msgstr "Maatregel is al toegepast"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Reeds geïmplementeerde maatregelen"
 
@@ -4495,7 +4500,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Voornaam"
 
@@ -4573,6 +4578,11 @@ msgstr "Rapporten"
 msgid "label_help_sessions"
 msgstr "RI&E's"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4622,7 +4632,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4644,7 +4654,7 @@ msgid "label_language"
 msgstr "Taal"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Naam"
 
@@ -4702,7 +4712,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Login"
 
@@ -4723,7 +4733,7 @@ msgid "label_logo_selection"
 msgstr "Welk logo wilt u linksboven tonen?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4798,13 +4808,13 @@ msgstr "Voldeed deze tool aan uw verwachtingen?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Nieuw wachtwoord"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Opnieuw wachtwoord"
 
@@ -4895,7 +4905,7 @@ msgid "label_oira_consultants"
 msgstr "Externe diensten"
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Huidige wachtwoord"
 
@@ -4937,7 +4947,7 @@ msgstr "Opnieuw wachtwoord"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Geplande maatregelen"
 
@@ -4966,7 +4976,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5175,7 +5185,7 @@ msgid "label_sector_description"
 msgstr "Omschrijving van de branche"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Titel van de branche"
 
@@ -5343,7 +5353,7 @@ msgid "label_survey_title"
 msgstr "Versie"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Titel van geïmporteerde RI&E"
 
@@ -5462,12 +5472,12 @@ msgid "label_update"
 msgstr "Publiceer"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML-bestand"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Naam voor RI&E versie"
 
@@ -5729,7 +5739,7 @@ msgstr ""
 "vergrendeld en krijgt deze een officiële gevalideerde status."
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "De laatste (enige) versie van de branche-RI&E kan niet verwijderd worden."
@@ -5792,7 +5802,7 @@ msgid "message_member_see_all"
 msgstr "Leden kunnen de risicoanalyse raadplegen en wijzigen."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Een RI&E ckan niet worden verwijdert na publicatie. De-publiceer hem eerst."
@@ -5989,7 +5999,7 @@ msgid "navigation_help"
 msgstr "Help"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Uitloggen"
@@ -6072,32 +6082,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6615,17 +6620,17 @@ msgid "title_about"
 msgstr "Over"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Verwijder account"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Wachtwoord veranderen"
 
@@ -6665,12 +6670,12 @@ msgid "title_help_unpublished"
 msgstr "Verwijder deze RI&E uit de client."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Persoonlijke details"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Voorkeuren"
 
@@ -6770,7 +6775,7 @@ msgstr ""
 "beschikbaar zijn in online client."
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "De RI&E is succesvol geïmporteerd"
 

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr "Aanvaarden"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr "Standaardmaatregel toevoegen"
 msgid "Add Module"
 msgstr "Module toevoegen"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Profielvraag toevoegen"
@@ -188,7 +188,7 @@ msgstr "Bijna klaar&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Er is een fout opgetreden bij het versturen van de bevestingse-mail."
 
@@ -276,7 +276,7 @@ msgstr "Kandidaat-land"
 msgid "Certificate"
 msgstr "Certificaat"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Wijzig e-mailadres"
 
@@ -308,7 +308,7 @@ msgstr "Sluiten"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Bevestig wijziging van OiRA-e-mailadres"
 
@@ -368,7 +368,7 @@ msgstr "Creative Commons License"
 msgid "Decline"
 msgstr "Weigeren"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Verwijder de account"
@@ -427,11 +427,11 @@ msgid "Edit"
 msgstr "Toon"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Bewerk ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Bewerk Profielvraag"
 
@@ -447,7 +447,7 @@ msgstr "Toon organisatie"
 msgid "Edit training card"
 msgstr "Bewerk trainingskaart"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-mailadres/accountnaam"
 
@@ -563,7 +563,7 @@ msgstr "Ik wil het volgende met u delen"
 msgid "Identifier"
 msgstr "Identificatie"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Verkeerd bestandsformaat voor afbeelding. Gebruik a.u.b. PNG, JPEG of GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Ongeldig wachtwoord"
 
@@ -599,7 +599,7 @@ msgstr "Ongeldig wachtwoord"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -793,7 +793,7 @@ msgstr "Officieel OiRA-logo"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -893,7 +893,7 @@ msgid "Pass information to the people concerned."
 msgstr "Geef informatie door aan de betrokken personen."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Wachtwoord komt niet overeen met bevestigingswaarde"
@@ -1080,13 +1080,13 @@ msgid "Run slideshow"
 msgstr "Diavoorstelling tonen"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Opslaan"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Veranderingen opslaan"
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Invoeren eenmalige gebeurtenis"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standaard"
 
@@ -1180,7 +1180,7 @@ msgstr "Start de vragen"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Submodule"
 
@@ -1270,7 +1270,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Er waren geen wijzigingen om op te slaan."
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Dit e-mailadres is niet beschikbaar."
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Onbeantwoord"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Uploaden"
 
@@ -1505,7 +1505,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1513,16 +1513,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "U bent klaar met de slides van de training!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Uw e-mailadres werd bijgewerkt."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Uw wachtwoord ter bevestiging"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Uw wachtwoord werd gewijzigd."
 
@@ -1845,7 +1845,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annuleren"
@@ -2522,7 +2522,7 @@ msgstr ""
 "'${email}' wanneer u klikt op onderstaande bevestigingslink."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Bevestig uw nieuwe e-mailadres door te klikken op de link in de e-mail die u "
@@ -2612,7 +2612,7 @@ msgid "error_invalid_login"
 msgstr "Een loginnaam mag alleen kleine letters en cijfers bevatten."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Upload een geldig XML-bestand"
 
@@ -2827,7 +2827,7 @@ msgid "filename_report_timeline"
 msgstr "Actieplan voor ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -3015,7 +3015,7 @@ msgid "header_launch"
 msgstr "Officiële lancering van het project â€“ September 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Wettelijke bepalingen en beleidsreferenties"
 
@@ -3642,6 +3642,11 @@ msgstr "1. Voorbereiding"
 msgid "help_help_introduction"
 msgstr "Algemene informatie over risicobeoordeling"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3804,7 +3809,7 @@ msgid "help_sector_password"
 msgstr "Met dit wachtwoord kunt u zich aanmelden op de opmaakomgeving."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Als u geen titel opgeeft, wordt deze uit het importbestand gehaald."
 
@@ -3870,7 +3875,7 @@ msgstr ""
 "van het OiRA-instrument bij de gebruikers."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Als u geen titel opgeeft, zal titel uit het bestand worden gehaald."
 
@@ -4471,7 +4476,7 @@ msgstr "Maatregel is al toegepast"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Reeds geïmplementeerde maatregelen"
 
@@ -4511,7 +4516,7 @@ msgid "label_file_caption"
 msgstr "Bijschrift voor inhoud"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Voornaam"
 
@@ -4589,6 +4594,11 @@ msgstr "5. Verslag"
 msgid "label_help_sessions"
 msgstr "Uw risicoanalyse uitvoeren"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4638,7 +4648,7 @@ msgid "label_involve"
 msgstr "Participatie"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4660,7 +4670,7 @@ msgid "label_language"
 msgstr "Taal"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Naam"
 
@@ -4718,7 +4728,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Loginnaam"
 
@@ -4739,7 +4749,7 @@ msgid "label_logo_selection"
 msgstr "Welk logo wilt u linksboven tonen?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4816,13 +4826,13 @@ msgstr "Voldeed deze tool aan uw verwachtingen?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Gewenst wachtwoord"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Opnieuw wachtwoord"
 
@@ -4913,7 +4923,7 @@ msgid "label_oira_consultants"
 msgstr "Externe diensten"
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Huidig wachtwoord"
 
@@ -4955,7 +4965,7 @@ msgstr "Opnieuw wachtwoord"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Geplande maatregelen"
 
@@ -4984,7 +4994,7 @@ msgid "label_print_tool_preview"
 msgstr "Print een tool preview"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5193,7 +5203,7 @@ msgid "label_sector_description"
 msgstr "Geef een beschrijving van uw sector"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Titel van de sector."
 
@@ -5359,7 +5369,7 @@ msgid "label_survey_title"
 msgstr "Versienaam"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Titel van geïmporteerd OiRA-instrument"
 
@@ -5478,12 +5488,12 @@ msgid "label_update"
 msgstr "Bijwerken"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML-bestand"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Naam voor de versie van het OiRA-instrument"
 
@@ -5748,7 +5758,7 @@ msgstr ""
 "vergrendeld en krijgt deze een officiële gevalideerde status."
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "U kunt de enige versie van het OiRA-instrument niet verwijderen."
 
@@ -5822,7 +5832,7 @@ msgid "message_member_see_all"
 msgstr "Leden kunnen de risicoanalyse raadplegen en wijzigen."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "U kunt geen versie van het OiRA-instrument verwijderen die gepubliceerd is. "
@@ -6022,7 +6032,7 @@ msgid "navigation_help"
 msgstr "Help"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Uitloggen"
@@ -6105,32 +6115,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6656,17 +6661,17 @@ msgid "title_about"
 msgstr "Over"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Account verwijderen"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Wachtwoord veranderen"
 
@@ -6706,12 +6711,12 @@ msgid "title_help_unpublished"
 msgstr "Dit OiRA-instrument van de online gebruikerssite verwijderen."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Persoonlijke details"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Voorkeuren"
 
@@ -6812,7 +6817,7 @@ msgstr ""
 "Weet u zeker dat u de publicatie van dit OiRA-instrument wilt ongedaan maken?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Het OiRA-instrument werd geïmporteerd"
 

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -399,11 +399,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -842,7 +842,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1015,13 +1015,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1411,16 +1411,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2307,7 +2307,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2487,7 +2487,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2670,7 +2670,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3280,6 +3280,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3399,7 +3404,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3452,7 +3457,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -3971,7 +3976,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4011,7 +4016,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4089,6 +4094,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4138,7 +4148,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4160,7 +4170,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4218,7 +4228,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4239,7 +4249,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4314,13 +4324,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4411,7 +4421,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4453,7 +4463,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4482,7 +4492,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4689,7 +4699,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4855,7 +4865,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -4971,12 +4981,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5223,7 +5233,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5274,7 +5284,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5451,7 +5461,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5534,32 +5544,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6037,17 +6042,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6087,12 +6092,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6182,7 +6187,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -96,7 +96,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -171,7 +171,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -253,7 +253,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -402,11 +402,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -755,7 +755,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1018,13 +1018,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1089,7 +1089,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1115,7 +1115,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1414,16 +1414,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2386,7 +2386,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2749,7 +2749,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3359,6 +3359,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3478,7 +3483,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3531,7 +3536,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -4050,7 +4055,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4090,7 +4095,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4168,6 +4173,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4217,7 +4227,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4239,7 +4249,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4297,7 +4307,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4318,7 +4328,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4393,13 +4403,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4490,7 +4500,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4532,7 +4542,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4561,7 +4571,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4768,7 +4778,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4934,7 +4944,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -5050,12 +5060,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5302,7 +5312,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5353,7 +5363,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5613,32 +5623,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6116,17 +6121,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6166,12 +6171,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6261,7 +6266,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr "Aceito"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Adicionar Módulo"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Adicionar Perguntas do perfil"
@@ -188,7 +188,7 @@ msgstr "Quase a terminar&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Ocorreu um erro ao enviar o e-mail de confirmação."
 
@@ -276,7 +276,7 @@ msgstr "Paísa candidato"
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Alterar endereço de e-mail"
 
@@ -308,7 +308,7 @@ msgstr "Fechar"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Confirmar alteração do endereço de e-mail OiRA"
 
@@ -368,7 +368,7 @@ msgstr "Licença Creative Commons "
 msgid "Decline"
 msgstr "Resuso"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Apagar conta"
@@ -427,11 +427,11 @@ msgid "Edit"
 msgstr "Editar"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Editar ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Editar Perguntas do perfil"
 
@@ -447,7 +447,7 @@ msgstr "Editar organização"
 msgid "Edit training card"
 msgstr "Editar o conteúdo da Formação"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "Endereço de e-mail/nome da conta"
 
@@ -562,7 +562,7 @@ msgstr "Clique para seguir ligação"
 msgid "Identifier"
 msgstr "Identificador"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato de ficheiro inválido. Por favor use PNG, JPEG ou GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Palavra-passe inválida"
 
@@ -597,7 +597,7 @@ msgstr "Palavra-passe inválida"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr "Logótipo oficial da OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgid "Pass information to the people concerned."
 msgstr "Transmitir informações às pessoas interessadas."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "A palavra-passe não coincide com a definida"
@@ -1078,13 +1078,13 @@ msgid "Run slideshow"
 msgstr "Ver slides"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Guardar"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Guardar alterações"
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Mensagem de opção de ocorrência única"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1178,7 +1178,7 @@ msgstr "Iniciar o seu teste"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Submódulo"
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Não existiam alterações para guardar."
 
@@ -1285,7 +1285,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Este endereço de e-mail não está disponível."
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Sem resposta"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Carregar"
 
@@ -1502,7 +1502,7 @@ msgstr "Assegure-se sempre de que dispõe de uma versão impressa, atualizada."
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1510,16 +1510,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Terminaram os slides com o conteúdo da formação!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "O endereço de e-mail foi atualizado."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "A sua palavra-passe para confirmação"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "A palavra-passe foi alterada corretamente."
 
@@ -1830,7 +1830,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Cancelar"
@@ -2496,7 +2496,7 @@ msgstr ""
 "'${email}' ao clicar na ligação de confirmação em baixo."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Confirme o novo endereço de e-mail, clicando na ligação que será enviada "
@@ -2579,7 +2579,7 @@ msgstr ""
 "Um nome de login apenas pode ser constituído por letras minúsculas e números."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Carregue um ficheiro XML válido"
 
@@ -2786,7 +2786,7 @@ msgid "filename_report_timeline"
 msgstr "Plano de ação para ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2974,7 +2974,7 @@ msgid "header_launch"
 msgstr "Lançamento oficial do projeto – Setembro de 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Referências legais e normativas"
 
@@ -3596,6 +3596,11 @@ msgstr "1. Preparação"
 msgid "help_help_introduction"
 msgstr "Informação geral sobre a avaliação de riscos"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3748,7 +3753,7 @@ msgstr ""
 "editor."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 "Se não especificar um título, o mesmo será retirado do ficheiro de entrada."
@@ -3808,7 +3813,7 @@ msgstr ""
 "Ferramenta OiRA nos clientes."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Se não especificar um título, o mesmo será retirado da entrada."
 
@@ -4407,7 +4412,7 @@ msgstr "Medida já executada"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Medidas já implementadas"
 
@@ -4447,7 +4452,7 @@ msgid "label_file_caption"
 msgstr "Legenda do conteúdo"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Nome próprio"
 
@@ -4525,6 +4530,11 @@ msgstr "5. Relatório"
 msgid "label_help_sessions"
 msgstr "Realizar a sua avaliação de riscos"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4574,7 +4584,7 @@ msgid "label_involve"
 msgstr "Envolvimento"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4596,7 +4606,7 @@ msgid "label_language"
 msgstr "Idioma"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Apelido"
 
@@ -4654,7 +4664,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Nome de login"
 
@@ -4675,7 +4685,7 @@ msgid "label_logo_selection"
 msgstr "Qual é o logótipo que pretende mostrar no canto superior esquerdo?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4750,13 +4760,13 @@ msgstr "Considera a ferramenta OiRA útil para a sua atividade?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Palavra-passe pretendida"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Coloque novamente a sua palavra-passe"
 
@@ -4847,7 +4857,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Palavra-passe atual"
 
@@ -4889,7 +4899,7 @@ msgstr "Coloque novamente a sua palavra-passe"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Medidas planeadas"
 
@@ -4918,7 +4928,7 @@ msgid "label_print_tool_preview"
 msgstr "imprimir o conteúdo da ferramenta"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5125,7 +5135,7 @@ msgid "label_sector_description"
 msgstr "Forneça uma descrição do seu setor"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Título do setor."
 
@@ -5293,7 +5303,7 @@ msgid "label_survey_title"
 msgstr "Nome da versão"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Título da Ferramenta OiRA importada"
 
@@ -5412,12 +5422,12 @@ msgid "label_update"
 msgstr "Atualizar"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Ficheiro XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Nome para a versão da Ferramenta OiRA "
 
@@ -5676,7 +5686,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Esta é a única versão da Ferramenta OiRA e, por isso, não pode ser apagada. "
@@ -5747,7 +5757,7 @@ msgstr ""
 "organização."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Não é possível apagar uma versão da Ferramenta OiRA que tenha sido "
@@ -5931,7 +5941,7 @@ msgid "navigation_help"
 msgstr "Ajuda"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Sair da sessão"
@@ -6014,32 +6024,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6559,17 +6564,17 @@ msgid "title_about"
 msgstr "Sobre"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Apagar conta"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Mudar palavra-passe"
 
@@ -6609,12 +6614,12 @@ msgid "title_help_unpublished"
 msgstr "Remova esta Ferramenta OiRA do cliente online."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Dados pessoais"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Configurações"
 
@@ -6714,7 +6719,7 @@ msgstr ""
 "Tem a certeza de que pretende anular a publicação desta Ferramenta OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Ferramenta OiRA importada com sucesso"
 

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -96,7 +96,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Add Module"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr ""
@@ -171,7 +171,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
@@ -253,7 +253,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -402,11 +402,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -755,7 +755,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1018,13 +1018,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1089,7 +1089,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr ""
 
@@ -1115,7 +1115,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1414,16 +1414,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgid "error_invalid_login"
 msgstr ""
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr ""
 
@@ -2493,7 +2493,7 @@ msgid "filename_report_timeline"
 msgstr ""
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2676,7 +2676,7 @@ msgid "header_launch"
 msgstr ""
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr ""
 
@@ -3286,6 +3286,11 @@ msgstr ""
 msgid "help_help_introduction"
 msgstr ""
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3405,7 +3410,7 @@ msgid "help_sector_password"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr ""
 
@@ -3459,7 +3464,7 @@ msgid "help_surveygroup_title"
 msgstr ""
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr ""
 
@@ -3978,7 +3983,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4018,7 +4023,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4096,6 +4101,11 @@ msgstr ""
 msgid "label_help_sessions"
 msgstr ""
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4145,7 +4155,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4167,7 +4177,7 @@ msgid "label_language"
 msgstr ""
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4225,7 +4235,7 @@ msgid "label_login"
 msgstr ""
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr ""
 
@@ -4246,7 +4256,7 @@ msgid "label_logo_selection"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4321,13 +4331,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr ""
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4418,7 +4428,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr ""
 
@@ -4460,7 +4470,7 @@ msgstr ""
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4489,7 +4499,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4696,7 +4706,7 @@ msgid "label_sector_description"
 msgstr ""
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr ""
 
@@ -4862,7 +4872,7 @@ msgid "label_survey_title"
 msgstr ""
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr ""
 
@@ -4978,12 +4988,12 @@ msgid "label_update"
 msgstr ""
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr ""
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr ""
 
@@ -5230,7 +5240,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 
@@ -5281,7 +5291,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 
@@ -5458,7 +5468,7 @@ msgid "navigation_help"
 msgstr ""
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr ""
@@ -5541,32 +5551,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6044,17 +6049,17 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6094,12 +6099,12 @@ msgid "title_help_unpublished"
 msgstr ""
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6189,7 +6194,7 @@ msgid "unpublish_confirm"
 msgstr ""
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,7 +111,7 @@ msgstr "Prijať"
 msgid "Action plan (Excel spreadsheet)"
 msgstr "Akčný plán (tabuľka v Exceli)"
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr "Pridať %s"
 
@@ -123,7 +123,7 @@ msgstr "Pridať opatrenie"
 msgid "Add Module"
 msgstr "Pridať modul"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Pridať profilovú otázku"
@@ -186,7 +186,7 @@ msgstr "Takmer hotovo&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Pri posielaní potvrdzujúceho e-mailu sa vyskytla chyba."
 
@@ -272,7 +272,7 @@ msgstr "Kandidátska krajina"
 msgid "Certificate"
 msgstr "Certifikát"
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Zmeniť e-mailovú adresu"
 
@@ -304,7 +304,7 @@ msgstr "Zatvoriť"
 msgid "Comments"
 msgstr "Pripomienky"
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Potvrdiť zmenu e-mailovej adresy OiRA"
 
@@ -362,7 +362,7 @@ msgstr "Licencia Creative Commons"
 msgid "Decline"
 msgstr "Odmietnuť"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Odstrániť konto"
@@ -422,11 +422,11 @@ msgid "Edit"
 msgstr "Upraviť"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Upraviť ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Pridať profilovú otázku"
 
@@ -442,7 +442,7 @@ msgstr "Upraviť organizáciu"
 msgid "Edit training card"
 msgstr "Upraviť kartu školenia"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-mailová adresa/názov konta"
 
@@ -556,7 +556,7 @@ msgstr "Chcem sa s vami podeliť o nasledovné"
 msgid "Identifier"
 msgstr "Identifikátor"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr "Importovať verziu nástroja OiRA"
 
@@ -584,7 +584,7 @@ msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Neplatný formát súboru pre obrázok. Použite formát PNG, JPEG alebo GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Neplatné heslo"
 
@@ -592,7 +592,7 @@ msgstr "Neplatné heslo"
 msgid "Invalid security token, try to request a new one"
 msgstr "Neplatný bezpečnostný token, skúste požiadať o nový."
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -783,7 +783,7 @@ msgstr "Oficiálne logo OiRA"
 msgid "OiRA Tool"
 msgstr "Nástroj OiRA"
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr "Import nástroja OiRA"
 
@@ -884,7 +884,7 @@ msgid "Pass information to the people concerned."
 msgstr "Informovať dotknuté osoby."
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Heslo sa nepodobá hodnote potvrdenia"
@@ -1070,13 +1070,13 @@ msgid "Run slideshow"
 msgstr "Spustiť prezentáciu"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Uložiť"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Uložiť zmeny"
@@ -1144,7 +1144,7 @@ msgstr "Jednoduché (zobraziť iba Všeobecné smerovanie)"
 msgid "Single occurance prompt"
 msgstr "Výzva v prípade jedného výskytu"
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Štandardné"
 
@@ -1171,7 +1171,7 @@ msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 "V tejto aplikácii OiRA nie je spustenie testovacej relácie k dispozícii."
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Podmodul"
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr "Na prechod do identifikačnej fázy nie je dostatok informácií."
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Neexistovali žiadne zmeny na uloženie."
 
@@ -1280,7 +1280,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Táto e-mailová adresa nie je k dispozícii."
 
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr "Táto otázka sa musí používateľa opýtať, či sa na neho vzťahuje profil."
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr "Túto požiadavku nebolo možné spracovať."
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Nenavštívené"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Nahrať"
 
@@ -1500,7 +1500,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1508,16 +1508,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "So snímkami zo školenia ste skončili!"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Vaša e-mailová adresa bola aktualizovaná."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Vaše heslo na potvrdenie"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Vaše heslo bolo úspešne zmenené."
 
@@ -1808,7 +1808,7 @@ msgstr "Áno, archívna relácia"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Zrušiť"
@@ -2482,7 +2482,7 @@ msgstr ""
 "na ${url} budú zmenené na „${email}“."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Potvrďte svoju novú e-mailovú adresu kliknutím na tento odkaz v e-maile, "
@@ -2564,7 +2564,7 @@ msgid "error_invalid_login"
 msgstr "Prihlasovacie meno môže obsahovať iba malé písmená a čísla."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Nahrajte platný súbor XML"
 
@@ -2773,7 +2773,7 @@ msgid "filename_report_timeline"
 msgstr "Akčný plán pre ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2960,7 +2960,7 @@ msgid "header_launch"
 msgstr "Oficiálne spustenie projektu &ndash; september 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Právne odkazy a odkazy na zásady"
 
@@ -3593,6 +3593,11 @@ msgstr "1. Príprava"
 msgid "help_help_introduction"
 msgstr "Všeobecné informácie o hodnotení rizík"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3746,7 +3751,7 @@ msgstr ""
 "tohto editora."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Ak neuvediete názov, bude prevzatý zo vstupného súboru."
 
@@ -3809,7 +3814,7 @@ msgstr ""
 "klientov."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Ak neuvediete názov, bude prevzatý zo vstupu."
 
@@ -4403,7 +4408,7 @@ msgstr "Opatrenie už bolo zavedené"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Už realizované opatrenia"
 
@@ -4443,7 +4448,7 @@ msgid "label_file_caption"
 msgstr "Popisok obsahu"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Krstné meno"
 
@@ -4521,6 +4526,11 @@ msgstr "5. Správa"
 msgid "label_help_sessions"
 msgstr "Vykonanie vášho hodnotenia rizík"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4570,7 +4580,7 @@ msgid "label_involve"
 msgstr "Zahrnúť"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4592,7 +4602,7 @@ msgid "label_language"
 msgstr "Jazyk"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Priezvisko"
 
@@ -4650,7 +4660,7 @@ msgid "label_login"
 msgstr "Prihlásenie"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Prihlasovacie meno"
 
@@ -4671,7 +4681,7 @@ msgid "label_logo_selection"
 msgstr "Ktoré logo chcete zobraziť v ľavom dolnom rohu?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4748,13 +4758,13 @@ msgstr "Splnil tento nástroj OiRA vaše potreby?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Požadované heslo"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Znova heslo"
 
@@ -4846,7 +4856,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Súčasné heslo"
 
@@ -4888,7 +4898,7 @@ msgstr "Znova heslo"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Plánované opatrenia"
 
@@ -4917,7 +4927,7 @@ msgid "label_print_tool_preview"
 msgstr "Vytlačiť prehľad nástroja"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5126,7 +5136,7 @@ msgid "label_sector_description"
 msgstr "Uveďte opis vášho odvetvia"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Názov odvetvia."
 
@@ -5293,7 +5303,7 @@ msgid "label_survey_title"
 msgstr "Názov verzie"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Názov importovaného nástroja OiRA"
 
@@ -5412,12 +5422,12 @@ msgid "label_update"
 msgstr "Aktualizovať"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Súbor XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Názov verzie nástroja OiRA"
 
@@ -5677,7 +5687,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr ""
 "Toto je jediná verzia nástroja OiRA a preto sa nedávymazať. Možno chcete "
@@ -5749,7 +5759,7 @@ msgstr ""
 "Členovia môžu prezerať a upravovať všetky hodnotenia rizík organizácie."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Uverejnenú verziu nástroja OiRA nemôžete vymazať. Najprv zrušte jej "
@@ -5930,7 +5940,7 @@ msgid "navigation_help"
 msgstr "Pomoc"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Odhlásenie"
@@ -6013,32 +6023,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6551,17 +6556,17 @@ msgid "title_about"
 msgstr "O nás"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Odstrániť konto"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Zmena hesla"
 
@@ -6601,12 +6606,12 @@ msgid "title_help_unpublished"
 msgstr "Odstrániť tento nástroj OiRA z online klienta."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Osobné údaje"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Preferencie"
 
@@ -6705,7 +6710,7 @@ msgid "unpublish_confirm"
 msgstr "Naozaj chcete zrušiť uverejnenie tohto nástroja OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Úspešne importovaný nástroj OiRA."
 

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr "Sprejmi"
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Dodaj Modul"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Dodaj Profilno vprašanje"
@@ -188,7 +188,7 @@ msgstr "Skoraj končano&hellip;"
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Med pošiljanjem potrditvene e-pošte je prišlo do napake."
 
@@ -280,7 +280,7 @@ msgstr "Država kandidatka"
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Spremeni e-poštni račun"
 
@@ -312,7 +312,7 @@ msgstr "Zapri"
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr "Potrdi spremembo e-poštnega naslova OiRA"
 
@@ -372,7 +372,7 @@ msgstr "Licenca Creative Commons"
 msgid "Decline"
 msgstr "Zavrni"
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr "Izbriši račun"
@@ -433,11 +433,11 @@ msgid "Edit"
 msgstr "Uredi"
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr "Uredi ${name}"
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr "Uredi Profilno vprašanje"
 
@@ -453,7 +453,7 @@ msgstr "Uredi organizacijo"
 msgid "Edit training card"
 msgstr "Uredite vadbeno kartico"
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr "E-poštni naslov/ime računa"
 
@@ -568,7 +568,7 @@ msgstr "Z vami želim deliti naslednje"
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Napačen format slike. Prosim, uporabi PNG, JPEG ali GIF."
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Neveljavno geslo"
 
@@ -603,7 +603,7 @@ msgstr "Neveljavno geslo"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -793,7 +793,7 @@ msgstr "Uradni logotip orodja OiRA"
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgid "Pass information to the people concerned."
 msgstr "Posredovanje informacij zadevnim osebam"
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr "Geslo se ne ujema"
@@ -1083,13 +1083,13 @@ msgid "Run slideshow"
 msgstr "Zaženi diaprojekcijo"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Shrani"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Shrani spremembe"
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr "Enkraten takojšen pripetljaj "
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standardno"
 
@@ -1183,7 +1183,7 @@ msgstr "Začnite z vprašanji"
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Podmodul"
 
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr "Nobene spremembe se niso shranile."
 
@@ -1288,7 +1288,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr "Ta e-poštni naslov ni na voljo."
 
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr "Neodgovorjeno"
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Naloži"
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1516,16 +1516,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Končali ste z diapozitivi"
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr "Vaš e-poštni naslov je bil posodobljen."
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr "Vaše geslo za potrditev"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr "Vaše geslo je bilo uspešno spremenjeno."
 
@@ -1820,7 +1820,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Prekliči"
@@ -2480,7 +2480,7 @@ msgstr ""
 "povezavo spremenila v '${email}'."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 "Potrdite vaš nov e-poštni naslov, tako da kliknete na povezavo v e-pošti, ki "
@@ -2564,7 +2564,7 @@ msgid "error_invalid_login"
 msgstr "Uporabniško ime je lahko sestavljeno samo iz majhnih črk in številk."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Naložite veljavno datoteko XML"
 
@@ -2772,7 +2772,7 @@ msgid "filename_report_timeline"
 msgstr "Načrt ukrepov ${title}"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2960,7 +2960,7 @@ msgid "header_launch"
 msgstr "Uradno lansiranje projekta – september 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Zakonodaja in drugi viri"
 
@@ -3582,6 +3582,11 @@ msgstr "1. Priprava"
 msgid "help_help_introduction"
 msgstr "Splošne informacije o oceni tveganja"
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3730,7 +3735,7 @@ msgid "help_sector_password"
 msgstr "To je geslo, ki ga potrebujete za prijavo v to okolje urejevalnika."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Če ne specificirate naslova, bo uporabljen iz vnosne datoteke."
 
@@ -3791,7 +3796,7 @@ msgstr ""
 "odjemalcih."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Če ne specificirate naslova, bo uporabljen iz vnosa."
 
@@ -4374,7 +4379,7 @@ msgstr "Že izveden ukrep"
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Že izvedeni ukrepi"
 
@@ -4414,7 +4419,7 @@ msgid "label_file_caption"
 msgstr "Napis v zvezi z vsebino"
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr "Ime"
 
@@ -4492,6 +4497,11 @@ msgstr "5. Poročilo"
 msgid "label_help_sessions"
 msgstr "Izvajanje ocene tveganja"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4541,7 +4551,7 @@ msgid "label_involve"
 msgstr "Vključevanje"
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4563,7 +4573,7 @@ msgid "label_language"
 msgstr "Jezik"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr "Priimek"
 
@@ -4621,7 +4631,7 @@ msgid "label_login"
 msgstr "Nadaljuj"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Uporabniško ime"
 
@@ -4642,7 +4652,7 @@ msgid "label_logo_selection"
 msgstr "Kater logotip želite, da je prikazan v zgornjem levem kotu?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4719,13 +4729,13 @@ msgstr "Ali to orodje OiRA ustreza vašim potrebam?"
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Želeno geslo"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr "Ponovi geslo"
 
@@ -4816,7 +4826,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Trenutno geslo"
 
@@ -4858,7 +4868,7 @@ msgstr "Ponovi geslo"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Načrtovani ukrepi"
 
@@ -4887,7 +4897,7 @@ msgid "label_print_tool_preview"
 msgstr "vsebina orodja za tiskanje"
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -5096,7 +5106,7 @@ msgid "label_sector_description"
 msgstr "Vnesite opis vašega sektorja"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Naslov sektorja."
 
@@ -5263,7 +5273,7 @@ msgid "label_survey_title"
 msgstr "Ime različice"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Naslov uvoženega orodja OiRA"
 
@@ -5382,12 +5392,12 @@ msgid "label_update"
 msgstr "Posodobi"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "Datoteka XML"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Ime za različico orodja OiRA"
 
@@ -5646,7 +5656,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Ne morete izbrisati samo različice orodja OiRA."
 
@@ -5713,7 +5723,7 @@ msgstr ""
 "uporabnikov."
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr ""
 "Objavljene različice orodja OiRA ni mogoče izbrisati. Najprej prekličite "
@@ -5895,7 +5905,7 @@ msgid "navigation_help"
 msgstr "Pomoč"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Odjava"
@@ -5978,32 +5988,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6520,17 +6525,17 @@ msgid "title_about"
 msgstr "Vizitka"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Izbriši račun"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr "Spremeni geslo"
 
@@ -6570,12 +6575,12 @@ msgid "title_help_unpublished"
 msgstr "Odstrani to orodje OiRA s spletnega odjemalca."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr "Osebni podatki"
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr "Nastavitve"
 
@@ -6674,7 +6679,7 @@ msgid "unpublish_confirm"
 msgstr "Ste prepričani, da želite preklicati objavo tega orodja OiRA?"
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Uspešno uvoženo orodje OiRA"
 

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-02 21:22+0000\n"
+"POT-Creation-Date: 2023-11-22 11:27+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Action plan (Excel spreadsheet)"
 msgstr ""
 
-#: euphorie/content/browser/module.py:76
+#: euphorie/content/browser/module.py:38
 msgid "Add %s"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Add Module"
 msgstr "Lägg till Modul"
 
-#: euphorie/content/browser/profilequestion.py:60
+#: euphorie/content/browser/profilequestion.py:22
 #: euphorie/deployment/tiles/templates/addbar.pt:35
 msgid "Add Profile question"
 msgstr "Lägg till Profilfråga"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:279
+#: euphorie/client/browser/settings.py:345
 msgid "An error occured while sending the confirmation email."
 msgstr "Ett fel har inträffat när lösenordspåminnelsen skulle skickas ut"
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "Certificate"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:71
+#: euphorie/client/browser/settings.py:74
 msgid "Change email address"
 msgstr "Okänd e-postadress"
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:304
+#: euphorie/client/browser/settings.py:370
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr "Creative Commons-license"
 msgid "Decline"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:77
+#: euphorie/client/browser/settings.py:80
 #: euphorie/client/browser/templates/account-delete.pt:41
 msgid "Delete account"
 msgstr ""
@@ -403,11 +403,11 @@ msgid "Edit"
 msgstr ""
 
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:21
-#: euphorie/content/browser/module.py:98
+#: euphorie/content/browser/module.py:60
 msgid "Edit ${name}"
 msgstr ""
 
-#: euphorie/content/browser/profilequestion.py:72
+#: euphorie/content/browser/profilequestion.py:34
 msgid "Edit Profile question"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Edit training card"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:118
+#: euphorie/client/browser/settings.py:121
 msgid "Email address/account name"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "Identifier"
 msgstr "Identifierare"
 
-#: euphorie/content/browser/upload.py:557
+#: euphorie/content/browser/upload.py:564
 msgid "Import OiRA Tool version"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:195
+#: euphorie/client/browser/settings.py:261
 msgid "Invalid password"
 msgstr "Lösenord"
 
@@ -568,7 +568,7 @@ msgstr "Lösenord"
 msgid "Invalid security token, try to request a new one"
 msgstr ""
 
-#: euphorie/client/browser/training.py:696
+#: euphorie/client/browser/training.py:716
 msgid "It seems you missed a slide"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "OiRA Tool"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:187
+#: euphorie/content/browser/upload.py:188
 msgid "OiRA Tool import"
 msgstr ""
 
@@ -846,7 +846,7 @@ msgid "Pass information to the people concerned."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:42
-#: euphorie/client/browser/settings.py:109
+#: euphorie/client/browser/settings.py:112
 #: euphorie/content/widgets/password.py:18
 msgid "Password doesn't compare with confirmation value"
 msgstr ""
@@ -1022,13 +1022,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:144
+#: euphorie/client/browser/settings.py:203
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:172
+#: euphorie/client/browser/settings.py:238
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Spara ändringar"
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Single occurance prompt"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:164
+#: euphorie/content/browser/upload.py:165
 msgid "Standard"
 msgstr "Standard"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
 
-#: euphorie/content/browser/module.py:45 euphorie/deployment/tiles/addbar.py:19
+#: euphorie/content/browser/module.py:20 euphorie/deployment/tiles/addbar.py:19
 msgid "Submodule"
 msgstr "Delmodul"
 
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:183
+#: euphorie/client/browser/settings.py:249
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:359
+#: euphorie/client/browser/settings.py:425
 msgid "This email address is not available."
 msgstr ""
 
@@ -1248,7 +1248,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:390
+#: euphorie/client/browser/settings.py:456
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1293,7 +1293,7 @@ msgstr ""
 msgid "Unvisited"
 msgstr ""
 
-#: euphorie/content/browser/upload.py:561
+#: euphorie/content/browser/upload.py:568
 msgid "Upload"
 msgstr "Ladda upp"
 
@@ -1410,7 +1410,7 @@ msgstr ""
 msgid "You need to specify a title for the organisation."
 msgstr ""
 
-#: euphorie/client/browser/training.py:694
+#: euphorie/client/browser/training.py:714
 msgid "You should start the training from the beginning"
 msgstr ""
 
@@ -1418,16 +1418,16 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:403
+#: euphorie/client/browser/settings.py:469
 msgid "Your email address has been updated."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:113
+#: euphorie/client/browser/settings.py:116
 msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:198
+#: euphorie/client/browser/settings.py:264
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1717,7 +1717,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:310
-#: euphorie/client/browser/settings.py:200
+#: euphorie/client/browser/settings.py:266
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Avbryt"
@@ -2298,7 +2298,7 @@ msgid "email_change_intro"
 msgstr "Ändra land/språk"
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:365
+#: euphorie/client/browser/settings.py:431
 msgid "email_change_pending"
 msgstr ""
 
@@ -2377,7 +2377,7 @@ msgid "error_invalid_login"
 msgstr "Inloggningsnamnet får endast bestå av små bokstäver och siffror."
 
 #. Default: "Please upload a valid XML file"
-#: euphorie/content/browser/upload.py:577
+#: euphorie/content/browser/upload.py:584
 msgid "error_invalid_xml"
 msgstr "Ladda upp en giltig XML-fil"
 
@@ -2574,7 +2574,7 @@ msgid "filename_report_timeline"
 msgstr "Handlingsplan ${title}.doc"
 
 #. Default: "Contents of OIRA tool ${title}"
-#: euphorie/content/browser/survey.py:445
+#: euphorie/content/browser/survey.py:478
 msgid "filename_tool_contents"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgid "header_launch"
 msgstr "Officiell lansering av projektet – september 2011"
 
 #. Default: "Legal and policy references"
-#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:311
+#: euphorie/client/docx/compiler.py:364 euphorie/content/browser/survey.py:344
 msgid "header_legal_references"
 msgstr "Rättsliga och politiska referenser"
 
@@ -3383,6 +3383,11 @@ msgstr ""
 "Generisk introduktion för klienten. Denna text är inte förknippade med "
 "specifika sidor."
 
+#. Default: "Do not include this module in the training, for example if the module does not have any relevance for workers."
+#: euphorie/content/behaviors/hide_from_training.py:13
+msgid "help_hide_from_training"
+msgstr ""
+
 #. Default: "This text should explain how the risk identification works."
 #: euphorie/content/help.py:63
 msgid "help_identification"
@@ -3535,7 +3540,7 @@ msgstr ""
 "Detta är det lösenord du behöver för att logga in på denna redaktörsmiljö."
 
 #. Default: "If you do not specify a title it will be taken from the input file."
-#: euphorie/content/browser/upload.py:139
+#: euphorie/content/browser/upload.py:140
 msgid "help_sector_title"
 msgstr "Om du inte specificerar en titel kommer den att tas från indatafilen."
 
@@ -3599,7 +3604,7 @@ msgstr ""
 "i klienterna."
 
 #. Default: "If you do not specify a title it will be taken from the input."
-#: euphorie/content/browser/upload.py:155
+#: euphorie/content/browser/upload.py:156
 msgid "help_upload_surveygroup_title"
 msgstr "Om du inte specificerar en titel den kommer att tas från indatan."
 
@@ -4154,7 +4159,7 @@ msgstr ""
 
 #. Default: "Already implemented measures"
 #: euphorie/client/browser/templates/webhelpers.pt:677
-#: euphorie/client/browser/training.py:286
+#: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
 
@@ -4194,7 +4199,7 @@ msgid "label_file_caption"
 msgstr ""
 
 #. Default: "First name"
-#: euphorie/client/browser/settings.py:127
+#: euphorie/client/browser/settings.py:130
 msgid "label_first_name"
 msgstr ""
 
@@ -4272,6 +4277,11 @@ msgstr "Rapporter"
 msgid "label_help_sessions"
 msgstr "Sessioner"
 
+#. Default: "Hide from training"
+#: euphorie/content/behaviors/hide_from_training.py:12
+msgid "label_hide_from_training"
+msgstr ""
+
 #. Default: "History"
 #: euphorie/client/browser/templates/more_menu.pt:26
 msgid "label_history"
@@ -4321,7 +4331,7 @@ msgid "label_involve"
 msgstr ""
 
 #. Default: "Import XML translation from eTranslate"
-#: euphorie/content/browser/upload.py:196
+#: euphorie/content/browser/upload.py:197
 msgid "label_is_etranslate_compatible"
 msgstr ""
 
@@ -4343,7 +4353,7 @@ msgid "label_language"
 msgstr "Språk"
 
 #. Default: "Last name"
-#: euphorie/client/browser/settings.py:130
+#: euphorie/client/browser/settings.py:133
 msgid "label_last_name"
 msgstr ""
 
@@ -4401,7 +4411,7 @@ msgid "label_login"
 msgstr "Login"
 
 #. Default: "Login name"
-#: euphorie/content/browser/upload.py:148 euphorie/content/user.py:85
+#: euphorie/content/browser/upload.py:149 euphorie/content/user.py:85
 msgid "label_login_name"
 msgstr "Inloggningsnamn"
 
@@ -4422,7 +4432,7 @@ msgid "label_logo_selection"
 msgstr "Vilken logotyp vill du visa i det övre vänstra hörnet?"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:70
+#: euphorie/client/browser/templates/preferences.pt:72
 msgid "label_mailings"
 msgstr ""
 
@@ -4497,13 +4507,13 @@ msgstr ""
 
 #. Default: "Desired password"
 #: euphorie/client/browser/reset_password.py:33
-#: euphorie/client/browser/settings.py:95
+#: euphorie/client/browser/settings.py:98
 #: euphorie/client/browser/templates/login.pt:195
 msgid "label_new_password"
 msgstr "Önskat lösenord"
 
 #. Default: "Again password"
-#: euphorie/client/browser/settings.py:100
+#: euphorie/client/browser/settings.py:103
 msgid "label_new_password_confirmation"
 msgstr ""
 
@@ -4594,7 +4604,7 @@ msgid "label_oira_consultants"
 msgstr ""
 
 #. Default: "Current Password"
-#: euphorie/client/browser/settings.py:90
+#: euphorie/client/browser/settings.py:93
 msgid "label_old_password"
 msgstr "Lösenord"
 
@@ -4636,7 +4646,7 @@ msgstr "Bekräfta lösenord"
 
 #. Default: "Planned measures"
 #: euphorie/client/browser/templates/webhelpers.pt:696
-#: euphorie/client/browser/training.py:289
+#: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
@@ -4665,7 +4675,7 @@ msgid "label_print_tool_preview"
 msgstr ""
 
 #. Default: "Negative statement"
-#: euphorie/content/browser/survey.py:288
+#: euphorie/content/browser/survey.py:321
 #: euphorie/content/browser/templates/risk_view.pt:84
 #: euphorie/content/risk.py:79
 msgid "label_problem_description"
@@ -4872,7 +4882,7 @@ msgid "label_sector_description"
 msgstr "Ange en beskrivning av din bransch"
 
 #. Default: "Title of sector."
-#: euphorie/content/browser/upload.py:138
+#: euphorie/content/browser/upload.py:139
 msgid "label_sector_title"
 msgstr "Bransch titel."
 
@@ -5038,7 +5048,7 @@ msgid "label_survey_title"
 msgstr "Version namn"
 
 #. Default: "Title of imported OiRA Tool"
-#: euphorie/content/browser/upload.py:154
+#: euphorie/content/browser/upload.py:155
 msgid "label_surveygroup_title"
 msgstr "Titel på importerad undersökning."
 
@@ -5154,12 +5164,12 @@ msgid "label_update"
 msgstr "Uppdatera"
 
 #. Default: "XML file"
-#: euphorie/content/browser/upload.py:169
+#: euphorie/content/browser/upload.py:170
 msgid "label_upload_filename"
 msgstr "XML-fil"
 
 #. Default: "Name for OiRA Tool version"
-#: euphorie/content/browser/upload.py:163
+#: euphorie/content/browser/upload.py:164
 msgid "label_upload_survey_title"
 msgstr "Namn på undersökningens version"
 
@@ -5411,7 +5421,7 @@ msgid "message_click_to_validate"
 msgstr ""
 
 #. Default: "This is the only version of the OiRA Tool and can therefore not be deleted. Did you perhaps want to remove the OiRA Tool itself?"
-#: euphorie/content/browser/survey.py:218
+#: euphorie/content/browser/survey.py:251
 msgid "message_delete_no_last_survey"
 msgstr "Du kan inte radera den enda undersökningens version."
 
@@ -5462,7 +5472,7 @@ msgid "message_member_see_all"
 msgstr ""
 
 #. Default: "You cannot delete an OiRA Tool version that is published. Please unpublish it first."
-#: euphorie/content/browser/survey.py:199
+#: euphorie/content/browser/survey.py:232
 msgid "message_no_delete_published_survey"
 msgstr "Du kan inte radera den enda undersökningens version."
 
@@ -5640,7 +5650,7 @@ msgid "navigation_help"
 msgstr "Hjälp"
 
 #. Default: "Logout"
-#: euphorie/client/browser/settings.py:83
+#: euphorie/client/browser/settings.py:86
 #: euphorie/client/browser/templates/webhelpers.pt:53
 msgid "navigation_logout"
 msgstr "Logga ut"
@@ -5723,32 +5733,27 @@ msgid "notice_filters_active"
 msgstr ""
 
 #. Default: "Notify when a risk assessment was not modified for ${days} days."
-#: euphorie/client/notifications/notification__ra_not_modified.py:62
+#: euphorie/client/notifications/notification__ra_not_modified.py:72
 msgid "notification_description__ra_not_modified"
 msgstr ""
 
 #. Default: "You have not modified your risk assessment for ${reminder_days} days. Please remember to keep your risk assessment up to date.\nWith this link you can access the risk assessment."
-#: euphorie/client/notifications/notification__ra_not_modified.py:23
+#: euphorie/client/notifications/notification__ra_not_modified.py:24
 msgid "notification_mail_body__ra_not_modified"
 msgstr ""
 
-#. Default: "Reminder: Update of risk assessment"
-#: euphorie/client/notifications/notification__ra_not_modified.py:36
+#. Default: "Reminder: Update of risk assessment (${num} open)"
+#: euphorie/client/notifications/notification__ra_not_modified.py:43
 msgid "notification_mail_subject__ra_not_modified"
 msgstr ""
 
 #. Default: "Hello ${full_name},\n\n${main_text}\n\n${session_links}\n\nBest regards\nYour OiRA Team\n\n**This is an automatically generated mail. If you do not want to receive mails from OiRA, you can change this [here](${preferences_link})**"
-#: euphorie/client/notifications/base.py:44
+#: euphorie/client/notifications/base.py:52
 msgid "notification_mail_text__base"
 msgstr ""
 
-#. Default: "You are receiving this because you are subscribed to notifications from ${site_name}."
-#: euphorie/client/mails/templates/email_notification_template.pt:188
-msgid "notification_received_reason"
-msgstr ""
-
 #. Default: "Notify on orphaned risk assessments."
-#: euphorie/client/notifications/notification__ra_not_modified.py:52
+#: euphorie/client/notifications/notification__ra_not_modified.py:62
 msgid "notification_title__ra_not_modified"
 msgstr ""
 
@@ -6246,17 +6251,17 @@ msgid "title_about"
 msgstr "Om"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:213
+#: euphorie/client/browser/settings.py:279
 msgid "title_account_delete"
 msgstr "Dokumentation"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:249
+#: euphorie/client/browser/settings.py:315
 msgid "title_change_email"
 msgstr ""
 
 #. Default: "Change password"
-#: euphorie/client/browser/settings.py:65
+#: euphorie/client/browser/settings.py:68
 msgid "title_change_password"
 msgstr ""
 
@@ -6296,12 +6301,12 @@ msgid "title_help_unpublished"
 msgstr "Publicera den markerade undersökningen med de senaste ändringarna."
 
 #. Default: "Personal details"
-#: euphorie/client/browser/templates/preferences.pt:43
+#: euphorie/client/browser/templates/preferences.pt:45
 msgid "title_personal_details"
 msgstr ""
 
 #. Default: "Preferences"
-#: euphorie/client/browser/settings.py:59
+#: euphorie/client/browser/settings.py:62
 msgid "title_preferences"
 msgstr ""
 
@@ -6403,7 +6408,7 @@ msgstr ""
 "alla användare."
 
 #. Default: "Succesfully imported the OiRA Tool"
-#: euphorie/content/browser/upload.py:582
+#: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Undersökningen har importerats"
 


### PR DESCRIPTION
This removes the session title references, removes wording which references the title in the subject and introduces some plural forms.

Note: i18ndude cannot extract the plural forms. So currently only the plural default message is used. There is no problem with the singular form.
See: https://github.com/collective/i18ndude/issues/112