### PR TITLE
Add versions.cfg

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,2 @@
+[buildout]
+extends = versions-5.2.cfg


### PR DESCRIPTION
When running buildout from another repo which extend the Euphories versions.cfg via raw urls I get this error:
```
daimler@daimler:~/daimler.buildout$ make 
./py3/bin/buildout -Nt 2
While:
  Initializing.
Error: Error downloading extends for URL https://raw.githubusercontent.com/euphorie/Euphorie/main/versions.cfg: HTTP Error 404: Not Found
make: *** [Makefile:11: .installed.cfg] Error 1
```

This PR adds a versions.cfg which extends versions-5.2.cfg to allow buildout run without creating a symlink to a preferred Plone version, so that buildout.cfg can be referenced via GitHub raw URLs.