### PR TITLE
Do not log anymore not found exceptions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changelog
 16.0.0 (unreleased)
 -------------------
 
+- Do not log anymore not found exceptions
+  [ale-rt]
+
 - Allow the client skin layer to be customized by other packages.
   [ale-rt]
 

--- a/src/euphorie/client/browser/error.py
+++ b/src/euphorie/client/browser/error.py
@@ -21,7 +21,6 @@ class ErrorView(BrowserView):
     def __call__(self):
         self.exception = aq_inner(self.context)
         self.context = aq_parent(self)
-        log.exception("Error at %r", self.context)
         error_type = self.exception.__class__.__name__
         exc_type, value, traceback = sys.exc_info()
         error_tb = "".join(format_exception(exc_type, value, traceback, as_html=False))


### PR DESCRIPTION
This saves the log from this stuff:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 176, in transaction_pubevents
    yield
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 385, in publish_module
    response = _publish(request, new_mod_info)
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/WSGIPublisher.py", line 264, in publish
    obj = request.traverse(path, validated_hook=validate_user)
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/BaseRequest.py", line 535, in traverse
    return response.notFoundError(URL)
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/HTTPResponse.py", line 998, in notFoundError
    raise exc
zExceptions.NotFound: https://instrumenten.rie.nl/nl/@@index_html
2024-02-06 10:58:35,562 ERROR   [euphorie.client.browser.error:24][waitress-0] Error at <Client at /Plone/client>
Traceback (most recent call last):
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/BaseRequest.py", line 518, in traverse
    subobject = self.traverseName(object, entry_name)
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/BaseRequest.py", line 349, in traverseName
    ob2 = adapter.publishTraverse(self, name)
  File "/srv/s-oira/.buildout/eggs/cp38/tno.euphorie-10.0.1-py3.8.egg/tno/euphorie/client/client.py", line 32, in publishTraverse
    return super(ClientPublishTraverser, self).publishTraverse(request, name)
  File "/srv/s-oira/.buildout/eggs/cp38/Zope-4.8.10-py3.8.egg/ZPublisher/BaseRequest.py", line 136, in publishTraverse
    subobject = object[name]
  File "/srv/s-oira/.buildout/eggs/cp38/plone.folder-3.1.0-py3.8.egg/plone/folder/ordered.py", line 235, in __getitem__
    raise KeyError(key)
KeyError: 'wp-login.php'
```