### PR TITLE
Use always_present_default in treeChanges.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 16.1.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix change detection when tool has been updated
+  Ref: scrum-2030
 
 
 16.1.0 (2024-03-05)

--- a/src/euphorie/client/update.py
+++ b/src/euphorie/client/update.py
@@ -1,4 +1,5 @@
 from euphorie.client import model
+from euphorie.client.profile import always_present_default
 from euphorie.client.utils import HasText
 from euphorie.content.interfaces import IQuestionContainer
 from z3c.saconfig import Session
@@ -117,7 +118,10 @@ def treeChanges(session, survey, profile=None):
                     # skipped.
                     results.add((entry["zodb_path"], nodes[0].type, "modified"))
             if node.type == entry["type"] == "risk":
-                if entry["always_present"] and node.identification != "no":
+                if (
+                    entry["always_present"]
+                    and node.identification != always_present_default
+                ):
                     results.add((entry["zodb_path"], node.type, "modified"))
                 if entry["risk_type"] != node.risk_type:
                     results.add((entry["zodb_path"], node.type, "modified"))


### PR DESCRIPTION
Fixes detection of changes in case `always_present_default` is not "no", e.g. when it has been patched.

Fixes syslabcom/scrum#2030

See also syslabcom/daimler.oira#281