### PR TITLE
Clean up references to guest accounts in last_modifier_id

### DIFF
--- a/src/euphorie/upgrade/deployment/v1/20240423105626_clean_up_last_modifier_id/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20240423105626_clean_up_last_modifier_id/upgrade.py
@@ -1,0 +1,33 @@
+from euphorie.client.model import Account
+from euphorie.client.model import Session
+from euphorie.client.model import SurveySession
+from ftw.upgrade import UpgradeStep
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class CleanUpLastModifierId(UpgradeStep):
+    """Clean up last_modifier_id."""
+
+    def __call__(self):
+        session = Session()
+        obsolete_guest_users = (
+            session.query(Account, SurveySession)
+            .filter(Account.id == SurveySession.last_modifier_id)
+            .filter(Account.id != SurveySession.account_id)
+            .filter(Account.account_type == "guest")
+        )
+        for guest_user, assessment in obsolete_guest_users:
+            assessment.last_modifier_id = assessment.account_id
+            logger.info("Updated session %s", assessment.id)
+            num_assessments = (
+                session.query(SurveySession)
+                .filter(SurveySession.account_id == guest_user.id)
+                .count()
+            )
+            if num_assessments == 0:
+                session.delete(guest_user)
+                logger.info("Deleted user %s", guest_user.id)


### PR DESCRIPTION
In acc2353126 (#719) we changed `transferGuestSession` to update `last_modifier_id` and delete the guest account after all sessions have been transferred. This upgrade step does a similar thing with existing sessions. We don't update the modification date because we don't know when the session was transferred. We also double check that the guest account doesn't have any sessions associated with it so that we can safely delete it.

Fixes syslabcom/scrum#2155