### PR TITLE
Scrum 2193  notifications allow user settings

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,12 @@ Changelog
 16.1.3 (unreleased)
 -------------------
 
+- Add registry setting `euphorie.notifications__allow_user_settings` to allow users to change their notification settings.
+  The default is set to `True` to allow users to do changes on their own.
+  This can be prevented if internal policies require so by changing this setting to `False`.
+  Ref: scrum-2193
+  [thet]
+
 - Support scaled answers.
   These are answers on a scale from usually 1-5, instead of only yes/no.
   [ale-rt, maurits]

--- a/src/euphorie/client/browser/settings.py
+++ b/src/euphorie/client/browser/settings.py
@@ -152,6 +152,12 @@ class Preferences(AutoExtensibleForm, form.Form):
         )
 
     @property
+    def allow_notification_settings(self):
+        return api.portal.get_registry_record(
+            "euphorie.notifications__allow_user_settings", default=True
+        )
+
+    @property
     @memoize
     def current_user(self):
         return get_current_account()
@@ -221,7 +227,7 @@ class Preferences(AutoExtensibleForm, form.Form):
         user.first_name = data["first_name"]
         user.last_name = data["last_name"]
 
-        if self.show_notifications:
+        if self.show_notifications and self.allow_notification_settings:
             for notification in self.all_notifications:
                 if self.request.get("notifications", {}).get(notification.id):
                     self.subscribe_notification(notification.id)

--- a/src/euphorie/client/browser/templates/preferences.pt
+++ b/src/euphorie/client/browser/templates/preferences.pt
@@ -67,13 +67,27 @@
                         notifications view/all_notifications;
                       "
                       tal:condition="python: view.show_notifications and notifications"
+                      tal:attributes="
+                        disabled not:view/allow_notification_settings|nothing;
+                      "
             >
 
               <h3 class="form-separation-header"
                   i18n:translate="label_notifications"
               >Notifications
               </h3>
-              <fieldset class="pat-checklist group checkbox">
+
+              <div class="pat-message notice"
+                   tal:condition="not:view/allow_notification_settings"
+                   i18n:translate="message_disallow_notification_settings"
+              >
+                  Due to an internal policy, these settings cannot be changed.
+              </div>
+
+
+              <fieldset class="pat-checklist group checkbox"
+                        style="${python:'' if view.allow_notification_settings else 'opacity: 0.5'}"
+              >
                 <tal:loop repeat="notification notifications">
                   <label class="">
                     <input checked="${python:'checked' if getattr(view.existing_notification_subscriptions.get(notification.id, None), 'enabled', notification.default) else None}"

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: bg <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgstr "Добавяне на потребител"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Допълнителна мярка"
 
@@ -184,16 +184,20 @@ msgstr "Всички езици"
 msgid "Almost done&hellip;"
 msgstr "Почти готово&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Получи се грешка при изпращане на имейл потвърждението."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -218,7 +222,7 @@ msgstr ""
 "Сигурни ли сте, че искате да продължите? След това действие рискът не може "
 "да се възстанови."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -314,7 +318,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Потвърждаване на промяна на OiRA имейл адрес"
 
@@ -574,7 +578,7 @@ msgstr ""
 "разполагате, а по-късно, при възможност,  да продължите от мястото, където "
 "сте прекъснали."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Искам да споделя следното с вас"
 
@@ -605,13 +609,13 @@ msgstr "Информация"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Невалиден формат на файла на изображението. Моля, използвайте PNG, JPEG или "
 "GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Невалидна парола"
 
@@ -683,7 +687,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Мярка"
@@ -951,7 +955,7 @@ msgstr "Прегледайте примерите под формуляра."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Отложено разглеждане"
 
@@ -1095,11 +1099,11 @@ msgstr "Оценки на риска"
 msgid "Risk assessments made with this tool"
 msgstr "Оценка на риска, извършена с този инструмент"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Правилно"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Внимание"
 
@@ -1112,13 +1116,13 @@ msgid "Run slideshow"
 msgstr "Пускане на слайдшоу"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Запазване"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Запазване на промените"
@@ -1191,7 +1195,7 @@ msgstr "Съобщение за еднократна поява"
 msgid "Standard"
 msgstr "Стандарт"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Основни мерки"
 
@@ -1208,7 +1212,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Започнете въпросите"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1254,7 +1258,7 @@ msgstr ""
 "Основната структура на Инструмента за онлайн интерактивна оценка на риска се "
 "състои от:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Нямаше направени промени, които да бъдат запазени."
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Този имейл адрес не е наличен."
 
@@ -1357,7 +1361,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1398,7 +1402,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Без отговор"
 
@@ -1413,6 +1417,10 @@ msgstr "Поставяне на изображение, което илюстр�
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Поставяне на изображение"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1555,7 +1563,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Приключихте с обучителните слайдове!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Вашият имейл адрес беше актуализиран."
 
@@ -1564,7 +1572,7 @@ msgid "Your password for confirmation"
 msgstr "Вашата парола за потвърждение"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Вашата парола беше променена успешно."
 
@@ -1700,28 +1708,28 @@ msgid "about_partners_3_smb"
 msgstr "микро- и малките предприятия имат някои недостатъци"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Опишете специфични мерки, необходими за намаляване на риска."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Изберете или опишете специфични мерки, необходими за намаляване на риска."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Опишете други мерки за намаляване на риска."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Изберете или опишете други мерки за намаляване на риска."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Макар и да има някои мерки, които не са свързани с разходи, повечето са. "
@@ -1729,7 +1737,7 @@ msgstr ""
 "годишния бюджет, ако е необходимо."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Назначете някой във Вашата фирма, който да поеме отговорността за "
@@ -1738,7 +1746,7 @@ msgstr ""
 "изпълнени."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Опишете: 1) какъв е общият Ви подход за елиминиране или (ако рискът е "
@@ -1746,7 +1754,7 @@ msgstr ""
 "за да бъде следван подходът (за елиминиране или намаляване на риска)"
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Опишете: 3) експертното ниво, което е необходимо, за да бъде изпълнена "
@@ -1837,7 +1845,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: положителни твърдения, които се съдържат в модули."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Добави"
 
@@ -1878,7 +1886,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Отменяне"
@@ -2146,8 +2154,8 @@ msgstr "Вид на обработваните данни"
 #: euphorie/client/browser/templates/conditions-bare.pt:68
 msgid "conditions_part5_entry"
 msgstr ""
-"Обработването се основава на член 5, параграф 1, букви а) и г) от <a href="
-"\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
+"Обработването се основава на член 5, параграф 1, букви а) и г) от <a "
+"href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
 "L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Регламент (ЕС) "
 "2018/1725</a> на Европейския парламент и на Съвета от 23 октомври 2018 г. "
 "относно защитата на физическите лица във връзка с обработването на лични "
@@ -2292,7 +2300,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Моля, отбележете всичко, което бихте искали да отпадне от обучението. "
@@ -2300,7 +2308,7 @@ msgstr ""
 "обучението."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Оценката на риска е  извършена автоматично от инструмента. Ще имате "
@@ -2485,17 +2493,17 @@ msgid "effect_high"
 msgstr "Високо (много високо) ниво на сериозност"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Ниско ниво на сериозност"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Значително ниво на сериозност"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Високо (много високо) ниво на сериозност"
 
@@ -2544,7 +2552,7 @@ msgstr ""
 "'${email}', когато кликнете върху връзката за потвърждаване по-долу."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Моля, потвърдете новия си имейл адрес, като кликнете върху връзката в имейл "
@@ -2602,7 +2610,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 до 249 служители"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Акаунт с този имейл адрес вече съществува."
 
@@ -2612,12 +2620,12 @@ msgid "error_existing_login"
 msgstr "Това име за вход вече се използва."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Моля, въведете бюджета в цели евро."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Моля, въведете валиден имейл адрес"
 
@@ -2632,65 +2640,65 @@ msgid "error_invalid_xml"
 msgstr "Моля, качете валиден XML файл"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Моля, въведете своя имейл адрес"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Моля, въведете парола"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Паролите не съвпадат"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Паролата трябва да е дълга поне 12 символа и е необходимо да съдържа поне "
 "една малка буква, голяма буква и един символ."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Тази дата трябва да съвпада или да е след началната дата."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Тази дата трябва да е преди или да съвпада с крайната дата."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Тази стойност трябва да е положително цяло число."
 
@@ -2801,7 +2809,7 @@ msgstr ""
 "продължите, е необходимо да актуализирате тези промени."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2833,7 +2841,7 @@ msgstr "Идентификационен доклад ${title}"
 msgid "filename_report_timeline"
 msgstr "Времева скала за ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2854,7 +2862,7 @@ msgid "french"
 msgstr "Опростени два критерия"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Почти никога"
 
@@ -2864,57 +2872,57 @@ msgid "frequency_almostnever"
 msgstr "Почти никога"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Постоянно"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Не много често"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Веднъж месечно"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Често"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Един път седмично"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Рядко"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Веднъж годишно"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Много често или редовно"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Най-малко един път на ден"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Редовно"
@@ -2940,12 +2948,12 @@ msgid "header_additional_content"
 msgstr "Допълнителна информация"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Допълнителни ресурси за оценка на риска"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Допълнителни ресурси за този модул"
 
@@ -3187,23 +3195,23 @@ msgid "header_risk_aware"
 msgstr "Знаете ли за всички рискове?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Какво е нивото на сериозност на нараняването ?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Колко често хора са изложени на риск?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Изберете приоритета на този риск"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Каква е вероятността това да се случи?"
 
@@ -3267,7 +3275,7 @@ msgid "header_settings"
 msgstr "Настройки"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Стандартни мерки"
 
@@ -3508,7 +3516,7 @@ msgid "help_authentication"
 msgstr "Този текст трябва да обяснява как се извършва регистрация и вход."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Попълнете отговорите на следните въпроси. Въз основа на вашите отговори "
@@ -3541,7 +3549,7 @@ msgstr ""
 "започнете с копие на съществуващ OiRA инструмент.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Посочете колко често този риск се среща в нормална ситуация."
 
@@ -3553,12 +3561,12 @@ msgstr ""
 "подразбиране. Той/тя все пак ще може да промени приоритета."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Посочете колко вероятно е този риск да се срещне в нормална ситуация."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Посочете сериозността, ако този риск възникне."
 
@@ -4181,13 +4189,13 @@ msgstr "Акаунтът е заключен"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "План за действие"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Бюджет"
@@ -4199,21 +4207,21 @@ msgstr "План за действие"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Планиране на края"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Кой носи отговорност?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Планиране на началото"
@@ -4236,7 +4244,7 @@ msgid "label_alphabetical"
 msgstr "Азбучен ред"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Оценяване"
 
@@ -4328,7 +4336,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4414,7 +4422,7 @@ msgid "label_delete_risk"
 msgstr "Вие сте на път да изтриете риска:  &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Описание"
@@ -4460,7 +4468,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Оценяване"
 
@@ -4486,7 +4494,7 @@ msgid "label_existing_measure"
 msgstr "Мерки, които вече са изпълнени"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4497,7 +4505,7 @@ msgid "label_exit"
 msgstr "Изход"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Знания и умения"
 
@@ -4512,7 +4520,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Добави мерки"
 
@@ -4617,7 +4625,7 @@ msgstr "История"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Определяне"
 
@@ -4627,7 +4635,7 @@ msgid "label_image"
 msgstr "Файл с изображение"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Приложена мярка"
 
@@ -4654,7 +4662,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Включване"
 
@@ -4702,8 +4710,8 @@ msgstr "Научете повече за OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Правни източници и източници от политики"
 
@@ -4766,7 +4774,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Общ подход (за елиминиране или намаляване на риска)"
@@ -4779,7 +4787,7 @@ msgstr "Конкретни действия, които се изискват, �
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Експертно ниво и/или изисквания, които са необходими"
@@ -4914,12 +4922,12 @@ msgstr "Не, необходими са допълнителни мерки."
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Бележки"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4975,14 +4983,14 @@ msgid "label_password_confirm"
 msgstr "Паролата отново"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Вече въведени мерки Планирани мерки"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Подготовка"
 
@@ -5075,13 +5083,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Изтрий тази мярка"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Доклад"
 
@@ -5225,7 +5233,7 @@ msgid "label_select_assessment"
 msgstr "Изберете оценка на риска"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Изберете една или повече от предлаганите общи мерки."
 
@@ -5245,7 +5253,7 @@ msgid "label_select_oira_tool"
 msgstr "Изберете OiRA инструмент"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Изберете основни мерки"
 
@@ -5721,8 +5729,8 @@ msgid "menu_import"
 msgstr "Импортиране на OiRA инструмент"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Обучение"
 
@@ -5773,13 +5781,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Не можете да изтриете единствената версия на OiRA инструмента."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Моля, попълнете това поле."
 
@@ -6033,7 +6046,7 @@ msgstr "Настройки"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Статус"
 
@@ -6181,14 +6194,14 @@ msgstr ""
 "OiRA, схемата за обучение на OiRA и помощният отдел на OiRA бъдат готови."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Този коментар ще бъде видим в доклада. Използвайте го за всяка информация, "
 "която искате да добавите за този риск."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Тези бележки ще бъдат видими в доклада и обученията. За да ги използвате за "
@@ -6217,45 +6230,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Висок"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Нисък"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Среден"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Голяма"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Средна"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Малка"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% завършен"
 
@@ -6323,7 +6336,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6336,7 +6349,7 @@ msgstr ""
 "предимства:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6406,25 +6419,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Това е ${priority_value} приоритетен риск."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "високо"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "ниско"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "средно"
@@ -6440,7 +6453,7 @@ msgid "risk_show_na_na"
 msgstr "не е приложимо"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Мярка ${number}"
 
@@ -6505,46 +6518,46 @@ msgstr ""
 "добре да излизате активно."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Не много високо ниво на сериозност"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Необходимо е спиране на работа за по-малко от 3 дни"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Високо ниво на сериозност"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Необходимо е спиране на работа за повече от три дни"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Много високо ниво на серозност"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "необратими наранявания, неизлечима болест, смърт"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Ниско ниво на сериозност"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Не е необходимо спиране на работа"
 
@@ -6644,12 +6657,12 @@ msgid "title_about"
 msgstr "За нас"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Изтриване на акаунт"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-08-08 12:36+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -167,7 +167,7 @@ msgstr "Afegir usuari"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Mesura addicional"
 
@@ -187,16 +187,20 @@ msgstr "Tots els idiomes"
 msgid "Almost done&hellip;"
 msgstr "Gairebé acabat&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "S'ha produït un error en enviar el correu electrònic de confirmació."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -219,7 +223,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Està segur que vol continuar? Aquesta acció no es pot revertir."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -313,7 +317,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Confirmar el canvi de l'adreça electrònica d'OiRA"
 
@@ -573,7 +577,7 @@ msgstr ""
 "Tanmateix, podeu utilitzar les estones de què disposeu i reprendre "
 "l’avaluació en un altre moment en el mateix punt en què la vareu deixar."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Voldria compartir el següent enllaç"
 
@@ -604,13 +608,13 @@ msgstr "Informació"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "El format de fitxer de l’imatge no és vàlid. Si us plau, utilitzeu PNG, JPEG "
 "o GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Contrasenya no vàlida"
 
@@ -681,7 +685,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Mesura"
@@ -951,7 +955,7 @@ msgstr "Si us plau, consulteu els exemples a la part inferior:"
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Posposat"
 
@@ -1094,11 +1098,11 @@ msgstr "Avaluacions de riscos"
 msgid "Risk assessments made with this tool"
 msgstr "Avaluacions de riscos realitzades amb aquesta eina"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Correcte"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Actuar"
 
@@ -1111,13 +1115,13 @@ msgid "Run slideshow"
 msgstr "Iniciar la presentació"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Desar"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Desar els canvis"
@@ -1189,7 +1193,7 @@ msgstr "Localització única"
 msgid "Standard"
 msgstr "Estàndard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Mesures pre-establertes"
 
@@ -1206,7 +1210,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Començar amb les preguntes"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1252,7 +1256,7 @@ msgstr ""
 "L’estructura bàsica d’una avaluació de riscos interactiva en línia "
 "consisteix en:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "No hi ha cap canvi per desar."
 
@@ -1318,7 +1322,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Aquesta adreça electrònica no està disponible."
 
@@ -1355,7 +1359,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1396,7 +1400,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "No respost"
 
@@ -1411,6 +1415,10 @@ msgstr "Carregar una imatge que il·lustri aquest risc."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Carregar una imatge"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1544,7 +1552,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Ha acabat la presentación de la formació!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "S'ha actualitzat l'adreça electrònica."
 
@@ -1553,7 +1561,7 @@ msgid "Your password for confirmation"
 msgstr "Contrasenya de confirmació"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "La contrasenya s'ha modificat correctament."
 
@@ -1688,29 +1696,29 @@ msgid "about_partners_3_smb"
 msgstr "les micro i petites empreses presenten algunes deficiències"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Descriviu les mesures específiques necessàries per reduir el risc."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Seleccioneu o descriviu les mesures específiques necessàries per reduir el "
 "risc"
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Descriviu qualsevol altra mesura per reduir el risc."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Seleccioneu o descriviu qualsevol altra mesura per reduir el risc."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Tot i que hi ha mesures que no comporten despeses, no són majoria. Per tant, "
@@ -1718,7 +1726,7 @@ msgstr ""
 "anual."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Nomeni una persona de l'empresa que sigui responsable de la implementació "
@@ -1726,7 +1734,7 @@ msgstr ""
 "descrits al pla i/o la responsabilitat d'assegurar-se que es duguin a terme."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descrigui: 1) el seu enfocament general pel que fa a l'eliminació o —si el "
@@ -1734,7 +1742,7 @@ msgstr ""
 "requereixen per implementar aquest enfocament (per eliminar o reduir el risc)"
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Descrigui: 3) el nivell de competència necessari per implementar la mesura, "
@@ -1824,7 +1832,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: sentències positives, incloses als mòduls."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Afegir"
 
@@ -1865,7 +1873,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Cancel·lar"
@@ -2137,8 +2145,8 @@ msgstr "Tipus de dades tractades"
 #: euphorie/client/browser/templates/conditions-bare.pt:68
 msgid "conditions_part5_entry"
 msgstr ""
-"El tractament es basa en els apartats d) i a) de l'article 5.1 del <a href="
-"\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
+"El tractament es basa en els apartats d) i a) de l'article 5.1 del <a "
+"href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
 "L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Reglament (UE) "
 "2018/1725</a> del Parlament Europeu i del Consell, de 23 d’octubre de 2018, "
 "relatiu a la protecció de les persones físiques pel que fa al tractament de "
@@ -2284,14 +2292,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Si us plau, marqueu allò que vulgueu excloure de la formació. Els elements "
 "que estiguin deshabilitats no es mostraran en el contingut de la formació."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "L'avaluació de riscos ha estat efectuada automàticament per l'eina. Podreu "
@@ -2472,17 +2480,17 @@ msgid "effect_high"
 msgstr "Gravetat elevada (molt elevada)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Gravetat baixa"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Gravetat significativa"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Gravetat elevada (molt elevada)"
 
@@ -2530,7 +2538,7 @@ msgstr ""
 "${email} quan faci clic a l'enllaç de confirmació que trobarà a continuació."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Confirmi l'adreça electrònica nova fent clic a l'enllaç que s'enviarà d'aquí "
@@ -2588,7 +2596,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "de 50 a 249 treballadors"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Ja hi ha un compte amb aquesta adreça electrònica."
 
@@ -2598,12 +2606,12 @@ msgid "error_existing_login"
 msgstr "Aquest nom d'inici de sessió ja està ocupat."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Introdueixi el pressupost mitjançant un import enter en euros."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Introdueixi una adreça electrònica vàlida"
 
@@ -2620,65 +2628,65 @@ msgid "error_invalid_xml"
 msgstr "Pugi un fitxer XML vàlid"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Introdueixi l'adreça electrònica"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Introdueixi una contrasenya"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Les contrasenyes no coincideixen"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "La contrasenya ha de tenir almenys 12 caràcters i ha de contenir almenys una "
 "lletra minúscula, una lletra majúscula i un dígit."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Aquesta data ha de ser la data final o una data posterior."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Aquesta data ha de ser la data final o una data anterior."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Aquest valor ha de ser un número enter positiu."
 
@@ -2789,7 +2797,7 @@ msgstr ""
 "de continuar, cal actualitzar aquests canvis."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 "Aquest risc s’ha establert com a existent per defecte. No es pot canviar."
@@ -2822,7 +2830,7 @@ msgstr "Informe d'identificació ${title}"
 msgid "filename_report_timeline"
 msgstr "Pla d'acció per a ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2843,7 +2851,7 @@ msgid "french"
 msgstr "Dos criteris simplificats"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Gairebé mai"
 
@@ -2853,57 +2861,57 @@ msgid "frequency_almostnever"
 msgstr "Gairebé mai"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Constantment"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "No gaire sovint"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Un cop per mes"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Sovint"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Un cop per setmana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Poc freqüent"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Un cop per any"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Amb molta freqüència o regularitat"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Com a mínim un cop per dia"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Freqüentment"
@@ -2928,12 +2936,12 @@ msgid "header_additional_content"
 msgstr "Contingut addicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Recursos addicionals per avaluar el risc"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Recursos additionals per a aquest mòdul"
 
@@ -3177,23 +3185,23 @@ msgid "header_risk_aware"
 msgstr "És conscient de tots els riscos?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Fins a quin punt és greu aquest dany?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Amb quina freqüència hi ha persones exposades a aquest risc?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Seleccioni la prioritat d'aquest risc"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Quina probabilitat hi ha que es produeixi aquest risc?"
 
@@ -3259,7 +3267,7 @@ msgid "header_settings"
 msgstr "Configuració"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Mesures estàndard"
 
@@ -3503,7 +3511,7 @@ msgstr ""
 "Aquest text hauria d'explicar com realitzar el registre i l'inici de sessió."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Si us plau, contesteu les preguntes següents. A partir de les vostres "
@@ -3536,7 +3544,7 @@ msgstr ""
 "una còpia d'una eina OiRA existent."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Indiqui amb quina freqüència es produeix aquest risc en una situació normal."
@@ -3549,13 +3557,13 @@ msgstr ""
 "així, l'usuari final podrà modificar-la."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Indiqui la probabilitat que es produeixi aquest risc en una situació normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Indiqui la gravetat en cas de produir-se aquest risc."
 
@@ -4173,13 +4181,13 @@ msgstr "El compte està bloquejat"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Pla d'acció"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Pressupost"
@@ -4191,21 +4199,21 @@ msgstr "Pla d'acció"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Final de la planificació"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Qui n'és responsable?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Inici de la planificació"
@@ -4228,7 +4236,7 @@ msgid "label_alphabetical"
 msgstr "Alfabèticament"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Avaluació"
 
@@ -4320,7 +4328,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4406,7 +4414,7 @@ msgid "label_delete_risk"
 msgstr "Està a punt de suprimir el risc: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Descripció"
@@ -4452,7 +4460,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Avaluació"
 
@@ -4478,7 +4486,7 @@ msgid "label_existing_measure"
 msgstr "Mesura implementada"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Mesures ja implementades"
@@ -4489,7 +4497,7 @@ msgid "label_exit"
 msgstr "Sortir"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Expertesa"
 
@@ -4504,7 +4512,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Afegir altres mesures"
 
@@ -4609,7 +4617,7 @@ msgstr "Historial"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identificació"
 
@@ -4619,7 +4627,7 @@ msgid "label_image"
 msgstr "Fitxer d'imatge"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Mesura implementada"
 
@@ -4646,7 +4654,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Implicació"
 
@@ -4694,8 +4702,8 @@ msgstr "Més informació sobre OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Referències legals i sobre polítiques"
 
@@ -4758,7 +4766,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Enfocament general (per eliminar o reduir el risc)"
@@ -4771,7 +4779,7 @@ msgstr "Accions concretes requerides per implementar aquest enfocament"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Nivell de competència i/o requisits necessaris"
@@ -4904,12 +4912,12 @@ msgstr "No, calen més mesures"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Notes"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4965,14 +4973,14 @@ msgid "label_password_confirm"
 msgstr "Repetiu la contrasenya"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Mesures planificades"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Preparació"
 
@@ -5064,13 +5072,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Esborrar aquesta mesura"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Informe"
 
@@ -5214,7 +5222,7 @@ msgid "label_select_assessment"
 msgstr "Seleccioneu una avaluació de riscos"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Seleccioni una o més de les mesures comunes facilitades."
 
@@ -5233,7 +5241,7 @@ msgid "label_select_oira_tool"
 msgstr "Seleccioneu una eina OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Seleccionar mesures pre-establertes"
 
@@ -5706,8 +5714,8 @@ msgid "menu_import"
 msgstr "Importar una eina OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Formació"
 
@@ -5756,13 +5764,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "No es pot suprimir la versió única de l'eina OiRA."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Manquen dades obligatòries."
 
@@ -6016,7 +6029,7 @@ msgstr "Configuració"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Grau d’emplenament"
 
@@ -6167,14 +6180,14 @@ msgstr ""
 "d'OiRA."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Aquest comentari serà visible a l’informe. Utilitzeu-lo per a qualsevol "
 "altra cosa que vulgueu escriure sobre aquest risc."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Aquestes notes seran visibles a l'informe i a la formació. Utilitzeu-les per "
@@ -6203,45 +6216,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Elevada"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Baixa"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Mitjana"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Elevada"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Mitjana"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Baixa"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Complet"
 
@@ -6309,7 +6322,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6321,7 +6334,7 @@ msgstr ""
 "descarregar. Registreu-vos en un sol pas i accedireu als avantatges següents:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6389,25 +6402,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Aquest és un risc de prioritat ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "elevada"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "baixa"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "mitjana"
@@ -6423,7 +6436,7 @@ msgid "risk_show_na_na"
 msgstr "no aplicable"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Mesura ${number}"
 
@@ -6487,46 +6500,46 @@ msgstr ""
 "motius de seguretat, és millor la primera opció."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "No gaire greu"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Cal interrompre la feina menys de 3 dies"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Greu"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Cal interrompre la feina més de 3 dies"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Molt greu"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Lesions irreversibles, malaltia incurable, mort"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Baixa"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "No cal interrompre la feina"
 
@@ -6599,8 +6612,8 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session-test.pt:95
 msgid "testsession_register"
 msgstr ""
-"O bé ${register_link}. Descobriu per què us hauríeu de registrar"
-"${tooltip_register}."
+"O bé ${register_link}. Descobriu per què us hauríeu de "
+"registrar${tooltip_register}."
 
 #. Default: "add all measures that have already been implemented"
 #: euphorie/content/utils.py:58
@@ -6623,12 +6636,12 @@ msgid "title_about"
 msgstr "Quant a"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Suprimir el compte"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgstr "Přidat uživatele"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Další opatření"
 
@@ -179,16 +179,20 @@ msgstr "Všechny jazyky"
 msgid "Almost done&hellip;"
 msgstr "Téměř hotovo&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Při odesílání potvrzujícího e-mailu se vyskytla chyba."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -211,7 +215,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Jste si jisti, že chcete pokračovat? Tuto akci nelze vrátit zpět."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -305,7 +309,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Potvrďte změnu e-mailové adresy OiRA"
 
@@ -562,7 +566,7 @@ msgid ""
 "off."
 msgstr " "
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Chci se s vámi podělit o následující informace"
 
@@ -593,11 +597,11 @@ msgstr "Informace"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Neplatný formát obrázku. Použijte PNG, JPEG nebo GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Neplatné heslo"
 
@@ -669,7 +673,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Opatření"
@@ -934,7 +938,7 @@ msgstr "Viz příklady uvedené pod formulářem."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Odloženo"
 
@@ -1077,11 +1081,11 @@ msgstr "Hodnocení rizik"
 msgid "Risk assessments made with this tool"
 msgstr "Hodnocení rizik provedená tímto nástrojem."
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Pozornost"
 
@@ -1094,13 +1098,13 @@ msgid "Run slideshow"
 msgstr "Spustit prezentaci"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Uložit"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Uložit změny"
@@ -1171,7 +1175,7 @@ msgstr "Upozornění o jediném výskytu"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Standardní opatření"
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Spusťte otázky"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1232,7 +1236,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Základní struktura on-line interaktivního hodnocení rizik obsahuje:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1283,7 +1287,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Nebyly uloženy žádné změny."
 
@@ -1299,7 +1303,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Tato e-mailová adresa není k dispozici."
 
@@ -1335,7 +1339,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1376,7 +1380,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Nezodpovězeno"
 
@@ -1391,6 +1395,10 @@ msgstr "Vložit obrázek znázorňující toto riziko."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Vložit obrázek"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1519,7 +1527,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Máte hotové tréninkové snímky!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Vaše e-mailová adresa byla aktualizována."
 
@@ -1528,7 +1536,7 @@ msgid "Your password for confirmation"
 msgstr "Vaše heslo pro potvrzení"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Vaše heslo bylo úspěšně změněno."
 
@@ -1654,42 +1662,42 @@ msgid "about_partners_3_smb"
 msgstr "mikropodniky a makropodniky mají určité nedostatky"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Popište konkrétní opatření potřebná pro snížení rizika."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr "Vyberte nebo popište konkrétní opatření ke snížení rizika."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Popište další možná opatření ke snížení rizika. ."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Vyberte nebo popište další opatření ke snížení rizika."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr "Náklady, které bude třeba vynaložit na realizaci opatření."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr "Ustanovte odpovědnou osobu za realizaci opatření."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr "Popište opatření pro odstranění nebo snížení rizika."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr "Odborná způsobilost nebo potřebné znalosti a dovednosti."
 
@@ -1772,7 +1780,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: kladná sdělení obsažená v modulech."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Přidat"
 
@@ -1813,7 +1821,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Zrušit"
@@ -2221,14 +2229,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Zaškrtněte prosím vše, co byste chtěli ze školení vyloučit. Šedě označené "
 "položky se na kartě školení nezobrazí."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Nástroj provedl hodnocení rizika automaticky. Hodnotu tohoto rizika budete "
@@ -2410,17 +2418,17 @@ msgid "effect_high"
 msgstr "Vysoká závažnost"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Malá závažnost"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Významná závažnost"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Vysoká závažnost"
 
@@ -2467,7 +2475,7 @@ msgstr ""
 "kliknete na potvrzující odkaz níže."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Prosím potvrďte svou novou e-mailovou adresu kliknutím na odkaz v e-mailu, "
@@ -2524,7 +2532,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 až 249 zaměstnanců"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Účet s touto e-mailovou adresou již existuje."
 
@@ -2534,12 +2542,12 @@ msgid "error_existing_login"
 msgstr "Toto přihlašovací jméno již existuje."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Zadejte prosím rozpočet v celých EUR"
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Prosím zadejte platnou e-mailovou adresu"
 
@@ -2554,65 +2562,65 @@ msgid "error_invalid_xml"
 msgstr "Prosím nahrajte platný soubor XML"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Prosím zadejte svou e-mailovou adresu"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Prosím zadejte heslo"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Hesla se neshodují"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Heslo musí mít alespoň 12 znaků a musí obsahovat alespoň jedno malé písmeno, "
 "jedno velké písmeno a jednu číslici."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Toto datum musí být k počátečnímu datu nebo po něm."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Toto datum musí být před datem ukončení."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Tato hodnota musí být kladné celé číslo."
 
@@ -2719,7 +2727,7 @@ msgstr ""
 "být všechny změny v nástroji OiRA vnořeny do vaší relace."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2751,7 +2759,7 @@ msgstr "Identifikační zpráva ${title}"
 msgid "filename_report_timeline"
 msgstr "Akční plán ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2772,7 +2780,7 @@ msgid "french"
 msgstr "Dvě zjednodušená kritéria"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Téměř nikdy"
 
@@ -2782,57 +2790,57 @@ msgid "frequency_almostnever"
 msgstr "Téměř nikdy"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Nepřetržitě"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Nepříliš často"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Jednou měsíčně"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Často"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Jednou týdně"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Zřídkakdy"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Jednou ročně"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Velmi často nebo pravidelně"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Minimálně jednou denně"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Pravidelně"
@@ -2857,12 +2865,12 @@ msgid "header_additional_content"
 msgstr "Další obsah"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Další zdroje pro hodnocení rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Dodatečné zdroje pro tento modul"
 
@@ -3105,23 +3113,23 @@ msgid "header_risk_aware"
 msgstr "Jste si vědom/a všech rizik?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Jaká je odhadovaná závažnost následku?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Jak často dochází k ohrožení?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Zvolte hodnotu rizika."
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Jaká je pravděpodobnost výskytu?"
 
@@ -3185,7 +3193,7 @@ msgid "header_settings"
 msgstr "Nastavení"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standardní kroky"
 
@@ -3428,7 +3436,7 @@ msgid "help_authentication"
 msgstr "Tento text by měl vysvětlit, jak se registrovat a přihlásit."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr "Vyberte vyhovující možnost. Systém vypočítá hodnotu rizika."
 
@@ -3457,7 +3465,7 @@ msgstr ""
 "kopií stávajícího nástroje OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Uveďte, jak často se riziko objevuje v běžné situaci."
 
@@ -3469,13 +3477,13 @@ msgstr ""
 "může prioritu změnit."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Uveďte, jak moc je pravděpodobné, že se toto riziko objeví v běžné situaci."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Uveďte závažnost, pokud se toto riziko vyskytne."
 
@@ -4066,13 +4074,13 @@ msgstr "Účet je uzamčen"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Akční plán"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Rozpočet"
@@ -4084,21 +4092,21 @@ msgstr "Akční plán"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Konec plánování"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Kdo je odpovědný?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Zahájení plánování"
@@ -4121,7 +4129,7 @@ msgid "label_alphabetical"
 msgstr "Abecedně"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Vyhledání + hodnocení rizik"
 
@@ -4213,7 +4221,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4299,7 +4307,7 @@ msgid "label_delete_risk"
 msgstr "Chystáte se odstranit riziko:  &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Popis"
@@ -4345,7 +4353,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Hodnocení rizik"
 
@@ -4371,7 +4379,7 @@ msgid "label_existing_measure"
 msgstr "Opatření již je zavedeno."
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Již provedená opatření"
@@ -4382,7 +4390,7 @@ msgid "label_exit"
 msgstr "Konec"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Odbornost"
 
@@ -4397,7 +4405,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Přidejte další opatření"
 
@@ -4502,7 +4510,7 @@ msgstr "Historie"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Vyhledání rizik"
 
@@ -4512,7 +4520,7 @@ msgid "label_image"
 msgstr "Obrazový soubor"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Provedené opatření"
 
@@ -4539,7 +4547,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Zapojení"
 
@@ -4587,8 +4595,8 @@ msgstr "Více o projektu OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Odkazy na právní předpisy a postupy"
 
@@ -4651,7 +4659,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Obecný přístup (k eliminaci nebo snížení rizika)"
@@ -4664,7 +4672,7 @@ msgstr "Specifický/é krok/y požadované k implementaci tohoto přístupu"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Míra potřebných znalostí a/nebo požadavků"
@@ -4799,12 +4807,12 @@ msgstr "Ne, jsou vyžadována další opatření."
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Poznámky"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4860,14 +4868,14 @@ msgid "label_password_confirm"
 msgstr "Heslo znovu"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Plánovaná opatření"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Příprava"
 
@@ -4959,13 +4967,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Smazat toto opatření"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Zpráva"
 
@@ -5107,7 +5115,7 @@ msgid "label_select_assessment"
 msgstr "Vyberte hodnocení rizik"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Zvolte jeden z uvedených známých a běžných kroků."
 
@@ -5126,7 +5134,7 @@ msgid "label_select_oira_tool"
 msgstr "Vyberte nástroj OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Vyberte standardní opatření"
 
@@ -5598,8 +5606,8 @@ msgid "menu_import"
 msgstr "Importovat nástroj OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Odborná příprava"
 
@@ -5649,13 +5657,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Nemůžete odstranit jedinou verzi nástroje OiRA."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5907,7 +5920,7 @@ msgstr "Nastavení"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Status"
 
@@ -6055,14 +6068,14 @@ msgstr ""
 "školicí program OiRA a help desk OiRA."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Tento komentář bude zobrazen v závěrečné zprávě. Použijte jej jako poznámku "
 "k hodnocení rizika."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Tyto poznámky budou viditelné ve zprávě a ve školení. Můžete je následně "
@@ -6091,45 +6104,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Vysoká"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Nízká"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Střední"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Velká"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Střední"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Malá"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Kompletní"
 
@@ -6198,7 +6211,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6210,7 +6223,7 @@ msgstr ""
 "Zaregistrujte se pomocí jednoho kroku a získejte přístup k těmto výhodám:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6276,25 +6289,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Toto je ${priority_value} hodnota rizika."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "vysoká"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "nízká"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "střední"
@@ -6310,7 +6323,7 @@ msgid "risk_show_na_na"
 msgstr "nevztahuje se"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Krok ${number}"
 
@@ -6375,46 +6388,46 @@ msgstr ""
 "důvodů bezpečnosti je lepší se odhlásit aktivně."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Nepříliš vážné"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Potřeba zastavit práci na méně než 3 dny"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Vážné"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Potřeba zastavit práci na vice než 3 dny"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Velmi závažné"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Nevratné poškození, nevyléčitelná nemoc, smrt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Slabé"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Není potřeba zastavit práci"
 
@@ -6511,12 +6524,12 @@ msgid "title_about"
 msgstr "Co je projekt OiRA (Online interaktivní vyhodnocení rizik)"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Zrušit účet"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:03+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Danish\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -166,16 +166,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -198,7 +202,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -288,7 +292,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -539,7 +543,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -570,11 +574,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -643,7 +647,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -1024,11 +1028,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -1041,13 +1045,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1116,7 +1120,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1133,7 +1137,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1171,7 +1175,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1216,7 +1220,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1232,7 +1236,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1267,7 +1271,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1308,7 +1312,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1322,6 +1326,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1437,7 +1445,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1446,7 +1454,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1546,42 +1554,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1653,7 +1661,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1694,7 +1702,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2032,12 +2040,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2201,17 +2209,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2256,7 +2264,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2310,7 +2318,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2320,12 +2328,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2340,63 +2348,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2514,7 +2522,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2535,7 +2543,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2545,57 +2553,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2616,12 +2624,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2863,23 +2871,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2943,7 +2951,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3184,7 +3192,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3209,7 +3217,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 
@@ -3219,12 +3227,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 
@@ -3714,13 +3722,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3732,21 +3740,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3769,7 +3777,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3861,7 +3869,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -3947,7 +3955,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -3993,7 +4001,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -4019,7 +4027,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4030,7 +4038,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4045,7 +4053,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4150,7 +4158,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4160,7 +4168,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4187,7 +4195,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4235,8 +4243,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4299,7 +4307,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4312,7 +4320,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4445,12 +4453,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4506,14 +4514,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4605,13 +4613,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4753,7 +4761,7 @@ msgid "label_select_assessment"
 msgstr "Vælg en risikovurdering"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4772,7 +4780,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5231,8 +5239,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5281,13 +5289,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5518,7 +5531,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5661,12 +5674,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5693,45 +5706,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5796,7 +5809,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5806,7 +5819,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5867,25 +5880,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5901,7 +5914,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -5958,46 +5971,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6086,12 +6099,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2016-07-28 15:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -164,7 +164,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr "Eine Kopie von “${title}” wurde zu Ihrem OiRA-Tool hinzugefügt."
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Weitere Maßnahme"
 
@@ -184,11 +184,11 @@ msgstr "Alle Sprachen"
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Beim Versenden der Bestätigungs-E-Mail ist ein Fehler aufgetreten."
 
@@ -196,6 +196,10 @@ msgstr "Beim Versenden der Bestätigungs-E-Mail ist ein Fehler aufgetreten."
 msgid "An error occured while sending the password reset instructions"
 msgstr ""
 "Bei Senden der E-mail zum Zurücksetzen des Passworts gab es einen Fehler"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
+msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
 msgid "Archive"
@@ -219,7 +223,7 @@ msgstr ""
 "Sind Sie sicher, dass Sie forfahren wollen? Dieser Vorgang kann nicht "
 "rückgängig gemacht werden."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -315,7 +319,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Änderung der OiRA-E-Mail-Adresse bestätigen"
 
@@ -579,7 +583,7 @@ msgstr ""
 "Allerdings können Sie eine Gefährdungsbeurteilung jederzeit unterbrechen und "
 "dann fortführen, wenn es Ihre Zeit erlaubt."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Ich würde Ihnen gerne folgendes Tool empfehlen"
 
@@ -610,11 +614,11 @@ msgstr "Informationen"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Falsches Dateiformat für das Bild. Bitte verwenden Sie PNG oder JPEG."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Ungültiges Passwort"
 
@@ -685,7 +689,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Maßnahme"
@@ -955,7 +959,7 @@ msgstr "Bitte werfen Sie einen Blick auf die Beispiele unter diesem Formular."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Aufgeschoben"
 
@@ -1099,11 +1103,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr "Vorhandene GBUs, die mit dieser Vorlage erstellt wurden"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Gefährdung nicht vorhanden"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Gefährdung vorhanden"
 
@@ -1116,13 +1120,13 @@ msgid "Run slideshow"
 msgstr "Bildschirmpräsentation"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Speichern"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Änderungen speichern"
@@ -1195,7 +1199,7 @@ msgstr "Aufforderung bei einem Standort"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Standardmaßnahmen"
 
@@ -1212,7 +1216,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Fragenteil starten"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1256,7 +1260,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Die generelle Struktur eines OiRA-Tools besteht aus:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1308,7 +1312,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 "Es wurden keine Änderungen vorgenommen, die noch gespeichert werden müssen."
@@ -1325,7 +1329,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr "Dieses Zertifikat wurde erstellt für"
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Diese E-Mail-Adresse ist nicht verfügbar."
 
@@ -1371,7 +1375,7 @@ msgstr ""
 "Hier muss der Endnutzer gefragt werden, ob das Profil für sie/ihn anwendbar "
 "ist."
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1412,7 +1416,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Nicht beantwortet"
 
@@ -1427,6 +1431,10 @@ msgstr ""
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Bild hochladen"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1557,7 +1565,7 @@ msgstr "Sie sollten die Unterweisung vom Start beginnen"
 msgid "You're done with the training slides!"
 msgstr "Sie sind fertig mit der Unterweisung!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Ihre E-Mail-Adresse wurde aktualisiert."
 
@@ -1566,7 +1574,7 @@ msgid "Your password for confirmation"
 msgstr "Ihr Passwort zur Bestätigung"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Ihr Passwort wurde erfolgreich geändert."
 
@@ -1708,27 +1716,27 @@ msgid "about_partners_3_smb"
 msgstr "es in Kleinst- und Kleinunternehmen einige Defizite"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Obwohl einzelne Maßnahmen ohne Kostenaufwand durchzuführen sind, kosten die "
@@ -1737,7 +1745,7 @@ msgstr ""
 "werden."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Bestimmen Sie eine Person in Ihrem Unternehmen zum Verantwortlichen für die "
@@ -1746,7 +1754,7 @@ msgstr ""
 "für deren Durchführung."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Beschreiben Sie: 1) Ihre allgemeine Vorgehensweise zur Vermeidung bzw. (wenn "
@@ -1755,7 +1763,7 @@ msgstr ""
 "erforderlich ist/sind (zur Vermeidung bzw. Reduzierung der Gefährdung)"
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Beschreiben Sie: 3) die erforderlichen Fachkenntnisse, um die Maßnahme "
@@ -1836,7 +1844,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: Positive Aussagen, die in Modulen gruppiert sind."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Hinzufügen"
 
@@ -1877,7 +1885,7 @@ msgstr "Ja, GBU archivieren"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Abbrechen"
@@ -2215,7 +2223,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Bitte klicken Sie alles an, was Sie von der Unterweisung ausschließen "
@@ -2223,7 +2231,7 @@ msgstr ""
 "Unterweisungskarten angezeigt."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Die Bewertung der Priorität wurde für diese Gefährdung automatisch "
@@ -2414,17 +2422,17 @@ msgid "effect_high"
 msgstr "Hoher (sehr hoher) Schweregrad"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Niedriger Schweregrad"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Signifikanter Schweregrad"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Hoher (sehr hoher) Schweregrad"
 
@@ -2472,7 +2480,7 @@ msgstr ""
 "geändert, wenn Sie auf den untenstehenden Bestätigungslink klicken."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Bitte bestätigen Sie Ihre neue E-Mail-Adresse, indem Sie auf den Link in der "
@@ -2530,7 +2538,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 bis 249 Mitarbeiter"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Es besteht bereits ein Konto mit dieser E-Mail-Adresse."
 
@@ -2540,12 +2548,12 @@ msgid "error_existing_login"
 msgstr "Dieser Anmeldename ist bereits vergeben."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Geben Sie das Budget in Euro ohne Centbeträge ein."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein."
 
@@ -2560,63 +2568,63 @@ msgid "error_invalid_xml"
 msgstr "Laden Sie eine gültige XML-Datei hoch."
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Geben Sie Ihre E-Mail-Adresse ein."
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Geben Sie ein Passwort ein."
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Die Passwörter stimmen nicht überein."
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Dieses Datum muss nach dem Startdatum liegen."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Dieses Datum muss vor dem Enddatum liegen."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Dieser Wert muss eine ganze positive Zahl sein."
 
@@ -2718,7 +2726,7 @@ msgstr ""
 "Änderungen im OiRA-Tool in Ihrer Sitzung zusammengeführt werden."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2746,7 +2754,7 @@ msgstr "Ermittlungsbericht ${title}"
 msgid "filename_report_timeline"
 msgstr "Aktionsplan für ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2767,7 +2775,7 @@ msgid "french"
 msgstr "Vereinfacht, zwei Kriterien"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Fast nie"
 
@@ -2777,57 +2785,57 @@ msgid "frequency_almostnever"
 msgstr "Fast nie"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Dauerhaft"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Nicht sehr häufig"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Nicht sehr häufig"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Häufig"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Häufig"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Selten"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Selten"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Sehr häufig oder regelmäßig"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Sehr häufig oder regelmäßig"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regelmäßig"
@@ -2852,12 +2860,12 @@ msgid "header_additional_content"
 msgstr "Weitere Inhalte"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Anhänge"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Quellen und Anhänge zu diesem Modul."
 
@@ -3101,23 +3109,23 @@ msgid "header_risk_aware"
 msgstr "Sind Sie sich aller Gefährdungen bewusst?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Welchen Schweregrad hat der Schaden?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Wie häufig sind Personen dieser Gefährdung ausgesetzt?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Priorität für diese Gefährdung wählen"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Wie hoch ist die Wahrscheinlichkeit, dass diese Gefährdung auftritt?"
 
@@ -3181,7 +3189,7 @@ msgid "header_settings"
 msgstr "Einstellungen"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standardmaßnahmen"
 
@@ -3423,7 +3431,7 @@ msgid "help_authentication"
 msgstr "Dieser Text sollte den Registrierungs- und Anmeldevorgang beschreiben."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Bitte beantworten Sie die folgenden Fragen. Aufgrund Ihrer Antworten wird "
@@ -3458,7 +3466,7 @@ msgstr ""
 "Sie dies basierend auf der Kopie eines bestehenden OiRA-Tools tun möchten ..."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Geben Sie an, wie oft diese Gefährdung unter normalen Bedingungen auftritt."
@@ -3471,14 +3479,14 @@ msgstr ""
 "unterstützen. Er/sie hat die Möglichkeit, die Priorität zu ändern."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Geben Sie an, wie wahrscheinlich das Auftreten der Gefährdung unter normalen "
 "Bedingungen ist."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Geben Sie den Schweregrad für das Eintreten dieser Gefährdung an."
 
@@ -4098,13 +4106,13 @@ msgstr "Konto gesperrt"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Aktionsplan"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budget"
@@ -4116,21 +4124,21 @@ msgstr "Aktionsplan"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Abschluss der Planung"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Wer ist die verantwortliche Person?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Beginn der Planung"
@@ -4153,7 +4161,7 @@ msgid "label_alphabetical"
 msgstr "Alphabetisch"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Beurteilung"
 
@@ -4245,7 +4253,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4333,7 +4341,7 @@ msgstr ""
 "löschen."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Beschreibung"
@@ -4379,7 +4387,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Bewertung"
 
@@ -4405,7 +4413,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4416,7 +4424,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4431,7 +4439,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Eine weitere Maßnahme hinzufügen"
 
@@ -4536,7 +4544,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Ermittlung"
 
@@ -4546,7 +4554,7 @@ msgid "label_image"
 msgstr "Bilddatei"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Bestehende Schutzmaßnahme"
 
@@ -4573,7 +4581,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Einbeziehen"
 
@@ -4621,8 +4629,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Rechtliche und politische Referenzen"
 
@@ -4685,7 +4693,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4699,7 +4707,7 @@ msgstr "Einzelne Aktion(en) zur Umsetzung dieser Vorgehensweise"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Erforderliche Fachkenntnisse und/oder Anforderungen"
@@ -4834,12 +4842,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Anmerkungen"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr "Benachrichtigungen"
 
@@ -4895,14 +4903,14 @@ msgid "label_password_confirm"
 msgstr "Wiederholung Passwort"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Vorbereitung"
 
@@ -4994,13 +5002,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Diese Maßnahme löschen"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Bericht"
 
@@ -5144,7 +5152,7 @@ msgid "label_select_assessment"
 msgstr "Wählen Sie eine Gefährdungsbeurteilung aus"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 "Wählen Sie eine oder mehrere der angebotenen bekannten, allgemeinen "
@@ -5167,7 +5175,7 @@ msgid "label_select_oira_tool"
 msgstr "GBU-Vorlage auswählen"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Standardmaßnahmen auswählen"
 
@@ -5647,8 +5655,8 @@ msgid "menu_import"
 msgstr "OiRA-Tool importieren"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Unterweisung"
 
@@ -5701,13 +5709,18 @@ msgstr ""
 "Diese OiRA-Tool Version kann nicht gelöscht werden, da sie die einzige ist. "
 "Wenn Sie diese entfernen möchten, löschen Sie das OiRA-Tool."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr "Sie können ${link_download_tool_contents}."
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Erforderliche Eingabe fehlt."
 
@@ -5944,7 +5957,7 @@ msgstr "Einstellungen"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Status"
 
@@ -6109,12 +6122,12 @@ msgstr ""
 "Helpdesk für OiRA eingerichtet wurden."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -6143,45 +6156,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Hoch"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Niedrig"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Mittel"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Hoch"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Mittelhoch"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Niedrig"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Vollständig"
 
@@ -6249,7 +6262,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6262,7 +6275,7 @@ msgstr ""
 "und genießen Sie die folgenden Vorteile:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6330,25 +6343,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Dies ist eine ${priority_value} Prioritätsgefährdung."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "hohe"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "niedrige"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "mittlere"
@@ -6364,7 +6377,7 @@ msgid "risk_show_na_na"
 msgstr "nicht anwendbar"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Maßnahme ${number}"
 
@@ -6432,46 +6445,46 @@ msgstr ""
 "Abmeldung."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Nicht sehr hoch"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Nicht sehr hoch"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Hoch"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Hoch"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Sehr hoch"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Sehr hoch"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Niedrig"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Niedrig"
 
@@ -6571,12 +6584,12 @@ msgid "title_about"
 msgstr "Informationen"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Konto löschen"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -5712,7 +5712,7 @@ msgstr ""
 #. Default: "Due to an internal policy, these settings cannot be changed."
 #: euphorie/client/browser/templates/preferences.pt:80
 msgid "message_disallow_notification_settings"
-msgstr ""
+msgstr "Die Einstellungen können aufgrund einer internen Policy nicht geändert werden."
 
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: xl <xl@hol.gr>\n"
 "Language-Team: el <LL@li.org>\n"
@@ -178,7 +178,7 @@ msgstr "Προσθήκη χρήστη"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Επιπρόσθετο μέτρο"
 
@@ -198,16 +198,20 @@ msgstr "Όλες οι γλώσσες"
 msgid "Almost done&hellip;"
 msgstr "Σχεδόν ολοκληρώσατε&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Σημειώθηκε ένα σφάλμα κατά την αποστολή του email επιβεβαίωσης."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -232,7 +236,7 @@ msgstr ""
 "Είστε βέβαιοι ότι θέλετε να συνεχίσετε; Αυτή η ενέργεια δεν μπορεί να "
 "αναστραφεί."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -332,7 +336,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Επιβεβαιώστε την αλλαγή της διεύθυνσης email OiRA"
 
@@ -603,7 +607,7 @@ msgstr ""
 "άλλη στιγμή το θελήσετε στο μέλλον, συνεχίζοντας από το σημείο όπου "
 "σταματήσατε. "
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Θέλω να μοιραστώ μαζί σας τα παρακάτω"
 
@@ -634,13 +638,13 @@ msgstr "Πληροφορίες"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Μη αποδεκτός τύπος αρχείου εικόνας. Αποδεκτοί τύποι αρχείων εικόνας PNG, "
 "JPEG ή GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Μη αποδεκτός κωδικός πρόσβασης"
 
@@ -714,7 +718,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Μέτρο"
@@ -987,7 +991,7 @@ msgstr "Βλέπε τα παραδείγματα κάτω από το έντυπ
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Κίνδυνος σε εκκρεμότητα"
 
@@ -1132,11 +1136,11 @@ msgstr "Μελέτες Εκτίμησης Κινδύνου"
 msgid "Risk assessments made with this tool"
 msgstr "Εκτιμήσεις επικινδυνότητας με το εργαλείο αυτό"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Ασφαλής κατάσταση"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Προσοχή κίνδυνος!"
 
@@ -1149,13 +1153,13 @@ msgid "Run slideshow"
 msgstr "Έναρξη παρουσίασης"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Αποθήκευση"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Αποθήκευση αλλαγών"
@@ -1228,7 +1232,7 @@ msgstr "Ειδοποίηση για περισσότερες από μία εμ�
 msgid "Standard"
 msgstr "Πρότυπο"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Προτεινόμενα μέτρα"
 
@@ -1245,7 +1249,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Έναρξη ερωτήσεων"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1292,7 +1296,7 @@ msgstr ""
 "Η βασική αρχιτεκτονική μιας επιγραμμικής διαδραστικής εκτίμησης κινδύνου "
 "αποτελείται από:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1346,7 +1350,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Δεν υπάρχουν αλλαγές για αποθήκευση."
 
@@ -1362,7 +1366,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Αυτή η διεύθυνση email δεν είναι διαθέσιμη."
 
@@ -1401,7 +1405,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1442,7 +1446,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Υπό εξέταση κίνδυνος"
 
@@ -1457,6 +1461,10 @@ msgstr "Φόρτωση εικόνας που αποτυπώνει τον κίν�
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Φόρτωση  εικόνας"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1595,7 +1603,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Ολοκληρώσατε με το εκπαιδευτικό υλικό!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Η διεύθυνση email σας έχει αλλάξει. "
 
@@ -1604,7 +1612,7 @@ msgid "Your password for confirmation"
 msgstr "Ο κωδικός πρόσβασής σας για επιβεβαίωση"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Η αλλαγή του κωδικού πρόσβασής σας ολοκληρώθηκε με επιτυχία."
 
@@ -1742,33 +1750,33 @@ msgstr ""
 "οι πολύ μικρές και μικρές επιχειρήσεις μπορεί να αντιμετωπίσουν ανεπάρκειες"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 "Προσθήκη από τον χρήστη των αναγκαίων μέτρων για τη μείωση του κινδύνου."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Επιλογή  ή προσθήκη από τον χρήστη των αναγκαίων μέτρων για τη μείωση του "
 "κινδύνου."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 "Προσθήκη από τον χρήστη επιπρόσθετου μέτρου για τη μείωση του κινδύνου."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "Επιλογή  ή προσθήκη από τον χρήστη  επιπρόσθετου μέτρου για τη μείωση του "
 "κινδύνου."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Παρότι η εφαρμογή ορισμένων μέτρων δεν έχει κόστος, τα περισσότερα μέτρα "
@@ -1777,7 +1785,7 @@ msgstr ""
 "ετήσιο προϋπολογισμό, εάν αυτό είναι απαραίτητο."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Αναθέστε σε κάποιον στην επιχείρησή σας την ευθύνη για την εφαρμογή αυτού "
@@ -1786,7 +1794,7 @@ msgstr ""
 "να διασφαλίζει την εφαρμογή τους."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Περιγράψτε: 1) ποια η γενική σας προσέγγιση για να εξαλείψετε τον κίνδυνο ή "
@@ -1795,7 +1803,7 @@ msgstr ""
 "εξαλείψετε ή να μειώσετε τον κίνδυνο)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Περιγράψτε: 3) το επίπεδο τεχνογνωσίας που απαιτείται για να εφαρμοστεί το "
@@ -1885,7 +1893,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: θετικές δηλώσεις, οι οποίες περιέχονται σε ενότητες."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "επιλογή"
 
@@ -1926,7 +1934,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Άκυρο"
@@ -2350,7 +2358,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Επιλέξτε ότι επιθυμείτε να μην συμπεριλαμβάνεται στο πρόγραμμα εκπαίδευσης. "
@@ -2358,7 +2366,7 @@ msgstr ""
 "εκπαιδευτικό υλικό."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Η αξιολόγηση του κινδύνου (εκτίμηση επικινδυνότητας) πραγματοποιήθηκε "
@@ -2553,17 +2561,17 @@ msgid "effect_high"
 msgstr "Μεγάλη (πολύ μεγάλη) σφοδρότητα"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Μικρή σοβαρότητα επιπτώσεων"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Μέτρια σοβαρότητα επιπτώσεων"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Μεγάλη σοβαρότητα επιπτώσεων"
 
@@ -2610,7 +2618,7 @@ msgstr ""
 "αλλάξουν σε '${email}' όταν κάνετε κλικ στο σύνδεσμο επιβεβαίωσης παρακάτω."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Παρακαλώ επιβεβαιώστε τη νέα σας διεύθυνση email κάνοντας κλικ στο email που "
@@ -2675,7 +2683,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 ως 249 εργαζόμενοι"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Υπάρχει ήδη λογαριασμός με αυτή τη διεύθυνση email."
 
@@ -2685,12 +2693,12 @@ msgid "error_existing_login"
 msgstr "Αυτό το όνομα σύνδεσης χρησιμοποιείται ήδη."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Παρακαλώ εισάγετε τον προϋπολογισμό σε ακέραια ευρώ."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Παρακαλώ εισάγετε μια αποδεκτή διεύθυνση email."
 
@@ -2707,23 +2715,23 @@ msgid "error_invalid_xml"
 msgstr "Παρακαλώ ανεβάστε ένα αποδεκτό αρχείο XML"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Παρακαλώ εισάγετε τη διεύθυνση email σας."
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Παρακαλώ εισάγετε έναν κωδικό πρόσβασης"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Οι κωδικοί πρόσβασης δεν είναι ίδιοι"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Ο κωδικός πρόσβασης πρέπει να αποτελείται από  τουλάχιστον 12 χαρακτήρες και "
@@ -2731,44 +2739,44 @@ msgstr ""
 "αριθμητικό ψηφίο."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας έναρξης."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 "Αυτή η ημερομηνία δεν πρέπει να είναι μεταγενέστερη της ημερομηνίας λήξης."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Αυτή η τιμή πρέπει να είναι θετικός ακέραιος αριθμός."
 
@@ -2888,7 +2896,7 @@ msgstr ""
 "ενότητά σας. "
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2920,7 +2928,7 @@ msgstr "Έκθεση της Εκτίμησης Κινδύνου ${title} "
 msgid "filename_report_timeline"
 msgstr "Σχέδιο Δράσης ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2941,7 +2949,7 @@ msgid "french"
 msgstr "Απλοποιημένα δύο κριτήρια "
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Σχεδόν ποτέ"
 
@@ -2951,57 +2959,57 @@ msgid "frequency_almostnever"
 msgstr "Σχεδόν ποτέ"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Διαρκώς"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Όχι πολύ συχνά"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Μία φορά το μήνα "
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Συχνά "
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Μία φορά την εβδομάδα "
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Σπάνια "
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Μία φορά το χρόνο"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Πολύ συχνά ή τακτικά "
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Τουλάχιστον μία φορά την ημέρα "
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Τακτικά"
@@ -3028,12 +3036,12 @@ msgid "header_additional_content"
 msgstr "Συμπληρωματικό περιεχόμενο"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Πρόσθετο πληροφοριακό υλικό για την εκτίμηση του κινδύνου"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Πρόσθετη πληροφόρηση γι’ αυτή τη θεματική ενότητα"
 
@@ -3280,23 +3288,23 @@ msgid "header_risk_aware"
 msgstr "Γνωρίζετε όλους τους κινδύνους;"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Ποια είναι η σοβαρότητα των επιπτώσεων?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Πόσο συχνά εκτίθενται άνθρωποι σε αυτό τον κίνδυνο;"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Επιλέξτε την επικινδυνότητα για αυτόν τον κίνδυνο"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Ποια η πιθανότητα να προκληθεί αυτός ο κίνδυνος;"
 
@@ -3362,7 +3370,7 @@ msgid "header_settings"
 msgstr "Ρυθμίσεις"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Τυπικά μέτρα αντιμετώπισης"
 
@@ -3609,7 +3617,7 @@ msgstr ""
 "Αυτό το κείμενο πρέπει να επεξηγεί πώς να εγγραφείτε και να συνδεθείτε."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Παρακαλούμε απαντήστε στις ακόλουθες ερωτήσεις. Με βάση τις απαντήσεις σας "
@@ -3643,7 +3651,7 @@ msgstr ""
 "αρχίσετε με ένα αντίγραφο κάποιου υπάρχοντος Εργαλείου OiRA. "
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο συχνά εκτίθενται οι εργαζόμενοι στον "
@@ -3657,14 +3665,14 @@ msgstr ""
 "προτεραιότητα. Ο χρήστης μπορεί να αλλάξει την προτεραιότητα."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο πιθανό είναι να εκδηλωθεί ο κίνδυνος "
 "αυτός σε φυσιολογικές συνθήκες."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 "Δηλώστε την εκτίμησή σας για το πόσο σοβαρές μπορεί να είναι οι επιπτώσεις "
@@ -4308,13 +4316,13 @@ msgstr "Ο λογαριασμός είναι κλειδωμένος"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Σχέδιο Δράσης"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Προϋπολογισμός"
@@ -4326,21 +4334,21 @@ msgstr "Σχέδιο Δράσης"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Τέλος εφαρμογής"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Ποιος είναι υπεύθυνος;"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Έναρξη εφαρμογής"
@@ -4363,7 +4371,7 @@ msgid "label_alphabetical"
 msgstr "Αλφαβητικά"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Διαχείριση Κινδύνων"
 
@@ -4455,7 +4463,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr "Συμβουλευτική υποστήριξη"
 
@@ -4541,7 +4549,7 @@ msgid "label_delete_risk"
 msgstr "Πρόκειται να διαγράψετε τον κίνδυνο: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Περιγραφή"
@@ -4587,7 +4595,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Αξιολόγηση"
 
@@ -4613,7 +4621,7 @@ msgid "label_existing_measure"
 msgstr "Μέτρο που έχει ήδη εφαρμοστεί"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Μέτρα σε εφαρμογή"
@@ -4624,7 +4632,7 @@ msgid "label_exit"
 msgstr "Έξοδος"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Εμπειρία/Εξειδίκευση"
 
@@ -4639,7 +4647,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Προσθήκη επιπρόσθετου μέτρου"
 
@@ -4744,7 +4752,7 @@ msgstr "Ιστορικό"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Αναγνώριση"
 
@@ -4754,7 +4762,7 @@ msgid "label_image"
 msgstr "Αρχείο εικόνας"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Μέτρο σε εφαρμογή"
 
@@ -4781,7 +4789,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr "Ανάκληση επικύρωσης της μελέτης εκτίμησης κινδύνου"
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Συμμετοχή των εργαζομένων"
 
@@ -4829,8 +4837,8 @@ msgstr "Περισσότερες πληροφορίες  για τα εργαλ�
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Νομικές αναφορές και αναφορές πολιτικής"
 
@@ -4893,7 +4901,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Γενική προσέγγιση (για την εξάλειψη ή μείωση του κινδύνου)"
@@ -4906,7 +4914,7 @@ msgstr "Απαιτείται ειδική ενέργεια(-ες) για την 
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Απαιτήσεις"
@@ -5041,12 +5049,12 @@ msgstr "Όχι, απαιτούνται περισσότερα μέτρα"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Σημειώσεις"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -5102,14 +5110,14 @@ msgid "label_password_confirm"
 msgstr "Επανάληψη κωδικού πρόσβασης"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Σχεδιαζόμενα μέτρα προς εφαρμογή"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Προετοιμασία"
 
@@ -5203,13 +5211,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Διαγραφή αυτού του μέτρου"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Έκθεση"
 
@@ -5353,7 +5361,7 @@ msgid "label_select_assessment"
 msgstr "Επιλέξτε μια εκτίμηση κινδύνου"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 "Επιλέξτε ένα ή περισσότερα από τα γνωστά και κοινώς αποδεκτά μέτρα που "
@@ -5376,7 +5384,7 @@ msgid "label_select_oira_tool"
 msgstr "Επιλογή ενός εργαλείου OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Επιλογή από τα προτεινόμενα μέτρα"
 
@@ -5860,8 +5868,8 @@ msgid "menu_import"
 msgstr "Εισαγωγή Εργαλείου OiRA "
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Πρόγραμμα εκπαίδευσης"
 
@@ -5919,13 +5927,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Δεν μπορείτε να διαγράψετε τη μοναδική έκδοση εργαλείου OiRA."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Το πεδίο είναι υποχρεωτικό."
 
@@ -6229,7 +6242,7 @@ msgstr "Ρυθμίσεις"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Παρούσα Κατάσταση"
 
@@ -6380,7 +6393,7 @@ msgstr ""
 "εξυπηρέτησης OiRA έχουν ολοκληρωθεί."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Αυτό το σχόλιο θα εμφανίζεται στην τελική έκθεση (Μελέτη Εκτίμησης "
@@ -6388,7 +6401,7 @@ msgstr ""
 "επιθυμείτε για αυτόν τον κίνδυνο."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Αυτές οι σημειώσεις θα εμφανίζονται στην έκθεση και στο υλικό των "
@@ -6419,45 +6432,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Υψηλή"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Χαμηλή"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Μέτρια"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Υψηλή"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Μέτρια"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Χαμηλή"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% πλήρης"
 
@@ -6526,7 +6539,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6539,7 +6552,7 @@ msgstr ""
 "ακόλουθα οφέλη:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6609,25 +6622,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Εκτίμηση επικινδυνότητας: ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "Υψηλή"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "Χαμηλή"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "Μέτρια "
@@ -6643,7 +6656,7 @@ msgid "risk_show_na_na"
 msgstr "μη διαθέσιμ."
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Μέτρο αντιμετώπισης ${number}"
 
@@ -6713,46 +6726,46 @@ msgstr ""
 "συνιστάται να αποσυνδέεστε επιλέγοντας 'Αποσύνδεση'."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Όχι πολύ σοβαρή "
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Χρειάζεται διακοπή από την εργασία για λιγότερες από 3 ημέρες "
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Σοβαρή "
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Χρειάζεται διακοπή από την εργασία για περισσότερες από 3 ημέρες "
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Πολύ σοβαρή "
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Μη αναστρέψιμος τραυματισμός, ανίατη ασθένεια, θάνατος "
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Μικρή "
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Δεν χρειάζεται διακοπή από την εργασία "
 
@@ -6857,12 +6870,12 @@ msgid "title_about"
 msgstr "Σχετικά"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Διαγραφή λογαριασμού "
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -160,16 +160,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -192,7 +196,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -284,7 +288,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -535,7 +539,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -639,7 +643,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -885,7 +889,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -1020,11 +1024,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -1037,13 +1041,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1112,7 +1116,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1167,7 +1171,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1212,7 +1216,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1228,7 +1232,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1263,7 +1267,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1318,6 +1322,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1433,7 +1441,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1442,7 +1450,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1542,42 +1550,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1649,7 +1657,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1690,7 +1698,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2028,12 +2036,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2195,17 +2203,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2250,7 +2258,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2304,7 +2312,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2314,12 +2322,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2334,63 +2342,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2480,7 +2488,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2508,7 +2516,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2529,7 +2537,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2539,57 +2547,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2610,12 +2618,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2857,23 +2865,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2937,7 +2945,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3178,7 +3186,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3203,7 +3211,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 
@@ -3213,12 +3221,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 
@@ -3709,13 +3717,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3727,21 +3735,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3764,7 +3772,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3856,7 +3864,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -3942,7 +3950,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -3988,7 +3996,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -4014,7 +4022,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4025,7 +4033,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4040,7 +4048,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4145,7 +4153,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4155,7 +4163,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4182,7 +4190,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4230,8 +4238,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4294,7 +4302,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4307,7 +4315,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4440,12 +4448,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4501,14 +4509,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4600,13 +4608,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4748,7 +4756,7 @@ msgid "label_select_assessment"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4767,7 +4775,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5226,8 +5234,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5276,13 +5284,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5513,7 +5526,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5656,12 +5669,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5688,45 +5701,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5795,7 +5808,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5805,7 +5818,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5866,25 +5879,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5900,7 +5913,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -5957,46 +5970,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6085,12 +6098,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: es <LL@li.org>\n"
@@ -166,7 +166,7 @@ msgstr "Añadir usuario"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Medida adicional"
 
@@ -186,16 +186,20 @@ msgstr "Todos los idiomas"
 msgid "Almost done&hellip;"
 msgstr "A punto de acabar&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Se ha producido un error al enviar el correo de confirmación."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -218,7 +222,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "¿Está seguro que quiere continuar? Esta acción no se puede revertir."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -314,7 +318,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Confirmar cambio de dirección de correo electrónico OiRA"
 
@@ -573,7 +577,7 @@ msgstr ""
 "Sin embargo, puede seguir con la evaluación el tiempo de que disponga y "
 "después continuar en el mismo punto en que lo dejó."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Deseo compartir el siguiente enlace"
 
@@ -604,12 +608,12 @@ msgstr "Información"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Formato de archivo inválido para imagen. Por favor utilice PNG, JPEG o GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Contraseña no válida"
 
@@ -682,7 +686,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Medida"
@@ -949,7 +953,7 @@ msgstr " Por favor, consulte los ejemplos debajo del formulario."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Pospuesto"
 
@@ -1095,11 +1099,11 @@ msgstr "Evaluaciones de riesgos"
 msgid "Risk assessments made with this tool"
 msgstr "Evaluaciones de riesgo realizadas con esta herramienta"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Atención"
 
@@ -1112,13 +1116,13 @@ msgid "Run slideshow"
 msgstr "Iniciar la presentación"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Guardar"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Guardar cambios"
@@ -1190,7 +1194,7 @@ msgstr "Aviso de ocurrencia único"
 msgid "Standard"
 msgstr "Estándar"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Medidas pre-establecidas"
 
@@ -1207,7 +1211,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Comenzar con las preguntas"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1253,7 +1257,7 @@ msgstr ""
 "La arquitectura básica de una herramienta interactiva de  evaluación de "
 "riesgos en línea, consiste en:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Ningún cambio que guardar."
 
@@ -1319,7 +1323,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "La dirección de correo electrónico no está disponible."
 
@@ -1357,7 +1361,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1398,7 +1402,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Sin respuesta"
 
@@ -1413,6 +1417,10 @@ msgstr "Subir una imagen que ilustre este riesgo."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Subir una imagen"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1547,7 +1555,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "¡Ha acabado la presentación de la formación!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Su dirección de correo electrónico se ha actualizado."
 
@@ -1556,7 +1564,7 @@ msgid "Your password for confirmation"
 msgstr "Contraseña de confirmación"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Su contraseña se ha cambiado correctamente."
 
@@ -1691,27 +1699,27 @@ msgid "about_partners_3_smb"
 msgstr "las medianas y pequeñas empresas  tienen defectos"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Describa las medidas específicas necesarias para reducir el riesgo."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr "Seleccione o describa las medidas específicas para reducir el riesgo."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Describa cualquier otra medida para reducir el riesgo."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Seleccione o describa cualquier otra medida para reducir el riesgo."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Aunque algunas medidas no cuestan dinero, la mayoría sí. Por tanto, se debe "
@@ -1719,7 +1727,7 @@ msgstr ""
 "si es necesario."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Designe a alguien de su empresa para que sea el responsable de la "
@@ -1728,7 +1736,7 @@ msgstr ""
 "se realicen."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Describa: 1) ¿cuál es su enfoque general para eliminar o (si el riesgo es "
@@ -1736,7 +1744,7 @@ msgstr ""
 "este enfoque (para eliminar o reducir el riesgo)"
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Describa: 3) el nivel de experiencia necesario para implantar la medida, por "
@@ -1826,7 +1834,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: Afirmaciones positivas, que están contenidas en módulos."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Añadir"
 
@@ -1867,7 +1875,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Cancelar"
@@ -2290,14 +2298,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Por favor marque aquello que quiera excluir de la formación. Los elementos "
 "que estén deshabilitados no se mostrarán en el contenido de la formación."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "La herramienta ha evaluado de forma automática el riesgo. Podrá modificar la "
@@ -2484,17 +2492,17 @@ msgid "effect_high"
 msgstr "Gravedad alta (muy alta)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Gravedad débil"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Gravedad importante"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Gravedad alta (muy alta)"
 
@@ -2541,7 +2549,7 @@ msgstr ""
 "cambiarán a '${email}' al hacer clic en el enlace de confirmación siguiente."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Confirme su nueva dirección de correo electrónico haciendo clic en el enlace "
@@ -2599,7 +2607,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "de 50 a 249 empleados"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Ya existe una cuenta con esta dirección de correo electrónico."
 
@@ -2609,12 +2617,12 @@ msgid "error_existing_login"
 msgstr "El nombre de login ya existe."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Introduzca un presupuesto en euros."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Introduzca una dirección de correo electrónico válida"
 
@@ -2629,65 +2637,65 @@ msgid "error_invalid_xml"
 msgstr "Cargue un archivo XML válido"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Introduzca su dirección de correo electrónico"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Introduzca una contraseña"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Las contraseñas no coinciden"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "La contraseña debe tener al menos 12 carácteres y debe contener al menos una "
 "letra minúscula, una letra mayúscula y un dígito."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Esta fecha debe ser igual o posterior a la fecha de inicio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Esta fecha debe ser igual o anterior a la fecha de finalización."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "El valor debe ser un número entero positivo."
 
@@ -2796,7 +2804,7 @@ msgstr ""
 "fusionar los cambios realizados en la herramienta OiRA en su sesión."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 "Este riesgo se ha establecido como existente por defecto. No se puede "
@@ -2830,7 +2838,7 @@ msgstr "Informe de identificación ${title}"
 msgid "filename_report_timeline"
 msgstr "Plan de acción ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2851,7 +2859,7 @@ msgid "french"
 msgstr "Dos criterios simplificados"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Casi nunca"
 
@@ -2861,57 +2869,57 @@ msgid "frequency_almostnever"
 msgstr "Casi nunca"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Constante"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "No muy frecuente"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Una vez al mes"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Frecuente"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Una vez a la semana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Raro"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Una vez al año"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Muy frecuente o habitual"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Mínimo una vez al día"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regular"
@@ -2936,12 +2944,12 @@ msgid "header_additional_content"
 msgstr "Contenido adicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Recursos adicionales para evaluar el riesgo"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Recursos adicionales para este módulo"
 
@@ -3184,23 +3192,23 @@ msgid "header_risk_aware"
 msgstr "¿Es consciente de todos los riesgos?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "¿Cuál es la gravedad del daño?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "¿Con qué frecuencia está expuesta la gente a este riesgo?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Seleccione la prioridad de este riesgo"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "¿Cuál es la probabilidad de que se produzca el riesgo?"
 
@@ -3266,7 +3274,7 @@ msgid "header_settings"
 msgstr "Ajustes"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Medidas estándar"
 
@@ -3507,7 +3515,7 @@ msgid "help_authentication"
 msgstr "Este texto debe explicar cómo registrarse e iniciar sesión."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Responda a las siguientes preguntas. Como resultado de sus respuestas, el "
@@ -3543,7 +3551,7 @@ msgstr ""
 "empezar con una copia de una herramienta OiRA existente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Indicar con qué frecuencia se produce el riesgo en una situación normal."
@@ -3556,13 +3564,13 @@ msgstr ""
 "usuario podrá seguir cambiando la prioridad."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Indicar la probabilidad de que ocurra este riesgo en una situación normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Indique la gravedad si este riesgo se produce."
 
@@ -3705,9 +3713,9 @@ msgstr ""
 "Describa el nivel de experiencia necesario para implantar la medida, por "
 "ejemplo \"sentido común (no se requieren conocimientos de OSH)\", \"no se "
 "requiere experiencia específica con OSH, pero se requiere un conocimiento "
-"sobre OSH mínimo o formación y/o consultoría sobre OSH\" o \"experto en OSH"
-"\". También puede describir aquí cualquier otro requisito adicional (si lo "
-"hay)."
+"sobre OSH mínimo o formación y/o consultoría sobre OSH\" o \"experto en "
+"OSH\". También puede describir aquí cualquier otro requisito adicional (si "
+"lo hay)."
 
 #. Default: "Include any relevant information that may be helpful for the end-user."
 #: euphorie/content/module.py:52 euphorie/content/page.py:17
@@ -4182,13 +4190,13 @@ msgstr "La cuenta está bloqueada"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Plan de acción"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Presupuesto"
@@ -4200,21 +4208,21 @@ msgstr "Plan de acción"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Final del plan"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "¿Quién es responsable?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Inicio del plan"
@@ -4237,7 +4245,7 @@ msgid "label_alphabetical"
 msgstr "Alfabéticamente"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Evaluación"
 
@@ -4329,7 +4337,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4415,7 +4423,7 @@ msgid "label_delete_risk"
 msgstr "Está a punto de eliminar el riesgo: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Descripción"
@@ -4461,7 +4469,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Evaluación"
 
@@ -4487,7 +4495,7 @@ msgid "label_existing_measure"
 msgstr "Medida ya aplicada"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Medidas ya implantadas"
@@ -4498,7 +4506,7 @@ msgid "label_exit"
 msgstr "Salir"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Competencias"
 
@@ -4513,7 +4521,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Añadir otra medida"
 
@@ -4618,7 +4626,7 @@ msgstr "Historial"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identificación"
 
@@ -4628,7 +4636,7 @@ msgid "label_image"
 msgstr "Archivo de imagen"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Medida implementada"
 
@@ -4655,7 +4663,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Implicación"
 
@@ -4703,8 +4711,8 @@ msgstr "Más información sobre OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Referencias legales y de política"
 
@@ -4767,7 +4775,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Enfoque general (para eliminar o reducir el riesgo)"
@@ -4780,7 +4788,7 @@ msgstr "Acciones específicas necesarias para implantar este enfoque"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Nivel de experiencia y/o requisitos necesarios"
@@ -4915,12 +4923,12 @@ msgstr "No, se requieren más medidas"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Notas"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4976,14 +4984,14 @@ msgid "label_password_confirm"
 msgstr "Repita la contraseña"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Medidas planificadas"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Preparación"
 
@@ -5075,13 +5083,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Borrar esta medida"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Informe"
 
@@ -5225,7 +5233,7 @@ msgid "label_select_assessment"
 msgstr "Seleccione una evaluación de riesgos"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Seleccione una o varias de las medidas habituales indicadas."
 
@@ -5246,7 +5254,7 @@ msgid "label_select_oira_tool"
 msgstr "Seleccione una herramienta OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Seleccionar medidas pre-establecidas"
 
@@ -5718,8 +5726,8 @@ msgid "menu_import"
 msgstr "Importar herramienta OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Formación"
 
@@ -5768,13 +5776,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "No puede borrar la única versión de la herramienta OiRA."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Faltan datos obligatorios."
 
@@ -6029,7 +6042,7 @@ msgstr "Ajustes"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Grado de cumplimentación"
 
@@ -6178,14 +6191,14 @@ msgstr ""
 "ayuda de Oira estén listos."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Este comentario será visible en el informe. Úselo para cualquier otra cosa "
 "que desee escribir sobre este riesgo."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Estas notas serán visibles en el informe y en la formación. Úselas para "
@@ -6215,45 +6228,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Alto"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Bajo"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Medio"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Grande"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Media"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Pequeña"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% completa"
 
@@ -6321,7 +6334,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6333,7 +6346,7 @@ msgstr ""
 "de descarga. Regístrese en un solo paso y acceda a las siguientes ventajas:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6402,25 +6415,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Este es un riesgo prioritario ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "alto"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "bajo"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "medio"
@@ -6436,7 +6449,7 @@ msgid "risk_show_na_na"
 msgstr "no procede"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Medida ${number}"
 
@@ -6502,46 +6515,46 @@ msgstr ""
 "seguridad, es mejor la primera opción."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "No muy grave"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Necesidad de parar de trabajar menos de 3 días"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Grave"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Necesidad de parar de trabajar mas de 3 días"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Muy grave"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Lesión irreversible, enfermedad incurable, muerte"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Débil"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "No hay necesidad de parar de trabajar"
 
@@ -6640,12 +6653,12 @@ msgid "title_about"
 msgstr "Información sobre"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Borrar cuenta"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:05+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Estonian\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -166,16 +166,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -198,7 +202,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -288,7 +292,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -539,7 +543,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -570,11 +574,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -643,7 +647,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -1024,11 +1028,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -1041,13 +1045,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1116,7 +1120,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1133,7 +1137,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1171,7 +1175,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1216,7 +1220,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1232,7 +1236,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1267,7 +1271,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1308,7 +1312,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1322,6 +1326,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1437,7 +1445,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1446,7 +1454,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1546,42 +1554,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1653,7 +1661,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1694,7 +1702,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2032,12 +2040,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2201,17 +2209,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2256,7 +2264,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2310,7 +2318,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2320,12 +2328,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2340,63 +2348,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2514,7 +2522,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2535,7 +2543,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2545,57 +2553,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2616,12 +2624,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2863,23 +2871,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2943,7 +2951,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3184,7 +3192,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3209,7 +3217,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 
@@ -3219,12 +3227,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 
@@ -3713,13 +3721,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3731,21 +3739,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3768,7 +3776,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3860,7 +3868,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -3946,7 +3954,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -3992,7 +4000,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -4018,7 +4026,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4029,7 +4037,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4044,7 +4052,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4149,7 +4157,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4159,7 +4167,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4186,7 +4194,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4234,8 +4242,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4298,7 +4306,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4311,7 +4319,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4444,12 +4452,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4505,14 +4513,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4604,13 +4612,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4752,7 +4760,7 @@ msgid "label_select_assessment"
 msgstr "Valige riskihindamine"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4771,7 +4779,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5230,8 +5238,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5280,13 +5288,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5517,7 +5530,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5660,12 +5673,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5692,45 +5705,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5795,7 +5808,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5805,7 +5818,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5866,25 +5879,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5900,7 +5913,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -5957,46 +5970,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6085,12 +6098,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -144,16 +144,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -176,7 +180,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid "Are you sure you want to delete this measure? This action can not be reverted."
 msgstr ""
 
@@ -260,7 +264,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -503,7 +507,7 @@ msgstr ""
 msgid "However, you can spend whatever time you have available on an assessment and then return to it when convenient to pick up from the same point you left off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -534,11 +538,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -605,7 +609,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -836,7 +840,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -963,11 +967,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -980,13 +984,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1052,7 +1056,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1069,7 +1073,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1101,7 +1105,7 @@ msgstr ""
 msgid "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid "The current text in the fields 'Action plan', 'Prevention plan' and 'Requirements' of this measure will be overwritten. This action cannot be reverted. Are you sure you want to continue?"
 msgstr ""
 
@@ -1137,7 +1141,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1185,7 +1189,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1226,7 +1230,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1240,6 +1244,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1336,7 +1344,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1345,7 +1353,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1445,42 +1453,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1552,7 +1560,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1593,7 +1601,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -1931,12 +1939,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2098,17 +2106,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2153,7 +2161,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2207,7 +2215,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2217,12 +2225,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2237,63 +2245,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2383,7 +2391,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2411,7 +2419,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2432,7 +2440,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2442,57 +2450,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2514,12 +2522,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2762,23 +2770,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2842,7 +2850,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3083,7 +3091,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3109,7 +3117,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837
+#: euphorie/client/browser/risk.py:891
 #: euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
@@ -3120,13 +3128,13 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832
+#: euphorie/client/browser/risk.py:886
 #: euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841
+#: euphorie/client/browser/risk.py:895
 #: euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
@@ -3616,13 +3624,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3634,21 +3642,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3671,7 +3679,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3764,7 +3772,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -3850,7 +3858,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -3897,7 +3905,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -3923,7 +3931,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -3934,7 +3942,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -3949,7 +3957,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4056,7 +4064,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4067,7 +4075,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4094,7 +4102,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4142,8 +4150,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4207,7 +4215,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4220,7 +4228,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4354,12 +4362,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4415,14 +4423,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4514,13 +4522,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4662,7 +4670,7 @@ msgid "label_select_assessment"
 msgstr ""
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4681,7 +4689,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5140,8 +5148,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5190,13 +5198,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5428,7 +5441,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5571,12 +5584,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5603,45 +5616,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5707,7 +5720,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5717,7 +5730,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5779,25 +5792,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5813,7 +5826,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -5870,46 +5883,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -5998,12 +6011,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,7 +166,7 @@ msgstr "Lisää käyttäjä"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Lisätoimenpide"
 
@@ -186,16 +186,20 @@ msgstr "Kaikki kieliversiot"
 msgid "Almost done&hellip;"
 msgstr "Melkein valmista&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Virhe vahvistusviestin lähetyksessä."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -218,7 +222,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Haluatko varmasti jatkaa? Tätä toimintoa et pysty perumaan."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -314,7 +318,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Vahvista OiRA-sähköpostiosoitteen muutos"
 
@@ -570,7 +574,7 @@ msgstr ""
 "osissa sopivina ajankohtina. OiRA-sovellus tallentaa tekemäsi työn, jolloin "
 "sinun on helppo palata siihen kohtaan, johon viimeksi jäit."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Haluan jakaa seuraavan kanssasi"
 
@@ -601,13 +605,13 @@ msgstr "Lisätietoja"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Tarkista kuvan tiedostomuoto. Tallennettavan kuvan tulee olla PNG-, JPEG- "
 "tai GIF-muodossa."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Väärä salasana"
 
@@ -678,7 +682,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Toimenpide"
@@ -946,7 +950,7 @@ msgstr "Ota huomioon kaavakkeen alla olevat esimerkit."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "arvioimatta"
 
@@ -1095,11 +1099,11 @@ msgstr "Riskinarvioinnit"
 msgid "Risk assessments made with this tool"
 msgstr "Tämän välineen avulla tehdyt riskinarvioinnit"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "kehitettävää"
 
@@ -1112,13 +1116,13 @@ msgid "Run slideshow"
 msgstr "Katso diaesitys"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Tallenna"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Tallenna muutokset"
@@ -1191,7 +1195,7 @@ msgstr "Yksittäinen esiintyminen lyhyesti"
 msgid "Standard"
 msgstr "Vakio"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Ehdotetut toimenpiteet"
 
@@ -1208,7 +1212,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Vastaa kysymyksiin"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1254,7 +1258,7 @@ msgstr ""
 "Online-muotoisen vuorovaikutteisen riskinarvioinnin perusarkkitehtuuri "
 "koostuu seuraavista tekijöistä :"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Tallennettavia muutoksia ei ollut."
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Tämä sähköposti ei ole käytettävissä."
 
@@ -1358,7 +1362,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1399,7 +1403,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "vastaus puuttuu"
 
@@ -1414,6 +1418,10 @@ msgstr "Lataa tätä riskiä havainnollistava kuva."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Lataa kuva"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1550,7 +1558,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Olet nyt tutustunut koulutusmateriaaliin!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Sähköpostiosoitteesi on päivitetty."
 
@@ -1559,7 +1567,7 @@ msgid "Your password for confirmation"
 msgstr "Salasanasi vahvistusta varten"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Salasanasi on muutettu."
 
@@ -1686,35 +1694,35 @@ msgid "about_partners_3_smb"
 msgstr "mikro- ja pienyrityksillä on joitakin puutteita"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 "Kuvaa tähän ne toimenpiteet, jotka tarvitaan riskin poistamiseksi tai "
 "pienentämiseksi."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Valitse tai kuvaa ne toimenpiteet, jotka tarvitaan riskin poistamiseksi tai "
 "pienentämiseksi."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 "Valitse tai kuvaa ne toimenpiteet, jotka tarvitaan riskin poistamiseksi tai "
 "pienentämiseksi."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "Valitse tai kuvaa muut mahdolliset toimenpiteet, jotka tarvitaan riskin "
 "poistamiseksi tai pienentämiseksi."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Toimenpiteiden toteutuksesta saattaa syntyä kustannuksia, joihin tulee "
@@ -1722,14 +1730,14 @@ msgstr ""
 "vuosibudjetiin."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Nimeä tälle toimenpiteelle vastuuhenkilö, joka on valtuutettu toimenpiteiden "
 "toteuttamiseen ja/tai varmistamaan, että ne tulevat tehdyksi."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Kuvaa: Henkilöstöön, tiloihin, laitteisiin tms. kohdentuva yleinen "
@@ -1738,7 +1746,7 @@ msgstr ""
 "(esim. yrityksen prosessien kehittäminen, hankinnat)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Kuvaa: yrityksessä toimenpiteiden toteuttamiseksi tarvittava asiantuntemus "
@@ -1826,7 +1834,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: myönteiset lausumat, jotka sisältyvät moduuleihin."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Lisää"
 
@@ -1867,7 +1875,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Peruuta"
@@ -2280,14 +2288,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Valitse ne osiot, joita et halua sisällyttää mukaan koulutusmateriaaliin. "
 "Harmaana näkyvät osiot jäävät pois koulutusmateriaalista."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Sovellus määrittää riskin suuruuden automaattisesti. Voit tarvittaessa "
@@ -2474,17 +2482,17 @@ msgid "effect_high"
 msgstr "Suuri (erittäin suuri) vakavuus"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Vähäinen"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Merkittävä"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Sietämätön"
 
@@ -2531,7 +2539,7 @@ msgstr ""
 "'${email}', kun napautat alla olevaa hyväksymislinkkiä."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Vahvista uusi sähköpostiosoitteesi napauttamalla linkkiä sähköpostissa, joka "
@@ -2590,7 +2598,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 – 249 työntekijää"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Tämän sähköpostiosoitteen sisältävä tili on jo olemassa."
 
@@ -2600,12 +2608,12 @@ msgid "error_existing_login"
 msgstr "Tämä kirjautumisnimi on jo käytössä."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Anna budjetti kokonaisina summina euroina."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Kirjoita voimassaoleva sähköpostiosoite"
 
@@ -2620,65 +2628,65 @@ msgid "error_invalid_xml"
 msgstr "Lähetä kelvollinen XML-tiedosto"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Kirjoita sähköpostiosoitteesi"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Kirjoita salasana"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Salasanat eivät täsmää"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Salasanan tulee sisältää vähintään 12 merkkiä, joista vähintään yhden merkin "
 "tulee olla pieni kirjain, yhden iso kirjain ja yhden numero."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Päivämäärän on oltava sama kuin alkamispäivä tai sitä myöhempi."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Päivämäärän on oltava sama kuin päättymispäivä tai sitä aiempi."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Kohtaan on merkittävä positiivinen kokonaisluku."
 
@@ -2791,7 +2799,7 @@ msgstr ""
 "täytyy päivittää nämä muutokset, ennen kuin voit jatkaa."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2822,7 +2830,7 @@ msgstr "Tunnistusraportti ${title}"
 msgid "filename_report_timeline"
 msgstr "Toimintasuunnitelma ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2843,7 +2851,7 @@ msgid "french"
 msgstr "Kaksi yksinkertaistettua kriteeriä"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Ei juuri koskaan"
 
@@ -2853,57 +2861,57 @@ msgid "frequency_almostnever"
 msgstr "Ei juuri koskaan"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Jatkuvasti"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Ei kovin usein"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Kerran kuukaudessa"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Usein"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Kerran viikossa"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Harvoin"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Kerran vuodessa"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Erittäin usein tai säännöllisesti"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Vähintään kerran päivässä"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Säännöllisesti"
@@ -2927,12 +2935,12 @@ msgid "header_additional_content"
 msgstr "Ylimääräinen sisältö"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Lisämateriaalia riskinarviointia varten"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Lisämateriaalia tähän osioon"
 
@@ -3175,23 +3183,23 @@ msgid "header_risk_aware"
 msgstr "Oletko tietoinen kaikista riskeistä?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Minkälainen on vahingon vakavuus?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Kuinka usein ihmiset altistuvat tälle riskille?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Määritä riskin suuruus"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Minkälainen on tämän riskin toteutumismahdollisuus?"
 
@@ -3255,7 +3263,7 @@ msgid "header_settings"
 msgstr "Asetukset"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Vakiotoimenpiteet"
 
@@ -3499,7 +3507,7 @@ msgstr ""
 "Tämän teksin tulee kuvailla, kuinka voi rekisteröityä ja kirjautua sisään."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Vastaa seuraaviin kysymyksiin: Sovellus määrittelee vastaustesi perusteella "
@@ -3532,7 +3540,7 @@ msgstr ""
 "riskinarvioinnista."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Ilmoita, kuinka usein riski esiintyy normaalissa tilanteessa."
 
@@ -3544,14 +3552,14 @@ msgstr ""
 "riskin suuruutta sovelluksessa."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Ilmoita, kuinka todennäköistä tämän riskin esiintyminen on normaalissa "
 "tilanteessa."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Ilmoita vakavuusaste tämän riskin ilmentyessä."
 
@@ -4156,13 +4164,13 @@ msgstr "Tili on lukittu"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Toimintasuunnitelma"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budjetti"
@@ -4174,21 +4182,21 @@ msgstr "Toimintasuunnitelma"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Toimenpiteet toteutettu/tilanne kunnossa"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Vastuuhenkilö"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Aikataulu: Toimenpiteiden suunnittelu"
@@ -4211,7 +4219,7 @@ msgid "label_alphabetical"
 msgstr "Aakkosjärjestys"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Tunnistus ja arviointi"
 
@@ -4303,7 +4311,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4389,7 +4397,7 @@ msgid "label_delete_risk"
 msgstr "Olet poistamassa lisäämääsi riskitekijää: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Kuvaus"
@@ -4435,7 +4443,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Arviointi"
 
@@ -4461,7 +4469,7 @@ msgid "label_existing_measure"
 msgstr "Toimenpide on jo toteutettu"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Käytössä olevat toimenpiteet"
@@ -4472,7 +4480,7 @@ msgid "label_exit"
 msgstr "Poistu"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Asiantuntemus"
 
@@ -4487,7 +4495,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Lisää muita toimenpiteitä"
 
@@ -4592,7 +4600,7 @@ msgstr "Versiohistoria"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Tunnistaminen"
 
@@ -4602,7 +4610,7 @@ msgid "label_image"
 msgstr "Kuvatiedosto"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Toteutettu toimenpide"
 
@@ -4629,7 +4637,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Osallistuminen ja yhteistyö"
 
@@ -4677,8 +4685,8 @@ msgstr "Lue lisää OiRAsta"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Oikeudelliset ja toimintaperiaatteita koskevat viitteet"
 
@@ -4741,7 +4749,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Toimenpide riskin poistamiseksi tai pienentämiseksi"
@@ -4756,7 +4764,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Tarvittava asiantuntemus ja/tai ulkopuolisen tuen tarve"
@@ -4889,12 +4897,12 @@ msgstr "Ei, tarvitaan lisätoimenpiteitä"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Huomautuksia"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4950,14 +4958,14 @@ msgid "label_password_confirm"
 msgstr "Toista salasana"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Suunnitellut toimenpiteet"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Suunnittelu"
 
@@ -5050,13 +5058,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Poista tämä toimenpide"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Raportti"
 
@@ -5198,7 +5206,7 @@ msgid "label_select_assessment"
 msgstr "Valitse riskinarviointi"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Valitse yksi tai useampi tunnetuista yleisistä toimenpiteistä."
 
@@ -5217,7 +5225,7 @@ msgid "label_select_oira_tool"
 msgstr "Valitse OiRA-työkalu"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Valitse toimenpiteet"
 
@@ -5690,8 +5698,8 @@ msgid "menu_import"
 msgstr "Tuo OiRA-työkalu"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Koulutus"
 
@@ -5744,13 +5752,18 @@ msgstr ""
 "Tämä on OiRA-työkalun ainoa versio, minkä vuoksi sitä ei voi poistaa. "
 "Halusitko ehkä poistaa OiRA-työkalun itsessään?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Täytä tämä kenttä."
 
@@ -6002,7 +6015,7 @@ msgstr "Asetukset"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Riskinarvioinnin tila"
 
@@ -6152,14 +6165,14 @@ msgstr ""
 "OiRAn koulutussuunnitelma ja OiRAn tukipalvelut ovat valmiina."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Tähän lisätty teksti näkyy raportilla. Kirjaa tähän mahdollisia lisätietoja "
 "riskiväittämään liittyen."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Nämä muistiinpanot näkyvät raporteilla ja koulutusmateriaalissa. Kirjaa "
@@ -6190,45 +6203,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "korkea"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "vähäinen"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "kohtalainen"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "todennäköinen"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "mahdollinen"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "epätodennäköinen"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Täydellinen"
 
@@ -6296,7 +6309,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6308,7 +6321,7 @@ msgstr ""
 "Rekisteröityminen vie hetken, ja saat siitä seuraavia etuja:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6378,25 +6391,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Riskitaso on suuruudeltaan ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "korkea"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "vähäinen"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "kohtalainen"
@@ -6412,7 +6425,7 @@ msgid "risk_show_na_na"
 msgstr "ei sovelleta"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Toimenpide ${number}"
 
@@ -6478,46 +6491,46 @@ msgstr ""
 "uudelleenkirjautumista varten."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Ei erittäin vakava"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Työt täytyy keskeyttää alle 3 päiväksi"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "haitalliset"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Työt täytyy keskeyttää yli 3 päiväksi"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "vakavat"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Pysyvä vamma, parantumaton sairaus, kuolema"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "vähäiset"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Työntekoa ei tarvitse keskeyttää"
 
@@ -6616,12 +6629,12 @@ msgid "title_about"
 msgstr "Tietoja"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Poista tili"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 15:59+0200\n"
 "Last-Translator: lemoine <xuelinlem@gmail.com>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -174,7 +174,7 @@ msgstr "Ajouter un utilisateur"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Mesure additionnelle"
 
@@ -194,16 +194,20 @@ msgstr "Langue"
 msgid "Almost done&hellip;"
 msgstr "Vous avez presque terminé&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Une erreur s’est produite lors de l’envoi de l’email de confirmation."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -226,7 +230,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Êtes vous sûr de vouloir continuer. Cette action est irreversible."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -322,7 +326,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Confirmer le changement d’adresse email OiRA"
 
@@ -585,7 +589,7 @@ msgstr ""
 "limité puis y revenir lorsque vous le désirez pour reprendre là où vous vous "
 "étiez arrêté. "
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 "Je souhaite vous faire découvrir cet outil d’aide à l’évaluation des risques"
@@ -617,12 +621,12 @@ msgstr "Information"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Le format de l’image est non valide. Veuillez utiliser : PNG, JPEG, GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Mot de passe invalide"
 
@@ -694,7 +698,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Mesure"
@@ -956,7 +960,7 @@ msgstr "Veuillez vous référer aux exemples présentés en dessous du formulair
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "A faire"
 
@@ -1099,11 +1103,11 @@ msgstr "Évaluations des risques"
 msgid "Risk assessments made with this tool"
 msgstr "Évaluations des risques réalisées avec cet outil"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Attention"
 
@@ -1116,13 +1120,13 @@ msgid "Run slideshow"
 msgstr "Lancer le diaporama"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Sauvegarder"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Sauvegarder les modifications"
@@ -1195,7 +1199,7 @@ msgstr "Message-guide d’une occurrence unique"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Mesures standards"
 
@@ -1212,7 +1216,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Commencez les questions"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1258,7 +1262,7 @@ msgstr ""
 "L’architecture de base d’une évaluation des risques interactive en ligne est "
 "la suivante:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1308,7 +1312,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Aucun changement à enregistrer."
 
@@ -1324,7 +1328,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Cette adresse email n’est pas disponible."
 
@@ -1362,7 +1366,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1403,7 +1407,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Sans réponse"
 
@@ -1418,6 +1422,10 @@ msgstr "Télécharger une image pour illustrer ce risque."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Télécharger image"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1556,7 +1564,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Vous avez terminé avec les diapositives de formation !"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Votre adresse email a été actualisée."
 
@@ -1565,7 +1573,7 @@ msgid "Your password for confirmation"
 msgstr "Votre mot de passe à confirmer "
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Votre mot de passe a été changé avec succès."
 
@@ -1712,32 +1720,32 @@ msgid "about_partners_3_smb"
 msgstr "les micro et petites entreprises rencontrent certaines difficultés"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Décrivez les mesures spécifiques nécessaires pour prévenir le risque."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Sélectionnez ou décrivez les mesures spécifiques nécessaires pour réduire le "
 "risque."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 "Décrivez les éventuelles mesures supplémentaires pour réduire le risque."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "Sélectionnez ou décrivez les éventuelles mesures supplémentaires pour "
 "réduire le risque."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Bien que la plupart des mesures ne coûtent pas d’argent, certaines peuvent "
@@ -1745,7 +1753,7 @@ msgstr ""
 "incluses dans les négociations du budget annuel si nécessaire."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Nommez quelqu’un dans votre société, responsable de la mise en place de "
@@ -1753,7 +1761,7 @@ msgstr ""
 "dans le plan et/ou la responsabilité de garantir qu’elles sont effectuées."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Décrire : 1) quelle est votre approche générale pour éliminer ou (si le "
@@ -1762,7 +1770,7 @@ msgstr ""
 "éliminer ou réduire le risque)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Décrire : 3) le niveau d’expérience nécessaire pour mettre en place la "
@@ -1851,7 +1859,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: déclarations positives contenues dans les modules."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Ajouter"
 
@@ -1892,7 +1900,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annuler "
@@ -2315,14 +2323,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Veuillez cocher tout ce que vous souhaitez exclure de la formation. Les "
 "éléments grisés ne seront pas affichés dans la session de formation."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "L’évaluation du risque a été effectuée automatiquement par l’outil.   Vous "
@@ -2516,17 +2524,17 @@ msgid "effect_high"
 msgstr "Grave (très grave)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Faible"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Important"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Grave (très grave)"
 
@@ -2573,7 +2581,7 @@ msgstr ""
 "'${email}' lorsque vous cliquerez sur le lien de confirmation ci-dessous."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Veuillez confirmer votre nouvelle adresse email en cliquant sur le lien dans "
@@ -2636,7 +2644,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 à 249 employés"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Il existe déjà un compte associé à cette adresse e-mail."
 
@@ -2646,12 +2654,12 @@ msgid "error_existing_login"
 msgstr "Ce nom d’utilisateur existe déjà."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Veuillez saisir un nombre entier pour le budget en Euros."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Veuillez entrer une adresse email valide"
 
@@ -2668,65 +2676,65 @@ msgid "error_invalid_xml"
 msgstr "Veuillez télécharger un fichier XML valide"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Veuillez saisir votre adresse e-mail"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Veuillez saisir un mot de passe "
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Les mots de passe ne correspondent pas "
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Le mot de passe doit être compose d’au moins 12 caractères et contenir au "
 "moins une lettre majuscule, une minuscule et un chiffre."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Cette date doit se situer après la date de début."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Cette date doit se situer avant la date de fin."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Cette valeur doit être un nombre entier positif."
 
@@ -2852,7 +2860,7 @@ msgstr ""
 "session."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2884,7 +2892,7 @@ msgstr "Oira liste des risques ${title}"
 msgid "filename_report_timeline"
 msgstr "Plan d’action ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2905,7 +2913,7 @@ msgid "french"
 msgstr "Cotation calculée simple (2 critères)"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Presque jamais"
 
@@ -2915,57 +2923,57 @@ msgid "frequency_almostnever"
 msgstr "Presque jamais"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Constamment"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Moyenne"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Exposition de l’ordre de une fois par mois"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Fréquente"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Exposition de l’ordre de une fois par semaine"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Faible"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Exposition de l’ordre de une fois par an"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Très fréquente"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Exposition quotidienne ou permanente"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Régulièrement"
@@ -2991,12 +2999,12 @@ msgid "header_additional_content"
 msgstr "Contenu supplémentaire"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Ressources supplémentaires pour évaluer le risque"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Ressources supplémentaires pour ce module"
 
@@ -3240,23 +3248,23 @@ msgid "header_risk_aware"
 msgstr "Êtes-vous conscient de tous les risques?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Quel est le niveau de gravité des dommages ?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "À quelle fréquence les gens sont-ils exposés à ce risque ?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Sélectionnez la priorité de ce risque"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Quelle est la probablilité d’apparition de ce risque ?"
 
@@ -3322,7 +3330,7 @@ msgid "header_settings"
 msgstr "Paramètres"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Mesures standard"
 
@@ -3566,7 +3574,7 @@ msgid "help_authentication"
 msgstr "Ce texte devrait expliquer comment s’enregistrer et se connecter."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Veuillez répondre aux questions suivantes.  En fonction de vos réponses, le "
@@ -3600,7 +3608,7 @@ msgstr ""
 "souhaitez démarrer avec une copie d’un outil OiRA existant."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Indiquez la fréquence de l’apparition de ce risque dans une situation "
@@ -3614,14 +3622,14 @@ msgstr ""
 "défaut. Il / Elle peut toujours changer la priorité."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Indiquez le degré de probabilité de l’apparition de ce risque dans une "
 "situation normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Indiquer la gravité si ce risque se produit."
 
@@ -3852,9 +3860,9 @@ msgstr ""
 #: euphorie/content/risk.py:146
 msgid "help_risk_type"
 msgstr ""
-"Le “ Risque prioritaire ” est l’un des plus grands risques du secteur. “ "
-"Risque ” fait référence au lieu de travail ou au travail effectué. “ "
-"Politique ” fait référence aux accords, aux procédures et aux décisions de "
+"Le “ Risque prioritaire ” est l’un des plus grands risques du secteur. "
+"“ Risque ” fait référence au lieu de travail ou au travail effectué. "
+"“ Politique ” fait référence aux accords, aux procédures et aux décisions de "
 "gestion."
 
 #. Default: "Give the name of the person responsible for the OiRA tools of this sector."
@@ -4275,13 +4283,13 @@ msgstr "Le compte est verrouillé"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Plan d’action"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budget"
@@ -4293,21 +4301,21 @@ msgstr "Plan d’action"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Date de fin prévue"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Qui est responsable ?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Date de commencement prévue"
@@ -4330,7 +4338,7 @@ msgid "label_alphabetical"
 msgstr "Alphabétique"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Evaluation"
 
@@ -4422,7 +4430,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr "Conseil"
 
@@ -4509,7 +4517,7 @@ msgstr ""
 "Vous êtes sur le point de supprimer le risque: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Description"
@@ -4555,7 +4563,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Estimation"
 
@@ -4581,7 +4589,7 @@ msgid "label_existing_measure"
 msgstr "Mesure déjà en place"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Des mesures déjà mises en place"
@@ -4592,7 +4600,7 @@ msgid "label_exit"
 msgstr "Quitter"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Expertise"
 
@@ -4607,7 +4615,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Ajouter une mesure supplémentaire"
 
@@ -4712,7 +4720,7 @@ msgstr "Historique"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identification"
 
@@ -4722,7 +4730,7 @@ msgid "label_image"
 msgstr "Fichier image"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Mesure déjà en place"
 
@@ -4749,7 +4757,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr "Invalider l’analyse des risques"
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Impliquer"
 
@@ -4797,8 +4805,8 @@ msgstr "En savoir plus sur OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Références légales et de politique"
 
@@ -4861,7 +4869,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Décrivez cette mesure"
@@ -4875,7 +4883,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -5012,12 +5020,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Remarques"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -5073,14 +5081,14 @@ msgid "label_password_confirm"
 msgstr "Répétez le mot de passe"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Mesures prévues"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Préparation"
 
@@ -5172,13 +5180,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Effacer cette mesure"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Rapport"
 
@@ -5320,7 +5328,7 @@ msgid "label_select_assessment"
 msgstr "Sélectionner une évaluation des risques"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Sélectionner une ou plusieurs des mesures communes connues fournies."
 
@@ -5339,7 +5347,7 @@ msgid "label_select_oira_tool"
 msgstr "Sélectionner un outil OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Sélectionner des mesures standards"
 
@@ -5815,8 +5823,8 @@ msgid "menu_import"
 msgstr "Importer outil OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Formation"
 
@@ -5869,13 +5877,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Vous ne pouvez pas effacer la seule version de l’Outil OiRA."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Ce champ est requis."
 
@@ -6154,7 +6167,7 @@ msgstr "Paramètres"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Avancement"
 
@@ -6306,14 +6319,14 @@ msgstr ""
 "programme de formation OiRA et le centre d’assistance OiRA seront prêts."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Votre commentaire sera retranscrit dans le rapport. Reporter ici tout "
 "information que vous jugez utiles au sujet de ce risque."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Ces notes seront visibles dans le rapport et la formation. Utilisez-les pour "
@@ -6342,45 +6355,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Élevée"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Faible"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Moyenne"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Élevée"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Moyenne"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Faible"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Complet"
 
@@ -6449,7 +6462,7 @@ msgid "report_end_date"
 msgstr "Date de fin : ${date}"
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6462,7 +6475,7 @@ msgstr ""
 "bénéficier des avantages suivants :"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6534,25 +6547,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Ceci est un risque prioritaire ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "élevé"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "bas"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "moyen"
@@ -6568,7 +6581,7 @@ msgid "risk_show_na_na"
 msgstr "ne s’applique pas"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Mesure ${number}"
 
@@ -6634,46 +6647,46 @@ msgstr ""
 "vaut mieux vous déconnecter activement."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Moyenne"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Accident ou maladie ave arrêt de travail"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Grave"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Accident ou maladie avec incapacité permanente partielle"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Très grave"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Accident ou maladie mortel"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Faible"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Accident ou maladie sans arrêt de travail"
 
@@ -6747,8 +6760,8 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session-test.pt:95
 msgid "testsession_register"
 msgstr ""
-"Ou ${register_link} à la place. Découvrez pourquoi vous devriez vous inscrire"
-"${tooltip_register}."
+"Ou ${register_link} à la place. Découvrez pourquoi vous devriez vous "
+"inscrire${tooltip_register}."
 
 #. Default: "add all measures that have already been implemented"
 #: euphorie/content/utils.py:58
@@ -6771,12 +6784,12 @@ msgid "title_about"
 msgstr "À propos"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Supprimer mon compte"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,7 +162,7 @@ msgstr "Dodaj korisnika"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr "Dodana preslika \"${title}\" vašem OiRA alatu."
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Dodatna mjera"
 
@@ -182,11 +182,11 @@ msgstr "Svi jezici"
 msgid "Almost done&hellip;"
 msgstr "Skoro je gotovo&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Došlo je do pogreške prilikom slanja e-pošte potvrde."
 
@@ -194,6 +194,10 @@ msgstr "Došlo je do pogreške prilikom slanja e-pošte potvrde."
 msgid "An error occured while sending the password reset instructions"
 msgstr ""
 "Došlo je do pogreške prilikom slanja uputa za ponovno postavljanje lozinke"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
+msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
 msgid "Archive"
@@ -215,7 +219,7 @@ msgstr "Jeste li sigurni da želite arhivirati ovu sesiju?"
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Jeste li sigurni da želite nastaviti? Ova se radnja ne može poništiti."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -311,7 +315,7 @@ msgstr "Komentari"
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Potvrdite promjenu OiRA adrese e-pošte"
 
@@ -571,7 +575,7 @@ msgstr ""
 "procjeni, a zatim se vratiti i nastaviti gdje ste stali kada vam to bude "
 "prikladno."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Želim s vama podijeliti sljedeće"
 
@@ -602,11 +606,11 @@ msgstr "Informacije"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nevažeći format slike. Molimo koristite PNG, JPEG ili GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Nevažeća lozinka"
 
@@ -677,7 +681,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Mjera"
@@ -937,7 +941,7 @@ msgstr "Pogledajte primjere ispod obrasca."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Odgođen"
 
@@ -1080,11 +1084,11 @@ msgstr "Procjene rizika"
 msgid "Risk assessments made with this tool"
 msgstr "Procjene rizika izvršene ovim alatom"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Rizik ne postoji"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Postoji rizik"
 
@@ -1097,13 +1101,13 @@ msgid "Run slideshow"
 msgstr "Pokreni dijaprojekciju"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Spremi"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Spremi promjene"
@@ -1175,7 +1179,7 @@ msgstr "Iniciranje jednog događaja"
 msgid "Standard"
 msgstr "Uobičajen"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Predložene mjere"
 
@@ -1192,7 +1196,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Kreni s pitanjima"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr "Pokretanje probne sesije nije dostupno u ovoj OiRA aplikaciji."
@@ -1237,7 +1241,7 @@ msgid ""
 msgstr ""
 "Osnovna arhitektura Internetske interaktivne procjene rizika sastoji se od:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1291,7 +1295,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr "Nema dovoljno podataka za prelazak u fazu prepoznavanja"
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Nema promjena za spremanje."
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Ova adresa e-pošte nije dostupna."
 
@@ -1347,7 +1351,7 @@ msgstr ""
 "Ovim se pitanjem od korisnika mora zatražiti da odgovori odnosi li se ovaj "
 "profil na njih."
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr "Ovaj zahtjev ne može biti obrađen. "
 
@@ -1388,7 +1392,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Neodgovoren"
 
@@ -1403,6 +1407,10 @@ msgstr "Učitajte sliku koja ilustrira ovaj rizik."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Učitajte sliku"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1536,7 +1544,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Završili ste sa slajdovima osposobljavanja!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Adresa vaše e-pošte je ažurirana."
 
@@ -1545,7 +1553,7 @@ msgid "Your password for confirmation"
 msgstr "Vaša lozinka za potvrdu"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Vaša lozinka je uspješno promijenjena."
 
@@ -1670,35 +1678,35 @@ msgid "about_partners_3_smb"
 msgstr "mikropoduzeća i mala poduzeća imaju neke nedostatke"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Opišite odgovarajuće mjere potrebne za smanjivanje rizika."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Odaberite ili opišite odgovarajuće mjere potrebne za smanjivanje rizika. "
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Opišite daljnju(e) mjeru(e) za smanjivanje rizika. "
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Odaberite ili opišite daljnju(e) mjeru(e) za smanjivanje rizika. "
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Iako neke mjere ne koštaju ništa, mnoge koštaju. Zbog toga za mjere treba "
 "proračun; ako je potrebno, uključite ih u godišnji proračun."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Odredite osobu u svojoj tvrtki koja će biti odgovorna za implementaciju ove "
@@ -1706,7 +1714,7 @@ msgstr ""
 "dužnosti koje će osigurati njihovo izvršenje."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Opišite: 1) koji je vaš opći pristup za uklanjanje ili (ako rizik nije "
@@ -1719,7 +1727,7 @@ msgstr ""
 "Ovdje možete opisati i bilo koji drugi dodatni zahtjev (ako takav postoji). "
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Opiši: 3) razinu ekspertize potrebnu za implementaciju mjere, npr. \"zdrav "
@@ -1810,7 +1818,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: pozitivne izjave, koje su spremljene u modulima."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Dodaj"
 
@@ -1851,7 +1859,7 @@ msgstr "Da, arhiviraj sesiju"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Odustani"
@@ -2115,8 +2123,8 @@ msgstr "Vrste podataka koji se obrađuju"
 #: euphorie/client/browser/templates/conditions-bare.pt:68
 msgid "conditions_part5_entry"
 msgstr ""
-"Obrada se temelji na članku 5. stavku 1. točkama (a) i (d)  <a href="
-"\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
+"Obrada se temelji na članku 5. stavku 1. točkama (a) i (d)  <a "
+"href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
 "L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Uredbe (EU) "
 "2018/1725</a>  Europskog parlamenta i Vijeća od 23. listopada 2018. o "
 "zaštiti pojedinaca u vezi s obradom osobnih podataka u institucijama, "
@@ -2259,14 +2267,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Molimo označite sve što želite isključiti iz osposobljavanja. Stavke koje su "
 "označene sivom bojom neće biti prikazane na kartici za osposobljavanje."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Alat je automatski procijenio rizik. U Planu mjera razina rizika može se "
@@ -2460,17 +2468,17 @@ msgid "effect_high"
 msgstr "Visoka (vrlo visoka) ozbiljnost"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Slaba"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Značajna"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Visoka (vrlo visoka)"
 
@@ -2517,7 +2525,7 @@ msgstr ""
 "'${email}' kada kliknete na donju poveznicu za potvrdu."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Potvrdite svoju novu adresu e-pošte klikom na ovu poveznicu u e-pošti koja "
@@ -2575,7 +2583,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 do 249 zaposlenika"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Račun s ovom adresom e-pošte već postoji."
 
@@ -2585,12 +2593,12 @@ msgid "error_existing_login"
 msgstr "Ovo se ime za prijavu već koristi."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Unesite proračun u cijelim eurima."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Unesite valjanu adresu e-pošte"
 
@@ -2605,65 +2613,65 @@ msgid "error_invalid_xml"
 msgstr "Prenesite valjanu XML datoteku"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Unesite adresu svoje e-pošte"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Unesite lozinku"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Lozinke se ne podudaraju"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Zaporka mora imati najmanje 12 znakova i mora sadržavati najmanje jedno malo "
 "slovo, jedno veliko slovo i jednu znamenku."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Ovaj datum mora biti isti ili veći od datuma početka."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Ovaj datum mora biti isti ili manji od datuma kraja."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Ova vrijednost mora biti pozitivan cijeli broj."
 
@@ -2771,7 +2779,7 @@ msgstr ""
 "izvršite ažuriranje kako biste preuzeli ove izmjene."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 "Ovaj je rizik automatski bio postavljen kao postojeći. Ovo ne možete "
@@ -2804,7 +2812,7 @@ msgstr "Izvješće o identifikaciji ${title}"
 msgid "filename_report_timeline"
 msgstr "Plan mjera za ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2825,7 +2833,7 @@ msgid "french"
 msgstr "Pojednostavljena dva mjerila"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Gotovo nikad"
 
@@ -2835,57 +2843,57 @@ msgid "frequency_almostnever"
 msgstr "Gotovo nikad"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Stalno"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Ne tako često"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Jednom mjesečno"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Često"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Jednom tjedno"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Rijetko"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Jednom godišnje"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Vrlo često ili redovito"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Najmanje jednom dnevno"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Redovito"
@@ -2910,12 +2918,12 @@ msgid "header_additional_content"
 msgstr "Dodatni sadržaj"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Dodatni resursi za procjenu rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Dodatni resursi za ovaj modul"
 
@@ -3157,23 +3165,23 @@ msgid "header_risk_aware"
 msgstr "Jeste li svjesni svih rizika?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Kolika je ozbiljnost štete?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Koliko su često osobe izložene ovom riziku?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Odaberite prioritet za ovaj rizik"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Koja je vjerojatnost pojave ovog rizika?"
 
@@ -3238,7 +3246,7 @@ msgid "header_settings"
 msgstr "Postavke"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Uobičajene mjere"
 
@@ -3482,7 +3490,7 @@ msgid "help_authentication"
 msgstr "Ovaj tekst pojašnjava način registracije i prijave."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Odgovorite na sljedeća pitanja. Na temelju vaših odgovora sustav će "
@@ -3516,7 +3524,7 @@ msgstr ""
 "započeti s kopijom postojećeg OiRA alata."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Navodi koliko se često ovaj rizik pojavljuje u normalnoj situaciji."
 
@@ -3528,13 +3536,13 @@ msgstr ""
 "uvijek može promijeniti prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Navodi kolika je vjerojatnost pojave ovog rizika u normalnoj situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Navodi ozbiljnost u slučaju da dođe do ovog rizika."
 
@@ -4141,13 +4149,13 @@ msgstr "Račun je zaključan"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Plan mjera"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Proračun"
@@ -4159,21 +4167,21 @@ msgstr "Plan mjera"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Planirani kraj"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Tko je odgovoran?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Planirani početak"
@@ -4196,7 +4204,7 @@ msgid "label_alphabetical"
 msgstr "Po abecednom redu"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Procjena"
 
@@ -4288,7 +4296,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4374,7 +4382,7 @@ msgid "label_delete_risk"
 msgstr "Namjeravate izbrisati rizik: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Opis"
@@ -4420,7 +4428,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "procjena"
 
@@ -4446,7 +4454,7 @@ msgid "label_existing_measure"
 msgstr "Već provedena mjera"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Provedene mjere"
@@ -4457,7 +4465,7 @@ msgid "label_exit"
 msgstr "Izlaz"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Ekspertiza"
 
@@ -4472,7 +4480,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Dodajte dodatnu mjeru"
 
@@ -4577,7 +4585,7 @@ msgstr "Povijest"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Prepoznavanje"
 
@@ -4587,7 +4595,7 @@ msgid "label_image"
 msgstr "Slikovna datoteka"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Provedena mjera"
 
@@ -4614,7 +4622,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Uključite"
 
@@ -4662,8 +4670,8 @@ msgstr "Saznaj više o OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Pravila i pravne reference"
 
@@ -4728,7 +4736,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Opći pristup (za eliminaciju ili smanjenje rizika)"
@@ -4741,7 +4749,7 @@ msgstr "Konkretna(e) aktivnost(i) potrebna(e) za implementaciju ovog pristupa"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Razina stručnosti i/ili potrebni zahtjevi"
@@ -4874,12 +4882,12 @@ msgstr "Ne, potrebno je više mjera"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Bilješke"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4935,14 +4943,14 @@ msgid "label_password_confirm"
 msgstr "Ponavljanje zaporke"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Planirane mjere"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Priprema"
 
@@ -5034,13 +5042,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Izbrišite ovu mjeru"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Završni dokumenti"
 
@@ -5183,7 +5191,7 @@ msgid "label_select_assessment"
 msgstr "Odaberite procjenu rizika"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Odaberite jednu ili više poznatih uobičajenih mjera koje su ponuđene."
 
@@ -5202,7 +5210,7 @@ msgid "label_select_oira_tool"
 msgstr "Odaberite OiRA alat"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Odaberite predložene mjere"
 
@@ -5676,8 +5684,8 @@ msgid "menu_import"
 msgstr "Uvezi OiRA alat"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Osposobljavanje"
 
@@ -5729,13 +5737,18 @@ msgstr ""
 "Ovo je jedina verzija OiRA alata i zato se ne može obrisati. Želite li možda "
 "ukloniti i sam OiRA alat?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Ispunite ovo polje."
 
@@ -5988,7 +6001,7 @@ msgstr "Postavke"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Status"
 
@@ -6138,14 +6151,14 @@ msgstr ""
 "korisnike budu spremne."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Komentar će biti vidljiv u izvješću. Koristite ga za bilo što drugo što "
 "biste mogli pisati o ovom riziku."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Te će bilješke biti vidljive u izvješću i osposobljavanju. Ovdje upišite sve "
@@ -6174,45 +6187,45 @@ msgstr "Kopirajte"
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Veliki"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Mali"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Srednji"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Velika"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Srednja"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Mala"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Dovršeno"
 
@@ -6281,7 +6294,7 @@ msgid "report_end_date"
 msgstr "Izvršit će: ${date}"
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6293,7 +6306,7 @@ msgstr ""
 "Registrirajte se u samo jednom koraku i pristupite sljedećim pogodnostima:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6361,25 +6374,25 @@ msgid "risk_present"
 msgstr "Rizik je utvrđen."
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Ovo je ${priority_value} rizik"
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "veliki"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "mali"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "srednji"
@@ -6395,7 +6408,7 @@ msgid "risk_show_na_na"
 msgstr "nije primjenjivo"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Mjera ${number}"
 
@@ -6459,46 +6472,46 @@ msgstr ""
 "aktivnih sesija."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Ne tako ozbiljna"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Potrebno je zastati s radom manje od 3 dana"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Ozbiljna"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Potrebno je zastati s radom više od 3 dana"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Vrlo ozbiljna"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Nepovratno oštećenje, neizlječiva bolest, smrt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Slaba"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Nije potrebno zastati s radom"
 
@@ -6593,12 +6606,12 @@ msgid "title_about"
 msgstr "O"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Brisanje računa"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: Florakalman <florakalman@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgstr "Felhasználó hozzáadása"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr "Hozzáadta a (z) \"$ {title}\" másolatát az OiRA eszközéhez."
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "További intézkedés(ek)"
 
@@ -184,17 +184,21 @@ msgstr "Összes nyelv"
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "A visszaigazoló e-mail elküldésekor hiba történt."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
 msgstr "Hiba történt a jelszó-visszaállítási utasítások elküldésekor"
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
+msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
 msgid "Archive"
@@ -216,7 +220,7 @@ msgstr "Biztos, hogy archiválni kívánja ezt a fejezetet?"
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Biztosan tovább lép? Később nem lehet visszavonni."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -312,7 +316,7 @@ msgstr "Megjegyzések"
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "OiRA e-mailcím megváltoztatásának megerősítése"
 
@@ -572,7 +576,7 @@ msgstr ""
 "rendelkezésére áll, majd egy későbbi alkalmas időpontban újra megnyithatja, "
 "és ott folytathatja, ahol abbahagyta."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Szeretném megosztani veletek a következőket"
 
@@ -603,12 +607,12 @@ msgstr "Információ"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Nem megfelelő képformátum. Kérem használjon PNG, JPEG vagy GIF formátumot."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Érvénytelen jelszó"
 
@@ -679,7 +683,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Intézkedés"
@@ -947,7 +951,7 @@ msgstr "Lásd az űrlap alatti példákat."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Elhalasztva"
 
@@ -1090,11 +1094,11 @@ msgstr "Kockázatértékelések"
 msgid "Risk assessments made with this tool"
 msgstr "Kockázatértékelések, amelyek ezzel az eszközzel készültek"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Rendben"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Figyelem"
 
@@ -1107,13 +1111,13 @@ msgid "Run slideshow"
 msgstr "Diavetítés indítása"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Mentés"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Változások mentése"
@@ -1186,7 +1190,7 @@ msgstr "Egyszeri előfordulás adatbevitel"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Standard intézkedések"
 
@@ -1203,7 +1207,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr "Ebben az OiRA alkalmazásban nem lehetséges teszt indítása"
@@ -1248,7 +1252,7 @@ msgid ""
 msgstr ""
 "Egy on-line interaktív kockázatértékelés alapvető felépítése a következő:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1304,7 +1308,7 @@ msgstr ""
 "Nem áll rendelkezésre elegendő információ ahhoz, hogy tovább lépjen az "
 "azonosítási fázisba"
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Nincsenek elmentésre váró változtatások."
 
@@ -1322,7 +1326,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Ez az e-mailcím nem elérhető."
 
@@ -1359,7 +1363,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr "Megkérdezi a felhasználót, hogy ez a profil alkalmazható-e rájuk."
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr "Ez a kérés nem hajtható végre."
 
@@ -1400,7 +1404,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Megválaszolatlan"
 
@@ -1415,6 +1419,10 @@ msgstr "Töltsön fel egy képet, amely a kockázatot illusztrálja"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Kép feltöltése"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1546,7 +1554,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Az e-mailcím frissítve lett."
 
@@ -1555,7 +1563,7 @@ msgid "Your password for confirmation"
 msgstr "Jelszó megerősítése"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "A jelszó megváltoztatása megtörtént."
 
@@ -1686,31 +1694,31 @@ msgid "about_partners_3_smb"
 msgstr "a mikró- és kisvállalkozások rendelkeznek gyenge pontokkal"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "A kockázat mérsékléséhez szükséges konkrét intézkedések leírása"
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "A kockázat mérsékléséhez szükséges konkrét intézkedések kiválasztása vagy "
 "leírása"
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "A kockázat mérsékléséhez szükséges bármely további intézkedés leírása"
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "A kockázat mérsékléséhez szükséges bármely további intézkedés kiválasztása "
 "vagy leírása"
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Előfordul, hogy egyes intézkedések nem kerülnek pénzbe, de a legtöbb igen. "
@@ -1718,7 +1726,7 @@ msgstr ""
 "venni az éves költségvetés összeállításába, ha szükséges."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Jelöljön ki valakit a vállalatnál, aki felelős ennek az intézkedésnek a "
@@ -1726,7 +1734,7 @@ msgstr ""
 "vagy felelős ezek végrehajtásáért."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Adja meg: 1) mi az általános megközelítés a kockázat kiküszöbölésére vagy "
@@ -1739,7 +1747,7 @@ msgstr ""
 "szakértő\". Itt megadhat további kiegészítő követelményeket is (ha vannak)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Az intézkedés megvalósításához szükséges szakértelem leírása, például &bdquo;"
@@ -1832,7 +1840,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: a modulokban szereplő pozitív állítások."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Hozzáadás"
 
@@ -1873,7 +1881,7 @@ msgstr "Igen, archiválja a fejezetet"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Mégse"
@@ -2144,10 +2152,11 @@ msgstr ""
 "Az adatkezelés a természetes személyeknek a személyes adatok uniós "
 "intézmények, szervek, hivatalok és ügynökségek általi kezelése tekintetében "
 "való védelméről és az ilyen adatok szabad áramlásáról szóló, 2018. október "
-"23-i <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv"
-"%3AOJ.L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">(EU) "
-"2018/1725 európai parlamenti és tanácsi rendelet</a> (a továbbiakban: a "
-"rendelet) 5. cikke (1) bekezdésének d), a) pontján alapul."
+"23-i <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?"
+"uri=uriserv%3AOJ.L_.2018.295.01.0039.01."
+"ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">(EU) 2018/1725 európai parlamenti és "
+"tanácsi rendelet</a> (a továbbiakban: a rendelet) 5. cikke (1) bekezdésének "
+"d), a) pontján alapul."
 
 #. Default: "Lawfulness of processing"
 #: euphorie/client/browser/templates/conditions-bare.pt:66
@@ -2290,12 +2299,12 @@ msgstr ""
 "felhasználó által is látható intézkedést kapjon az azonosítási szakaszban.)"
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Ezt a kockázatértékelést az OiRA automatikusan elvégezte. Meg tudja "
@@ -2496,17 +2505,17 @@ msgid "effect_high"
 msgstr "Magas (nagyon magas) súlyosság"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Gyenge súlyosság"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Jelentős súlyosság"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Magas (nagyon magas) súlyosság"
 
@@ -2554,7 +2563,7 @@ msgstr ""
 "ra/re változik, ha az alábbi megerősítő hivatkozásra kattint."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Kérjük, az új e-mailcímet a \"${email}\" címre néhány percen belül elküldött "
@@ -2613,7 +2622,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 - 249 munkavállaló"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Ezzel az e-mailcímmel már létezik egy felhasználói fiók."
 
@@ -2623,12 +2632,12 @@ msgid "error_existing_login"
 msgstr "Ez a bejelentkezési név már foglalt."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "A költségvetést egészre kerekített euró összegben adja meg."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Kérjük, adjon meg egy érvényes e-mailcímet"
 
@@ -2643,68 +2652,68 @@ msgid "error_invalid_xml"
 msgstr "Kérjük, érvényes XML fájlt töltsön fel"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Kérjük, adja meg az e-mailcímét"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Kérjük, adjon meg egy jelszót"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "A jelszavak nem egyeznek"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "A jelszó legyen legalább 12 karakter hosszú és tartalmazzon legalább egy "
 "kisbetűt, egy nagybetűt és egy számot."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 "Az Ön fiókja akkor jön létre, ha elfogadja a kikötéseket és feltételeket."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 "Ennek a dátumnak megegyezőnek vagy nagyobbnak kell lenni, mint a kezdő dátum."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 "Ennek a dátumnak megegyezőnek vagy kisebbnek kell lenni, mint a kezdő dátum."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Ennek az értéknek pozitív, egész számnak kell lenni."
 
@@ -2816,7 +2825,7 @@ msgstr ""
 "folytatná, frissítenie kell ezekre a változásokra."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 "Ezt a kockázatot automatikusan állandóan jelenlévőnek állították be. Ezt nem "
@@ -2850,7 +2859,7 @@ msgstr "Azonosítási jelentés ${title}"
 msgid "filename_report_timeline"
 msgstr "Cselekvési terv ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2871,7 +2880,7 @@ msgid "french"
 msgstr "Két egyszerűsített kritérium"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Szinte soha"
 
@@ -2881,57 +2890,57 @@ msgid "frequency_almostnever"
 msgstr "Szinte soha"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Állandóan"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Nem nagyon gyakran"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Havonta egyszer"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Gyakran"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Hetente egyszer"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Ritkán"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Évente egyszer"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Nagyon gyakran vagy rendszeresen"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Minimum naponta egyszer"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Rendszeresen"
@@ -2957,12 +2966,12 @@ msgid "header_additional_content"
 msgstr "További tartalom"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "További források a kockázatértékeléshez"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "További források ehhez a modulhoz"
 
@@ -3207,23 +3216,23 @@ msgid "header_risk_aware"
 msgstr "Tudatában van az összes kockázatnak?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Mennyire súlyos a potenciális kockázat?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Milyen gyakran vannak emberek kitéve ennek a kockázatnak?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Válassza ki a kockázat prioritását"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Mi a valószínűsége annak, hogy ez a kockázat előfordul?"
 
@@ -3289,7 +3298,7 @@ msgid "header_settings"
 msgstr "Beállítások"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standard intézkedések"
 
@@ -3542,7 +3551,7 @@ msgid "help_authentication"
 msgstr "Ez a rész a regisztráció és a bejelentkezés módját ismerteti."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Kérem válaszoljon a következő kérdésekre. Válaszai alapján a rendszer "
@@ -3576,7 +3585,7 @@ msgstr ""
 "OiRA eszköz másolatával szeretne-e indítani."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Jelezze, milyen gyakran merül fel ez a kockázat szokásos helyzetben."
 
@@ -3588,13 +3597,13 @@ msgstr ""
 "Ezután ő még megváltoztathatja a prioritást."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Jelezze, milyen valószínűséggel merül fel ez a kockázat szokásos helyzetben."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Jelölje a kockázat súlyosságát, amennyiben bekövetkezik."
 
@@ -4228,13 +4237,13 @@ msgstr "A felhasználói fiókot zárolták"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Cselekvési terv"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Költségvetés"
@@ -4246,21 +4255,21 @@ msgstr "Intézkedési terv"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Tervezés vége"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Ki a felelős?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Tervezés kezdete"
@@ -4283,7 +4292,7 @@ msgid "label_alphabetical"
 msgstr "Abc sorrend"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Értékelés"
 
@@ -4375,7 +4384,7 @@ msgstr "Jelszó megerősítése"
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4461,7 +4470,7 @@ msgid "label_delete_risk"
 msgstr "Törölni kívánja a kockázatot: Idquo;${risk-name}rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Leírás"
@@ -4507,7 +4516,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Értékelés"
 
@@ -4533,7 +4542,7 @@ msgid "label_existing_measure"
 msgstr "Az intézkedés már bevezetésre került"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4544,7 +4553,7 @@ msgid "label_exit"
 msgstr "Kilépés"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Szakértelem"
 
@@ -4559,7 +4568,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "További intézkedés hozzáadása"
 
@@ -4664,7 +4673,7 @@ msgstr "Előzmények"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Azonosítás"
 
@@ -4674,7 +4683,7 @@ msgid "label_image"
 msgstr "Képfájl"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Megvalósított intézkedés"
 
@@ -4701,7 +4710,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Bevonás"
 
@@ -4749,8 +4758,8 @@ msgstr "Tudjon meg többet az OiRA-ról!"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Hivatkozások jogszabályokra és szabályzatokra"
 
@@ -4815,7 +4824,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Általános megközelítés (a kockázat kiküszöbölésére vagy csökkentésére)"
@@ -4828,7 +4837,7 @@ msgstr "A megoldás bevezetéséhez szükséges konkrét lépés(ek)"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Szükséges szakértelem és/vagy követelmények szintje"
@@ -4961,12 +4970,12 @@ msgstr "Nem szükséges intézkedések bevezetése"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Megjegyzések"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -5022,14 +5031,14 @@ msgid "label_password_confirm"
 msgstr "Jelszó még egyszer"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Előkészítés"
 
@@ -5121,13 +5130,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Az intézkedés törlése"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Jelentés"
 
@@ -5271,7 +5280,7 @@ msgid "label_select_assessment"
 msgstr "Válasszon ki egy kockázatértékelést"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "A megadott gyakori intézkedések közül válasszon ki egyet vagy többet."
 
@@ -5290,7 +5299,7 @@ msgid "label_select_oira_tool"
 msgstr "OiRA eszköz kiválasztása"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Standard intézkedések kiválasztása"
 
@@ -5766,8 +5775,8 @@ msgid "menu_import"
 msgstr "OiRA eszköz importálása"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Oktatás"
 
@@ -5820,13 +5829,18 @@ msgstr ""
 "Ez az OiRA eszköz egyetlen verziója, így nem törölhető. Esetleg magát az "
 "OiRA eszközt szerette volna törölni?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Kérem töltse ki ezt a mezőt!"
 
@@ -5855,8 +5869,8 @@ msgstr ""
 msgid "message_involve_workers_requirement"
 msgstr ""
 "A munkahelyi biztonság és egészségvédelem területén az egyik kulcs a "
-"munkavállalók bevonása.  A munkáltatók számára jogszabály írja elő, <a href="
-"\"https://osha.europa.eu/en/legislation/directives/the-osh-framework-"
+"munkavállalók bevonása.  A munkáltatók számára jogszabály írja elő, <a "
+"href=\"https://osha.europa.eu/en/legislation/directives/the-osh-framework-"
 "directive/the-osh-framework-directive-introduction\">hogy</a> konzultáljanak "
 "a munkavállalókkal a munkahelyi egészségvédelmi és biztonsági kérdésekről.  "
 "Azonban a minimumkövetelményeken való túllépésnek vannak előnyei.  A "
@@ -6082,7 +6096,7 @@ msgstr "Beállítások"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Állapot"
 
@@ -6232,14 +6246,14 @@ msgstr ""
 "OiRA képzési terv és az OiRA ügyfélszolgálat."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Ez a megjegyzés látható lesz a jelentésben. Azt bármi másra használhatja, "
 "amire szeretné, ha írni szeretne erről a kockázatról."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Ezek a megjegyzések láthatóak lesznek a jegyzőkönyvben és a képzésben. Ezt "
@@ -6270,45 +6284,45 @@ msgstr "MÁSOLÁS"
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Magas"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Alacsony"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Közepes"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Nagy"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Közepes"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Kicsi"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Kész"
 
@@ -6378,7 +6392,7 @@ msgid "report_end_date"
 msgstr "Határidő: ${date}"
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6390,7 +6404,7 @@ msgstr ""
 "Regisztráljon egy lépésben és férjen hozzá a következő tartalmakhoz:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6459,25 +6473,25 @@ msgid "risk_present"
 msgstr "A kockázat jelen van."
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Ez egy ${priority_value} prioritású kockázat."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "magas"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "alacsony"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "közepes"
@@ -6493,7 +6507,7 @@ msgid "risk_show_na_na"
 msgstr "nem alkalmazható"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "${number} intézkedés"
 
@@ -6559,46 +6573,46 @@ msgstr ""
 "böngészőt. Biztonsági okokból jobb aktívan kijelentkezni."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Nem nagyon súlyos"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Kevesebb mint 3 napra kell abbahagyni a munkát"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Súlyos"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Több mint 3 napra kell abbahagyni a munkát"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Nagyon súlyos"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Visszafordíthatalan sérülés, gyógyíthatatlan betegség, halál"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Gyenge"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Nem kell abbahagyni a munkát"
 
@@ -6693,12 +6707,12 @@ msgid "title_about"
 msgstr "Névjegy"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Felhasználói fiók törlése"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2015-02-10 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Viðbótarráðstöfun"
 
@@ -179,11 +179,11 @@ msgstr "Öll tungumál"
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Villa kom upp þegar verið var að senda staðfestingarpóst."
 
@@ -192,6 +192,10 @@ msgid "An error occured while sending the password reset instructions"
 msgstr ""
 "Villa kom upp þegar verið var að senda leiðbeiningar um endursetningu "
 "lykilorðs."
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
+msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
 msgid "Archive"
@@ -213,7 +217,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Ertu viss um að þú viljir halda áfram? Þessi aðgerð er ekki afturkræf."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -309,7 +313,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Staðfestið breytt OiRA tölvupóstfang"
 
@@ -568,7 +572,7 @@ msgstr ""
 "Þú getur byrjað og hætt hvenær sem er. Hægt að halda áfram með fyrra mat og "
 "breyta að vild."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -599,11 +603,11 @@ msgstr "Upplýsingar"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Get ekki lesið myndskrá. Vinsamlegast notið PNG, JPEG eða GIF skrár."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Lykilorð ekki í lagi"
 
@@ -675,7 +679,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Ráðstöfun til úrbóta"
@@ -942,7 +946,7 @@ msgstr "Vinsamlegast athugaðu dæmin hér að aftan"
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Frestað"
 
@@ -1082,11 +1086,11 @@ msgstr "Áhættumat"
 msgid "Risk assessments made with this tool"
 msgstr "Áhættumat sem gerð eru með þessu verkfæri"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Áhættan er ekki til staðar"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Áhættan er til staðar"
 
@@ -1099,13 +1103,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Vista"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Vista breytingar"
@@ -1177,7 +1181,7 @@ msgstr "Eitt tilvik"
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Tillögur að aðgerðum"
 
@@ -1194,7 +1198,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1237,7 +1241,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Grunnuppbygging gagnvirks áhættumats á netinu samanstendur af: "
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1288,7 +1292,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1343,7 +1347,7 @@ msgstr ""
 "Þessi spurning verður að kanna hvort þessi lýsing á starfsemi eigi við hjá "
 "honum"
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1384,7 +1388,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Ekki opnað"
 
@@ -1399,6 +1403,10 @@ msgstr "Hlaðið inn mynd til útskýringar á þessari áhættu."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Hlaðið inn mynd"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1524,7 +1532,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Tölvupóstfang þitt hefur verið uppfært"
 
@@ -1533,7 +1541,7 @@ msgid "Your password for confirmation"
 msgstr "Vinsamlegast staðfestið með lykilorðinu"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Lykilorðinu hefur verið breytt."
 
@@ -1633,27 +1641,27 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Enda þótt sumar úrbótaaðgerðir kosti ekki fjármuni þá á það samt við um þær "
@@ -1661,7 +1669,7 @@ msgstr ""
 "inn í undirbúning á fjárveitingu ársins ef þörf er á."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Þú þarft að tilnefna einhvern aðila í fyrirtæki þínu sem ber ábyrgð á "
@@ -1670,7 +1678,7 @@ msgstr ""
 "þær séu framkvæmdar."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Gefðu lýsingu á: 1) almennri aðferð við að fjarlægja hættuna eða draga úr "
@@ -1678,7 +1686,7 @@ msgstr ""
 "nauðsynlegar aðgerði."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Gefðu lýsingu á: 3) hvaða sérfræðiþekking er nauðsynleg til að framkvæma "
@@ -1756,7 +1764,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: jákvæðum yfirlýsingum sem eru settar fram í flokkum."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Bæta við"
 
@@ -1797,7 +1805,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Hætta við"
@@ -2060,11 +2068,11 @@ msgstr "Gagnategundir sem unnið er úr"
 msgid "conditions_part5_entry"
 msgstr ""
 "Úrvinnslan byggir á grein 5.1 (d) í <a href=\"https://eur-lex.europa.eu/"
-"legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2018.295.01.0039.01.ENG&toc=OJ%3AL"
-"%3A2018%3A295%3ATOC\">reglugerð (ESB) 2018/1725</a> frá Evrópuþinginu og "
-"ráðinu frá 23. október 2018 um vernd einstaklinga þegar kemur að vinnslu á "
-"persónuupplýsingum hjá stofnunum Evrópusambandsins og upplýsingum um frjálsa "
-"för og slíkum upplýsingum (hér eftir Reglugerðin)."
+"legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2018.295.01.0039.01."
+"ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">reglugerð (ESB) 2018/1725</a> frá "
+"Evrópuþinginu og ráðinu frá 23. október 2018 um vernd einstaklinga þegar "
+"kemur að vinnslu á persónuupplýsingum hjá stofnunum Evrópusambandsins og "
+"upplýsingum um frjálsa för og slíkum upplýsingum (hér eftir Reglugerðin)."
 
 #. Default: "Lawfulness of processing"
 #: euphorie/client/browser/templates/conditions-bare.pt:66
@@ -2205,12 +2213,12 @@ msgstr ""
 "úrbótum sem notandinn sér við greiningu á áhættu)"
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Verkfærið metur áhættuna sjálkrafa. Hægt er að breyta forgangi áhættunar í "
@@ -2383,17 +2391,17 @@ msgid "effect_high"
 msgstr "Alvarlegar eða mjög alvarlegar afleiðingar"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Minni háttar"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Alvarlegt"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Mjög alvarlegt"
 
@@ -2442,7 +2450,7 @@ msgstr ""
 "þegar þú hefur hakað við staðfestingu hér fyrir neðan."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Vinsamlegast staðfestið nýtt tölvupóstfang með því að haka við krækjuna í "
@@ -2499,7 +2507,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 til 249 starfsmenn"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Þetta tölvupóstfang er þegar með aðgang að OiRA"
 
@@ -2509,12 +2517,12 @@ msgid "error_existing_login"
 msgstr "Þetta notendanafn er upptekið"
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Notið eingöngu tölustafi (ekki nota kommu og punkt)"
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Vinsamlegast setjið inn gilt tölvupóstfang"
 
@@ -2529,65 +2537,65 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Vinsamlegast settu inn tölvupóstfangið þitt."
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Vinsamlegast veldu lykilorð"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Lykilorðin eru ekki eins"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Lykilorðið verður að vera að lágmarki 12 stafir og þarf að innihalda a.m.k "
 "einn: stóran staf, lítinn staf og tölustaf."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir upphafsdagsetningu."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Þessi dagsetning þarf að vera sama dag eða á eftir lokadagsetningu."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Þetta þarf að vera heiltala stærri en núll."
 
@@ -2704,7 +2712,7 @@ msgstr ""
 "þarft að uppfæra þessar breytingar áður en þú heldur áfram."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 "Þessi áhætta hefur verið skilgreind sem stöðug áhætta (þ.e. alltaf fyrir "
@@ -2738,7 +2746,7 @@ msgstr "Áhættumatsskýrsla ${title}"
 msgid "filename_report_timeline"
 msgstr "Aðgerðaáætlun fyrir ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2759,7 +2767,7 @@ msgid "french"
 msgstr "Eimnfaldara tveggja þrepa mat á áhættu"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Næstum aldrei"
 
@@ -2769,57 +2777,57 @@ msgid "frequency_almostnever"
 msgstr "Næstum aldrei"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Stöðugt"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Ekki mjög oft"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Einu sinni í mánuði"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Oft"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Einu sinni í viku"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Sjaldan"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Einu sinni á ári"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Mjög oft eða reglulega"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Minnst einu sinni á dag"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Reglulega"
@@ -2843,12 +2851,12 @@ msgid "header_additional_content"
 msgstr "Annað efni"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Viðbótar upplýsingar til að meta áhættuna"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Viðbótar upplýsingar fyrir þennan flokk"
 
@@ -3090,23 +3098,23 @@ msgid "header_risk_aware"
 msgstr "Þekkir þú allar áhætturnar?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Hversu alvarlegt er vandamálið?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Hversu oft er fólk í hættu?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Veldu stig þessarar áhættu"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Hverjar eru líkurnar á að þessi hætta komi upp?"
 
@@ -3172,7 +3180,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Almennar lausnir"
 
@@ -3416,7 +3424,7 @@ msgid "help_authentication"
 msgstr "Þessi texti á að útskýra hvernig á að skrá sig inn á notendaaðgang"
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Vinsamlegast svaraðu eftirfarandi spurningum. Verkfærið metur áhættuna, "
@@ -3449,7 +3457,7 @@ msgstr ""
 "viljir byrja með afrit af OiRA verkfæri sem er þegar til staðar."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Tilgreindu hversu oft þessi áhætta kemur upp við venjulegar aðstæður."
 
@@ -3461,12 +3469,12 @@ msgstr ""
 "(forgangsröð). Hann eða hún getur breytt forgangsröðinni að vild."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Hversu líklegt er að þessi áhætta komi upp við venjulegar aðstæður?"
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Hversu alvarlegt verður atvikið ef það gerist?"
 
@@ -4050,13 +4058,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Aðgerðaáætlun"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Áætlaður kostnaður"
@@ -4068,21 +4076,21 @@ msgstr "Aðgerðaáætlun"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Áætluð verklok"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Hver ber ábyrgð?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Framkvæmdir/úrbætur hefjast"
@@ -4105,7 +4113,7 @@ msgid "label_alphabetical"
 msgstr "Í stafrófsröð"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -4197,7 +4205,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4283,7 +4291,7 @@ msgid "label_delete_risk"
 msgstr "Þú ert að eyða: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Lýsing"
@@ -4329,7 +4337,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Mat"
 
@@ -4355,7 +4363,7 @@ msgid "label_existing_measure"
 msgstr "Núverandi ráðstöfun til úrbóta."
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4366,7 +4374,7 @@ msgid "label_exit"
 msgstr "Útgangur"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Sérþekking"
 
@@ -4381,7 +4389,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Bætið við aðgerð"
 
@@ -4486,7 +4494,7 @@ msgstr "Saga"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Greining"
 
@@ -4496,7 +4504,7 @@ msgid "label_image"
 msgstr "Skrá með myndefni"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Ráðstöfun sem kemur til framkvæmda"
 
@@ -4523,7 +4531,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4571,8 +4579,8 @@ msgstr "Nánari upplýsingar um OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Tilvísanir í önnur gögn s.s. lög, reglur og önnur opinber gögn"
 
@@ -4635,7 +4643,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4650,7 +4658,7 @@ msgstr "Sérstakar aðgerðir til að innleiða úrbæturnar."
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Þekking og reynsla sem er nauðsynleg"
@@ -4783,12 +4791,12 @@ msgstr "Ekki er þörf á fleiri úrbótaaðgerðum"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Skýringar"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4844,14 +4852,14 @@ msgid "label_password_confirm"
 msgstr "Endurtakið lykilorðið"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Undirbúningur"
 
@@ -4943,13 +4951,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Eyða þessari tillögu að úrbótum"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Skýrsla"
 
@@ -5091,7 +5099,7 @@ msgid "label_select_assessment"
 msgstr "Velja áhættumat"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Veldu lausn eða lausnir sem eru tilgreindar."
 
@@ -5110,7 +5118,7 @@ msgid "label_select_oira_tool"
 msgstr "Veljið OiRA verkfæri"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Veljið tillögur að aðgerðum"
 
@@ -5519,8 +5527,8 @@ msgstr "Þú munt ekki geta prentað eða sótt skýrslur."
 #: euphorie/client/browser/templates/tooltips.pt:25
 msgid "list_test_session_limitations3"
 msgstr ""
-"Þú getur stofnað aðgang hvenær sem er með því að smella á tengilinn \"Nýskrá"
-"\" efst á síðunni."
+"Þú getur stofnað aðgang hvenær sem er með því að smella á tengilinn "
+"\"Nýskrá\" efst á síðunni."
 
 #: euphorie/client/adapters/history_item.py:123
 msgid "lock refreshed"
@@ -5575,8 +5583,8 @@ msgid "menu_import"
 msgstr "Flytja inn OiRA verkfæri"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5628,13 +5636,18 @@ msgstr ""
 "Þetta er eina gerðin af OiRA verkfærinu og er því ekki hægt að eyða henni. "
 "Vildirðu ef til vill fjarlægja OiRA verkfærið sjálft?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Fylla þarf í reitinn."
 
@@ -5874,7 +5887,7 @@ msgstr "Stillingar"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Staða"
 
@@ -6022,14 +6035,14 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Þessi athugasemd verður sýnileg í skýrslunni. Notið hana til þess að koma á "
 "framfæri einhverju sem tengist þessari áhættu."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -6058,45 +6071,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Há"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Lág"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Miðlungs"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Miklar"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Miðlungs"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Litlar"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Lokið"
 
@@ -6165,7 +6178,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6177,7 +6190,7 @@ msgstr ""
 "gögn. Stofnaðu aðgang til að nota verkfærið:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6243,25 +6256,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Áhættustig ${priority_value}"
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "Hátt"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "Lágt"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "Meðal"
@@ -6277,7 +6290,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Ráðstöfun til úrbóta ${number}"
 
@@ -6341,46 +6354,46 @@ msgstr ""
 "öryggisástæðum er æskilegt að skrá sig út með virkum hætti."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Ekki alvarlegt"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Nauðsynlegt að stöðva vinnu í 3 daga eða minna"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Alvarlegt"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Nauðsynlegt að stöðva vinnu í 3 daga eða meira"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Mjög alvarlegt"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Alvarleg slys og sjúkdómar, dauðsföll"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Lítið"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Engin ástæða til að stöðva vinnu"
 
@@ -6478,12 +6491,12 @@ msgid "title_about"
 msgstr "um"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Eyða aðgangi"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-11-26 11:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -168,7 +168,7 @@ msgstr "Aggiungi utente"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Ulteriore misura"
 
@@ -188,16 +188,20 @@ msgstr "Tutte le lingue"
 msgid "Almost done&hellip;"
 msgstr "Quasi fatto&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "È avvenuto un errore durante l'invio del messaggio di conferma."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -221,7 +225,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Sei sicuro che vuoi continuare? Questa azione non potrà essere annullata."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -319,7 +323,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Conferma modifica dell'indirizzo e-mail per lo strumento OiRA"
 
@@ -579,7 +583,7 @@ msgstr ""
 "interrompere la compilazione del tool per poi riprenderla in una fase "
 "successiva."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Vorrei condividere con voi ció che segue"
 
@@ -610,11 +614,11 @@ msgstr "Informazione"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato dell'immagine non valido, per favore usa PNG, JPEG o GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Password non valida"
 
@@ -686,7 +690,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Misura"
@@ -952,7 +956,7 @@ msgstr "Riferirsi agli esempi in basso al modulo….."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Adempimenti e rischi da completare"
 
@@ -1095,13 +1099,13 @@ msgstr "Valutazioni del rischio"
 msgid "Risk assessments made with this tool"
 msgstr "Valutazioni del rischio effettuate con questo strumento"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 "Adempimenti e rischi non applicabili o per i quali non sono previste "
 "ulteriori misure di miglioramento"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 "Adempimenti e rischi per i quali sono previste ulteriori misure di "
@@ -1116,13 +1120,13 @@ msgid "Run slideshow"
 msgstr "Avvia lo slideshow"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Salvare"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Salvare le modifiche"
@@ -1194,7 +1198,7 @@ msgstr "Singola localizzazione"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Misure di prevenzione e protezione"
 
@@ -1211,7 +1215,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Inizia le domande"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1258,7 +1262,7 @@ msgstr ""
 "L'architettura di base di una valutazione interattiva online dei rischi "
 "consiste in:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1309,7 +1313,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Non sono state salvate le modifiche."
 
@@ -1325,7 +1329,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Questo indirizzo e-mail non è disponibile"
 
@@ -1363,7 +1367,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1404,7 +1408,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Non esaminato"
 
@@ -1419,6 +1423,10 @@ msgstr "Carica un'immagine relativa al rischio."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Carica immagine"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1550,7 +1558,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Hai terminato le slides per la formazione!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "L'indirizzo e-mail è stato aggiornato."
 
@@ -1559,7 +1567,7 @@ msgid "Your password for confirmation"
 msgstr "Inserire la password per la conferma"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "La password è stata modificata con successo."
 
@@ -1695,45 +1703,45 @@ msgid "about_partners_3_smb"
 msgstr "le imprese micro e piccole hanno alcune imperfezioni"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Descrivi le misure specifiche necessarie per ridurre il rischio."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr "Seleziona o descrivi le misure necessarie per ridurre il rischio."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 "Descrivi tutte le misure di miglioramento per ridurre ulteriormente il "
 "rischio."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "Seleziona o descrivi tutte le misure di miglioramento per ridurre "
 "ulteriormente il rischio."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Inserire il budget di riferimento che si prevede di utilizzare per "
 "l’attuazione di questa determinata misura."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Indicare la persona che nella tua azienda deve provvedere all’ attuazione "
 "della misura obbligatoria adottata e dell’eventuale misura di miglioramento."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descrivere qual è l’approccio generale utilizzato per eliminare o ridurre i "
@@ -1741,7 +1749,7 @@ msgstr ""
 "miglioramento."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Descrivere quali sono le competenze / i requisiti necessari per l'attuazione "
@@ -1826,7 +1834,7 @@ msgstr ""
 "${Risks}: affermazioni positive riguardanti i pericoli indicati nei moduli."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Aggiungere"
 
@@ -1867,7 +1875,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annullare"
@@ -2141,8 +2149,8 @@ msgstr "Tipo di dati trattati"
 #: euphorie/client/browser/templates/conditions-bare.pt:68
 msgid "conditions_part5_entry"
 msgstr ""
-"Il trattamento si basa sull’articolo 5, paragrafo 1, lettera a), del <a href="
-"\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
+"Il trattamento si basa sull’articolo 5, paragrafo 1, lettera a), del <a "
+"href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
 "L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">regolamento (UE) "
 "2018/1725</a> del Parlamento europeo e del Consiglio, del 23 ottobre 2018, "
 "sulla tutela delle persone fisiche in relazione al trattamento dei dati "
@@ -2290,7 +2298,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Seleziona tutto ciò che vuoi escludere dalla formazione; tutti gli elementi "
@@ -2298,7 +2306,7 @@ msgstr ""
 "formazione."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Il livello di rischio per la sicurezza e la salute correlato ai pericoli "
@@ -2486,17 +2494,17 @@ msgid "effect_high"
 msgstr "Gravità alta (molto alta)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Gravità leggera"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Gravità significante"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Gravità alta (molto alta)"
 
@@ -2545,7 +2553,7 @@ msgstr ""
 "in basso."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Confermare il nuovo indirizzo e-mail cliccando sul link nel messaggio e-mail "
@@ -2604,7 +2612,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "Da 50 a 249 impiegati"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Un account con questo indirizzo e-mail è già esistente."
 
@@ -2614,12 +2622,12 @@ msgid "error_existing_login"
 msgstr "Questo nome d'accesso è giá occupato."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Inserire il budget in euro interi"
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Indicare un indirizzo e-mail valido"
 
@@ -2635,65 +2643,65 @@ msgid "error_invalid_xml"
 msgstr "Caricare un file XML valido"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Indicare il proprio indirizzo e-mail"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Indicare una password"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Le password non coincidono"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "La password deve essere lunga almeno 12 caratteri e deve contenere almeno "
 "una lettera maiuscula, almeno una lettera minuscola ed almeno un numero."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Questa data deve essere uguale o successiva alla data di inizio."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Questa data deve essere uguale o precedente alla data di fine."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Questo valore deve essere un numero intero positivo."
 
@@ -2796,7 +2804,7 @@ msgstr ""
 "continuare è necessario aggiornare le modifiche."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2828,7 +2836,7 @@ msgstr "Elenco dei rischi e degli adempimenti ${title}"
 msgid "filename_report_timeline"
 msgstr "Misure obbligatorie adottate e Programma di miglioramento per ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2849,7 +2857,7 @@ msgid "french"
 msgstr "Due criteri semplificati"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Quasi mai"
 
@@ -2859,57 +2867,57 @@ msgid "frequency_almostnever"
 msgstr "Quasi mai"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Costantemente"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Non frequente"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Uno per mese"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Spesso"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Uno per settimana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Raro"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Uno per anno"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Spesso o regolarmente"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Minimo una volta al giorno"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regolarmente"
@@ -2934,12 +2942,12 @@ msgid "header_additional_content"
 msgstr "Contenuti aggiuntivi"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Risorse aggiuntive per la valutazione del rischio"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Risorse aggiuntive per questo modulo"
 
@@ -3187,23 +3195,23 @@ msgid "header_risk_aware"
 msgstr "Sei consapevole dei rischi presenti nella tua azienda?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Cosa è la gravità del danno?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Quante volte la gente è esposta al rischio?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Il livello di rischio è"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Quali sono le eventualità che procura questo rischio?"
 
@@ -3270,7 +3278,7 @@ msgid "header_settings"
 msgstr "Impostazioni"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Misure standard"
 
@@ -3514,7 +3522,7 @@ msgstr ""
 "Questo testo dovrebbe spiegare come registrarsi e accedere allo strumento."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Rispondere alle seguenti domande. Sulla base delle risposte date, il sistema "
@@ -3547,7 +3555,7 @@ msgstr ""
 "con una copia di un tool OiRA esistente."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Indicare la frequenza che questo rischio si verifica in una situazione "
@@ -3561,14 +3569,14 @@ msgstr ""
 "L'utente finale ha poi la possibilità di modificare il grado di priorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Indicare quanto sia possibile che questo rischio si verifichi in una "
 "situazione normale."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Indicare la gravità che questo rischio potrebbe comportare."
 
@@ -4179,13 +4187,13 @@ msgstr "L'account è bloccato"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Misure di miglioramento"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budget (campo facoltativo)"
@@ -4197,7 +4205,7 @@ msgstr "Programma di miglioramento"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
@@ -4205,14 +4213,14 @@ msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Chi è il responsabile?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Stima inizio attuazione (solo per misure di miglioramento)"
@@ -4235,7 +4243,7 @@ msgid "label_alphabetical"
 msgstr "ordine alfabetico"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -4327,7 +4335,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4413,7 +4421,7 @@ msgid "label_delete_risk"
 msgstr "Stai per cancellare il rischio: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Descrizione"
@@ -4459,7 +4467,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Valutazione"
 
@@ -4485,7 +4493,7 @@ msgid "label_existing_measure"
 msgstr "Misura già attuata"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Misure già adottate"
@@ -4496,7 +4504,7 @@ msgid "label_exit"
 msgstr "Esci"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Competenza"
 
@@ -4511,7 +4519,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Aggiungi le misure di miglioramento"
 
@@ -4616,7 +4624,7 @@ msgstr "Storico"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identificazione"
 
@@ -4626,7 +4634,7 @@ msgid "label_image"
 msgstr "File immagine"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Misura già attuata"
 
@@ -4653,7 +4661,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Processo di VR"
 
@@ -4701,8 +4709,8 @@ msgstr "Scopri di più su OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Riferimenti normativi"
 
@@ -4765,7 +4773,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Tipologia di misura (per eliminare e ridurre i rischi)"
@@ -4778,7 +4786,7 @@ msgstr "Misura specifica"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Livello di esperienza o requisiti necessari"
@@ -4923,12 +4931,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Appunti"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4984,14 +4992,14 @@ msgid "label_password_confirm"
 msgstr "Ripetere password"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Misure programmate"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Presentazione"
 
@@ -5083,13 +5091,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Eliminare questa misura"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Report"
 
@@ -5249,7 +5257,7 @@ msgid "label_select_assessment"
 msgstr "Seleziona una valutazione dei rischi"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 "ATTENZIONE: le misure obbligatorie devono essere state tutte adottate e "
@@ -5272,7 +5280,7 @@ msgid "label_select_oira_tool"
 msgstr "Seleziona uno strumento OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Seleziona le misure di prevenzione e protezione precompilate"
 
@@ -5747,8 +5755,8 @@ msgid "menu_import"
 msgstr "Importare strumento OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Formazione"
 
@@ -5802,13 +5810,18 @@ msgstr ""
 "Questa è l'unica versione dello strumento OiRA e non è possibile "
 "cancellarla. Forse desidera rimuovere lo strumento OiRA stesso."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Campo obligatorio"
 
@@ -6071,7 +6084,7 @@ msgstr "Impostazioni"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Stato"
 
@@ -6221,7 +6234,7 @@ msgstr ""
 "sito OiRA, il progetto di formazione OiRA e l'help desk OiRA saranno pronti."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Questo commento sarà visibile nel Documento di valutazione dei rischi "
@@ -6229,7 +6242,7 @@ msgstr ""
 "rischio valutato."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Queste note saranno visibili nel report (DVR) e nel materiale formativo."
@@ -6260,45 +6273,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Alto"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Basso"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Medio"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Grande"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Medio"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Piccolo"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "Completo al ${completion_percentage}%"
 
@@ -6373,7 +6386,7 @@ msgid "report_end_date"
 msgstr "DATA DI CONCLUSIONE: ${date}"
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6386,7 +6399,7 @@ msgstr ""
 "l’accesso usufruendo dei seguenti vantaggi:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6463,25 +6476,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Questo è un rischio di priorità ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "Alto"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "basso"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "Medio"
@@ -6497,7 +6510,7 @@ msgid "risk_show_na_na"
 msgstr "non applicabile"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Misura ${number}"
 
@@ -6565,46 +6578,46 @@ msgstr ""
 "motivi di sicurezza è meglio farlo correttamente."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Non molto severo"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "È necessario fermare il lavoro per meno di 3 giorni"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Severo"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "È necessario fermare il lavoro per più di 3 giorni"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Molto rigido"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Danno irreversibile, malattia incurabile, morte"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Debole"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Non è necessario fermare il lavoro"
 
@@ -6680,8 +6693,8 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session-test.pt:95
 msgid "testsession_register"
 msgstr ""
-"Oppure ${register_link}. Scopri perché è necessario registrarsi"
-"${tooltip_register}."
+"Oppure ${register_link}. Scopri perché è necessario "
+"registrarsi${tooltip_register}."
 
 #. Default: "add all measures that have already been implemented"
 #: euphorie/content/utils.py:58
@@ -6704,12 +6717,12 @@ msgid "title_about"
 msgstr "Riguardo"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Eliminare account"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgstr "Pridėti naują naudotoją"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Papildoma priemonė"
 
@@ -184,16 +184,20 @@ msgstr "Visos kalbos"
 msgid "Almost done&hellip;"
 msgstr "Beveik baigta"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Siunčiant patvirtinimo laišką įvyko klaida."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -216,7 +220,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Ar tikrai norite tęsti? Šio veiksmo negalima atšaukti."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -309,7 +313,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Patvirtinti OiRA el. pašto adreso pakeitimą"
 
@@ -567,7 +571,7 @@ msgstr ""
 "Tačiau vertinimui skirkite tiek laiko, kiek jo turite – bet kada galėsite "
 "tęsti nuo tos vietos, kur baigėte praeitą kartą."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Noriu pasidalinti šia informacija su jumis"
 
@@ -598,11 +602,11 @@ msgstr "Informacija"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Netinkamas vaizdo failo formatas. Naudokite PNG, JEPG arba GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Neteisingas slaptažodis"
 
@@ -673,7 +677,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Priemonė"
@@ -935,7 +939,7 @@ msgstr "Žr. formos apačioje pateiktus pavyzdžius."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Atidėta"
 
@@ -1078,11 +1082,11 @@ msgstr "Atlikti rizikos vertinimai"
 msgid "Risk assessments made with this tool"
 msgstr "Naudojantis šia priemone atlikti rizikos vertinimai"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "GERAI"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Dėmesio"
 
@@ -1095,13 +1099,13 @@ msgid "Run slideshow"
 msgstr "Paleisti skaidrių demonstraciją"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Išsaugoti"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Išsaugoti keitinius"
@@ -1173,7 +1177,7 @@ msgstr "Vienkartinis raginimas"
 msgid "Standard"
 msgstr "Standartinis"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Standartinės priemonės"
 
@@ -1190,7 +1194,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Pradėkite atsakinėti į klausimus"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1236,7 +1240,7 @@ msgstr ""
 "Pagrindinės internetinės interaktyviosios rizikos vertinimo priemonės "
 "sudedamosios dalys yra šios:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1286,7 +1290,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Jokie pakeitimai išsaugoti nebus."
 
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Šis el. pašto adresas yra negaliojantis."
 
@@ -1337,7 +1341,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1378,7 +1382,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Neatsakyta"
 
@@ -1393,6 +1397,10 @@ msgstr "Įkelkite vaizdo failą, kuris iliustruoja šią riziką."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Įkelti paveikslėlį"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1525,7 +1533,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Baigėte mokymo skaidres!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Jūsų el. pašto adresas buvo atnaujintas."
 
@@ -1534,7 +1542,7 @@ msgid "Your password for confirmation"
 msgstr "Patvirtinimui reikalingas jūsų slaptažodis"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Jūsų slaptažodis sėkmingai pakeistas."
 
@@ -1659,34 +1667,34 @@ msgid "about_partners_3_smb"
 msgstr "mikro ir nedidelės įmonės turi tam tikrų trūkumų"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Nustatykite konkrečias priemones rizikai sumažinti."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr "Pasirinkite arba nustatykite konkrečias priemones rizikai sumažinti."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Nustatykite kitas priemones rizikai sumažinti."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Nustatykite kitas priemones rizikai sumažinti."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Kai kurios priemonės nekainuoja nė cento, tačiau daugelis kainuoja. Dėl to "
 "jas reikia finansuoti. Jas reikia įtraukti į metinį biudžetą (jei reikia)."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Paskirkite ką nors iš savo kompanijos atsakingu už šios priemonės "
@@ -1694,7 +1702,7 @@ msgstr ""
 "(arba) užtikrinti, kad jie yra atliekami."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Nurodykite: 1) koks yra pagrindinis būdas pašalinti arba (jei neišvengiama) "
@@ -1702,7 +1710,7 @@ msgstr ""
 "(pašalinti arba sumažinti riziką) pritaikyti."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Nurodykite: 3) koks yra reikalingų žinių lygis, pavyzdžiui, „sveikas protas "
@@ -1791,7 +1799,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: teigiami atsakymai, kurie pateikiami moduliuose."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Įkelti"
 
@@ -1832,7 +1840,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Atšaukti"
@@ -2104,12 +2112,12 @@ msgstr "Tvarkomų duomenų pobūdis"
 msgid "conditions_part5_entry"
 msgstr ""
 "Duomenys tvarkomi remiantis 2018 m. spalio 23 d. Europos Parlamento ir "
-"Tarybos <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv"
-"%3AOJ.L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Reglamento "
-"(ES) 2018/1725</a> dėl fizinių asmenų apsaugos Sąjungos institucijoms, "
-"organams, tarnyboms ir agentūroms tvarkant asmens duomenis ir dėl laisvo "
-"tokių duomenų judėjimo (toliau – Reglamentas) 5 straipsnio 1 dalies a ir d "
-"punktais."
+"Tarybos <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?"
+"uri=uriserv%3AOJ.L_.2018.295.01.0039.01."
+"ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Reglamento (ES) 2018/1725</a> dėl "
+"fizinių asmenų apsaugos Sąjungos institucijoms, organams, tarnyboms ir "
+"agentūroms tvarkant asmens duomenis ir dėl laisvo tokių duomenų judėjimo "
+"(toliau – Reglamentas) 5 straipsnio 1 dalies a ir d punktais."
 
 #. Default: "Lawfulness of processing"
 #: euphorie/client/browser/templates/conditions-bare.pt:66
@@ -2249,14 +2257,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Pažymėkite viską, ką galbūt norėtumėte neįtraukti į mokymą. Elementai, kurie "
 "yra pilki, mokymo kortelėje nebus rodomi."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Priemonė automatiškai atliko rizikos vertinimą. Veiksmų plane, jeigu "
@@ -2439,17 +2447,17 @@ msgid "effect_high"
 msgstr "Didelis (labai didelis) sunkumas"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Nedidelis sunkumas"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Žymus sunkumas"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Didelis (labai didelis) sunkumas"
 
@@ -2496,7 +2504,7 @@ msgstr ""
 "paskyros pavadinimas ${url} bus pakeistas į '${email}'."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Paspaudę laiške, kurį netrukus atsiųsime adresu \"${email}\", pateiktą "
@@ -2553,7 +2561,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "Nuo 50 iki 249 darbuotojų"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Paskyra su šiuo el. pašto adresu jau galioja"
 
@@ -2563,12 +2571,12 @@ msgid "error_existing_login"
 msgstr "Šis prisijungimo vardas jau naudojamas."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Biudžetą sudarinėkite sumas nurodydami eurais."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Įveskite galiojantį el. pašto adresą"
 
@@ -2583,65 +2591,65 @@ msgid "error_invalid_xml"
 msgstr "Įkelkite tinkamą XML failą"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Įveskite savo el. pašto adresą"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Įveskite slaptažodį"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Slaptažodis netinkamas"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Slaptažodį turi sudaryti mažiausiai 12 simbolių, iš kurių bent viena mažoji "
 "raidė, viena didžioji raidė ir vienas skaitmuo."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Ši data turi sutapti su pradžios data arba būti už ją vėlesnė."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Ši data turi sutapti su pabaigos data arba būti už ją ankstesnė."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Šioje vietoje nurodykite teigiamą sveikąjį skaičių."
 
@@ -2750,7 +2758,7 @@ msgstr ""
 "šiuos pakeitimus turite patvirtinti."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2782,7 +2790,7 @@ msgstr "Nustatymo ataskaitos ${title}"
 msgid "filename_report_timeline"
 msgstr "Prevencinių veiksmų planas ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2803,7 +2811,7 @@ msgid "french"
 msgstr "Du supaprastinti kriterijai"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Beveik niekada"
 
@@ -2813,57 +2821,57 @@ msgid "frequency_almostnever"
 msgstr "Beveik niekada"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Nuolat"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Nelabai dažnas"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Kartą per mėnesį"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Dažnas"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Kartą per savaitę"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Retas"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Kartą per metus"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Labai dažnas arba reguliarus"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Mažiausiai kartą per dieną"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Reguliariai"
@@ -2888,12 +2896,12 @@ msgid "header_additional_content"
 msgstr "Papildomas turinys"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Papildomi rizikos vertinimo šaltiniai"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Papildomi šaltiniai šram modulini"
 
@@ -3136,23 +3144,23 @@ msgid "header_risk_aware"
 msgstr "Ar žinote visas rizikas?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Koks yra žalos sunkumas?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Kaip dažnai žmonės su šia rizika susiduria?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Pasirinkite šios rizikos lygį"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Kokia tikimybė, kad ši rizika atsiras?"
 
@@ -3216,7 +3224,7 @@ msgid "header_settings"
 msgstr "Parametrai"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standartinės priemonės"
 
@@ -3463,7 +3471,7 @@ msgstr ""
 "prisijungti."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Atsakykite į toliau pateiktus klausimus. Atsižvelgiant į jūsų atsakymus, "
@@ -3496,7 +3504,7 @@ msgstr ""
 "pradėti nuo esamos OiRA priemonės kopijos."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Nurodyti, kaip dažnai rizika pasireiškia normaliose situacijose."
 
@@ -3508,12 +3516,12 @@ msgstr ""
 "prioritetą vis dar gali pakeisti."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Nurodyti, kokia rizikos pasireiškimo normaliose situacijose tikimybė."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Nurodyti atsiradusios rizikos sunkumą."
 
@@ -4124,13 +4132,13 @@ msgstr "Paskyra užblokuota"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Veiksmų planas"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Biudžetas"
@@ -4142,21 +4150,21 @@ msgstr "Veiksmų planas"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Įgyvendinimo pabaiga"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Kas atsakingas?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Įgyvendinimo pradžia"
@@ -4179,7 +4187,7 @@ msgid "label_alphabetical"
 msgstr "Abėcėlės tvarka"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Vertinimas"
 
@@ -4271,7 +4279,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4357,7 +4365,7 @@ msgid "label_delete_risk"
 msgstr "Norite ištrinti riziką: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Aprašymas"
@@ -4403,7 +4411,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Vertinimas"
 
@@ -4429,7 +4437,7 @@ msgid "label_existing_measure"
 msgstr "Jau įdiegta priemonė"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Jau įgyvendintos priemonės"
@@ -4440,7 +4448,7 @@ msgid "label_exit"
 msgstr "Išeiti"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Kompetencija"
 
@@ -4455,7 +4463,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Įtraukite papildomą priemonę"
 
@@ -4560,7 +4568,7 @@ msgstr "Istorija"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Nustatymas"
 
@@ -4570,7 +4578,7 @@ msgid "label_image"
 msgstr "Atvaizdo failas"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Įgyvendinta priemonė"
 
@@ -4597,7 +4605,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Įtraukti"
 
@@ -4645,8 +4653,8 @@ msgstr "Daugiau apie OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Nuorodos į teisės aktus"
 
@@ -4709,7 +4717,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Pagrindinis sprendimas (pašalinti arba sumažinti riziką)"
@@ -4723,7 +4731,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Reikalingų žinių ir (arba) reikalavimų lygis"
@@ -4856,12 +4864,12 @@ msgstr "Ne, būtinos papildomos priemonės"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Pastabos"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4917,14 +4925,14 @@ msgid "label_password_confirm"
 msgstr "Pakartoti slaptažodį"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Planuojamos priemonės"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Paruošimas"
 
@@ -5016,13 +5024,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Pašalinti šią priemonę"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Ataskaita"
 
@@ -5164,7 +5172,7 @@ msgid "label_select_assessment"
 msgstr "Pasirinkite rizikos vertinimą"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Pasirinkite vieną ar kelias iš pateiktų priemonių."
 
@@ -5183,7 +5191,7 @@ msgid "label_select_oira_tool"
 msgstr "Pasirinkite OiRA priemonę"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Pasirinkite standartines priemones"
 
@@ -5654,8 +5662,8 @@ msgid "menu_import"
 msgstr "Įkelti OiRA priemonę"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Mokymas"
 
@@ -5708,13 +5716,18 @@ msgstr ""
 "Tai vienintelė OiRA priemonės versija, todėl jos pašalinti negalima. Ar "
 "norite pašalinti pačią OiRA priemonę?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Šis laukas būtinas"
 
@@ -5970,7 +5983,7 @@ msgstr "Parametrai"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Būsena"
 
@@ -6118,14 +6131,14 @@ msgstr ""
 "puslapis, OiRA mokymų schema ir žinynas."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Šis komentaras bus matomas Ataskaitoje. Naudokite šį lauką, norėdami įrašyti "
 "daugiau informacijos apie šią riziką."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Pastabos bus matomos ataskaitoje ir mokymuose. Naudokite šią skiltį "
@@ -6154,45 +6167,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Aukštas"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Žemas"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Vidutinis"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Didelė"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Vidutinė"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Nedidelė"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Baigtas"
 
@@ -6261,7 +6274,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6273,7 +6286,7 @@ msgstr ""
 "atsisiuntimo funkcija. Registracija trunka tik akimirką ir yra naudinga, nes:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6340,25 +6353,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Tai ${priority_value} rizika."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "didelė"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "maža"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "vidutinė"
@@ -6374,7 +6387,7 @@ msgid "risk_show_na_na"
 msgstr "neaktualu"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Priemonė ${number}"
 
@@ -6438,46 +6451,46 @@ msgstr ""
 "naršyklę. Saugumo sumetimais patariama išsiregistruoti."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Nelabai sunkus"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Reikia nutraukti darbus mažiau nei 3 dienoms"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Didelis sunkumas"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Reikia nutraukti darbus daugiau nei 3 dienoms"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Labai didelis sunkumas"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Nepagydomas sužalojimas, nepagydoma liga, mirtis"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Silpnas"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Nutraukti darbo nereikia"
 
@@ -6576,12 +6589,12 @@ msgid "title_about"
 msgstr "Apie"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Šalinti paskyrą"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -163,7 +163,7 @@ msgstr "Pievienot lietotāju"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Papildu pasākums"
 
@@ -183,16 +183,20 @@ msgstr "Visas valodas"
 msgid "Almost done&hellip;"
 msgstr "Gandrīz pabeigts"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Sūtot apstiprinājuma e-pastu, radās kļūda."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -216,7 +220,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Vai esat pārliecināts, ka vēlaties turpināt? Šī ir neatgriezeniska darbība."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -308,7 +312,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Apstipriniet OiRA e-pasta adreses maiņu"
 
@@ -566,7 +570,7 @@ msgstr ""
 "brīdī, un atgriezties jebkurā laikā, lai turpinātu procesu no vietas, kurā "
 "apstājāties iepriekšējā reizē."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Es vēlos dalīties ar Jums šādos jaunumos"
 
@@ -597,11 +601,11 @@ msgstr "Informācija"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Nepiemērots attēla faila formāts. Lūdzu izmantot PNG, JPEG vai GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Nederīga parole"
 
@@ -672,7 +676,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Pasākums"
@@ -934,7 +938,7 @@ msgstr "Lūdzu, aplūkojiet piemērus zem veidlapas."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Atlikts jautājums"
 
@@ -1081,11 +1085,11 @@ msgstr "Riska novērtējumi"
 msgid "Risk assessments made with this tool"
 msgstr "Ar šo rīku veidotie riska novērtējumi"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Viss kārtībā"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Uzmanību"
 
@@ -1098,13 +1102,13 @@ msgid "Run slideshow"
 msgstr "Rādīt slīdrādi"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Saglabāt"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Saglabāt izmaiņas"
@@ -1176,7 +1180,7 @@ msgstr "Vienreizēja uzvedne"
 msgid "Standard"
 msgstr "Standarta"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Tipveida pasākums"
 
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Sākt jautājumus"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1236,7 +1240,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Riska interaktīvā novērtēšanas tiešsaistes rīka arhitektūra sastāv no:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1287,7 +1291,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Nebija nekādu saglabājamu izmaiņu."
 
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Šī e-pasta adrese nav pieejama."
 
@@ -1342,7 +1346,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1383,7 +1387,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Neatbildēts"
 
@@ -1398,6 +1402,10 @@ msgstr "Augšupielādēt attēlu, kas atspoguļo risku."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Augšuplādēt attēlu"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1530,7 +1538,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Jūs esat pabeidzis apmācības!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Jūsu e-pasta adrese ir atjaunināta."
 
@@ -1539,7 +1547,7 @@ msgid "Your password for confirmation"
 msgstr "Parole apstiprināšanai"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Jūsu parole ir veiksmīgi mainīta."
 
@@ -1642,9 +1650,9 @@ msgstr ""
 "OiRA projektu un tam domāto tīmekļa lietotni izstrādāja ${eu-osha}, par "
 "pamatu izmantojot riska novērtēšanas rīku (${RIE}) no Nīderlandes. Šo rīku "
 "ar Nīderlandes valdības finansējuma palīdzību izstrādāja TNO, sadarbojoties "
-"ar darba devēju organizāciju maziem un vidējiem uzņēmumiem: \"MKB-Nederland"
-"\", kā arī Nīderlandes Nodarbinātības ministriju. Arodbiedrības FNV, CNV un "
-"MHP palīdzēja turpināt lietotnes izstrādi."
+"ar darba devēju organizāciju maziem un vidējiem uzņēmumiem: \"MKB-"
+"Nederland\", kā arī Nīderlandes Nodarbinātības ministriju. Arodbiedrības "
+"FNV, CNV un MHP palīdzēja turpināt lietotnes izstrādi."
 
 #. Default: "The following technical partners contributed to the development of the OiRA project:"
 #: euphorie/client/browser/templates/about.pt:133
@@ -1665,32 +1673,32 @@ msgid "about_partners_3_smb"
 msgstr "mikrouzņēmumiem un maziem uzņēmumiem ir daži trūkumi"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 "Aprakstiet specifiskos pasākumus, kas nepieciešami, lai samazinātu risku."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Izvēlieties vai aprakstiet specifiskos pasākumus, kas nepieciešami, lai "
 "samazinātu risku."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Aprakstiet citus papildus veicamos pasākumus, kas samazinātu risku."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "Izvēieties vai aprakstiet citus papildus veicamos pasākumus, kas samazinātu "
 "risku."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Lai gan daži pasākumi riska novēršanai ir bezmaksas, lielākā daļa tomēr rada "
@@ -1698,7 +1706,7 @@ msgstr ""
 "pasākumus ikgadējā uzņēmuma budžetā."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Uzticiet kādam uzņēmuma darbiniekam atbildību par šī pasākuma ieviešanu. Šim "
@@ -1706,7 +1714,7 @@ msgstr ""
 "gādāt par to izpildi."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Aprakstiet: 1) savu pasākumu, lai risku novērstu vai samazinātu (ja tas nav "
@@ -1714,7 +1722,7 @@ msgstr ""
 "īstenotu šo pieeju (lai samazinātu vai novērstu risku) – nav obligāts lauks."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Aprakstiet: 3) pieredzes līmeni, kas nepieciešams šo pasākumu īstenotu, "
@@ -1803,7 +1811,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: apgalvojumi, kas iekļauti moduļos."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Pievienot"
 
@@ -1844,7 +1852,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Atcelt"
@@ -2109,12 +2117,12 @@ msgstr "Apstrādāto datu veids"
 msgid "conditions_part5_entry"
 msgstr ""
 "Datu apstrāde ir pamatota ar Eiropas Parlamenta un Padomes 2018. gada 23. "
-"oktobra <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv"
-"%3AOJ.L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Regulas "
-"(ES) 2018/1725</a> par fizisku personu aizsardzību attiecībā uz personas "
-"datu apstrādi Savienības iestādēs, struktūrās, birojos un aģentūrās un par "
-"šādu datu brīvu apriti (turpmāk “Regulas”) 5. panta 1. punkta d) un a) "
-"apakšpunktu."
+"oktobra <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?"
+"uri=uriserv%3AOJ.L_.2018.295.01.0039.01."
+"ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Regulas (ES) 2018/1725</a> par fizisku "
+"personu aizsardzību attiecībā uz personas datu apstrādi Savienības iestādēs, "
+"struktūrās, birojos un aģentūrās un par šādu datu brīvu apriti (turpmāk "
+"“Regulas”) 5. panta 1. punkta d) un a) apakšpunktu."
 
 #. Default: "Lawfulness of processing"
 #: euphorie/client/browser/templates/conditions-bare.pt:66
@@ -2252,14 +2260,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Lūdzu uzklikšķiniet, ja vēlaties daļu no teksta izslēgt no apmācībām. "
 "Teksts, kas tiek iekrāsots pelēks, netiks parādīts apmācību sadaļā."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Riska novērtējumu automātiski ir veicis rīks. Jūs varēsiet mainīt šim riska "
@@ -2441,17 +2449,17 @@ msgid "effect_high"
 msgstr "Augsta (ļoti augsta) bīstamības pakāpe"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Zema bīstamība"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Ievērojama bīstamība"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Augsta (ļoti augsta) bīstamība"
 
@@ -2499,7 +2507,7 @@ msgstr ""
 "un konta nosaukums vietnē ${url} tiks mainīts uz '${email}'."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Lūdzu, apstipriniet jauno e-pasta adresi, noklikšķinot uz saites e-pasta "
@@ -2559,7 +2567,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50-249 darbinieki"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Konts ar šādu e-pasta adresi jau pastāv."
 
@@ -2569,12 +2577,12 @@ msgid "error_existing_login"
 msgstr "Šis pieteikumvārds jau ir aizņemts."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Lūdzu, ievadiet budžetu eiro valūtā, pilnos skaitļos."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Lūdzu, ievadiet derīgu e-pasta adresi."
 
@@ -2589,65 +2597,65 @@ msgid "error_invalid_xml"
 msgstr "Lūdzu, augšupielādējiet derīgu XML failu."
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Lūdzu, ievadiet savu e-pasta adresi."
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Lūdzu, ievadiet paroli."
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Paroles nesakrīt."
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Parolei ir jābūt vismaz 12 zīmes garai un jāsatur vismaz viens lielais "
 "burts, vismaz viens mazais burts un viens cipars."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Šim datumam ir jābūt sākuma datumam vai pēc tā."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Šim datumam ir jābūt beigu datumam vai pirms tā."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Šim lielumam ir jābūt pozitīvam veselam skaitlim."
 
@@ -2756,7 +2764,7 @@ msgstr ""
 "jums ir jāievieš šie atjauninājumi."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2787,7 +2795,7 @@ msgstr "Identifikācijas pārskats ${title}"
 msgid "filename_report_timeline"
 msgstr "Rīcības plāns ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2808,7 +2816,7 @@ msgid "french"
 msgstr "Vienkāršoti divi kritēriji"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Gandrīz nekad"
 
@@ -2818,57 +2826,57 @@ msgid "frequency_almostnever"
 msgstr "Gandrīz nekad"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Nepārtraukti"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Ne pārāk bieži"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Reizi mēnesī"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Bieži"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Reizi nedēļā"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Reti"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Reizi gadā"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Ļoti bieži vai regulāri"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Vismaz reizi dienā"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regulāri"
@@ -2893,12 +2901,12 @@ msgid "header_additional_content"
 msgstr "Papildu saturs"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Papildu resursi riska novērtēšanai"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Papildu resursi šim modulim"
 
@@ -3141,23 +3149,23 @@ msgid "header_risk_aware"
 msgstr "Vai esat informēts par visiem riskiem?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Kāda ir kaitējuma bīstamības pakāpe?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Cik bieži cilvēki tiek pakļauti šim riskam?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Atlasiet šī riska prioritātes līmeni"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Cik liela ir šī riska rašanās iespējamība?"
 
@@ -3223,7 +3231,7 @@ msgid "header_settings"
 msgstr "Iestatījumi"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standarta līdzekļi"
 
@@ -3468,7 +3476,7 @@ msgid "help_authentication"
 msgstr "Šim tekstam jāizskaidro reģistrēšanās un pieteikšanās process."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Lūdzu, atbildiet uz zemāk norādītajiem jautājumiem. Balstoties uz jūsu "
@@ -3499,7 +3507,7 @@ msgstr ""
 "ar esoša OiRA rīka kopiju."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Norādiet, cik bieži šāds risks pastāv normālos apstākļos."
 
@@ -3511,12 +3519,12 @@ msgstr ""
 "noklusējuma. Lietotājs tik un tā varēs pats mainīt prioritātes līmeni."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Norādiet, cik ticama ir šī riska rašanās normālos apstākļos."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Norādiet bīstamības pakāpi, ko izraisa šī riska īstenošanās."
 
@@ -3544,8 +3552,8 @@ msgstr "Šim tekstam jāizskaidro, kā novērtēt identificētos riskus."
 #: euphorie/content/risk.py:181
 msgid "help_evaluation_method"
 msgstr ""
-"Ja aprēķini nav nepieciešami vai iespējami, atlasiet \"aptuvens novērtējums"
-"\"."
+"Ja aprēķini nav nepieciešami vai iespējami, atlasiet \"aptuvens "
+"novērtējums\"."
 
 #. Default: "This option allows users to skip the evaluation phase."
 #: euphorie/content/survey.py:75
@@ -4121,13 +4129,13 @@ msgstr "Konts ir bloķēts"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Rīcības plāns"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budžets"
@@ -4139,21 +4147,21 @@ msgstr "Rīcības plāns"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Pabeigšanas datums"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Kura ir atbildīgā persona?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Uzsākšanas datums"
@@ -4176,7 +4184,7 @@ msgid "label_alphabetical"
 msgstr "Pēc alfabēta"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Novērtējums"
 
@@ -4268,7 +4276,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4354,7 +4362,7 @@ msgid "label_delete_risk"
 msgstr "Jūs gatavojaties dzēst: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Apraksts"
@@ -4400,7 +4408,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Novērtēšana"
 
@@ -4426,7 +4434,7 @@ msgid "label_existing_measure"
 msgstr "Pasākums jau īstenots"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Jau ieviestie pasākumi"
@@ -4437,7 +4445,7 @@ msgid "label_exit"
 msgstr "Iziet"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Ekspertīze"
 
@@ -4452,7 +4460,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Pievienot papildus pasākumu"
 
@@ -4557,7 +4565,7 @@ msgstr "Vēsture"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identifikācija"
 
@@ -4567,7 +4575,7 @@ msgid "label_image"
 msgstr "Attēla fails"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Īstenotais pasākums"
 
@@ -4594,7 +4602,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Iesaiste"
 
@@ -4642,8 +4650,8 @@ msgstr "Uzzināt vairāk par OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Juridiskās un ar politikas nostādnēm saistītās atsauces"
 
@@ -4706,7 +4714,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Vispārējā pieeja (riska novēršana vai samazināšana)"
@@ -4719,7 +4727,7 @@ msgstr "Specifiskas darbības, kas jāveic, lai īstenotu šo pieeju"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Nepieciešamais pieredzes līmenis un/vai prasības"
@@ -4852,12 +4860,12 @@ msgstr "Nē, ir nepieciešams vairāk pasākumu"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Piezīmes"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4913,14 +4921,14 @@ msgid "label_password_confirm"
 msgstr "Atkārtoti ievadiet paroli"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Plānotie pasākumi"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Sagatavošanās"
 
@@ -5013,13 +5021,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Dzēst šo pasākumu"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Pārskats"
 
@@ -5162,7 +5170,7 @@ msgid "label_select_assessment"
 msgstr "Izvēlieties riska novērtējumu"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Izvēlieties vienu tipveida pasākumu"
 
@@ -5181,7 +5189,7 @@ msgid "label_select_oira_tool"
 msgstr "Izvēlieties OiRA rīku"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Izvēlēties tipveida pasākumus"
 
@@ -5656,8 +5664,8 @@ msgid "menu_import"
 msgstr "Importēt OiRA rīku"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Apmācības"
 
@@ -5706,13 +5714,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Jūs nevarat izdzēst vienīgo OiRA rīka versiju."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Lūdzu, aizpildiet šo lauku."
 
@@ -5965,7 +5978,7 @@ msgstr "Iestatījumi"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Statuss"
 
@@ -6115,14 +6128,14 @@ msgstr ""
 "rīka oficiālā atklāšana."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Šo komentāru varēs redzēt atskaitē. Izmantojiet šo lauku visiem tiem "
 "komentāriem, kurus vēlaties redzēt dokumentos."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Šo piezīmi varēs redzēt pārskatā un apmācību datos. Izmantojiet šo lauku "
@@ -6151,45 +6164,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Augsts"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Zems"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Vidējs"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Liela"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Vidēja"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Neliela"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Pabeigts"
 
@@ -6257,7 +6270,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6270,7 +6283,7 @@ msgstr ""
 "priekšrocībām."
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6339,25 +6352,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Šis ir ${priority_value}"
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "augstas prioritātes risks"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "zemas prioritātes risks"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "vidējas prioritātes risks"
@@ -6373,7 +6386,7 @@ msgid "risk_show_na_na"
 msgstr "nav attiecināms"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Līdzeklis Nr. ${number}"
 
@@ -6437,46 +6450,46 @@ msgstr ""
 "iemeslu dēļ ir labāk iziet no sistēmas."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Ne īpaši augsta bīstamības pakāpe"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Ir nepieciešams pārtraukt darbu uz ne vairāk kā 3 dienām"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Augsta bīstamības pakāpe"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Ir nepieciešams pārtraukt darbu uz vairāk nekā 3 dienām"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Ļoti augsta bīstamības pakāpe"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Neatgriezeniski ievainojumi, neizārstējamas slimības, nāve"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Zema bīstamības pakāpe"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Nav nepieciešamības pārtraukt darbu"
 
@@ -6551,8 +6564,8 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session-test.pt:95
 msgid "testsession_register"
 msgstr ""
-"Vai ${register_link} tā vietā. Uzziniet, kāpēc vajadzētu reģistrēties"
-"${tooltip_register}."
+"Vai ${register_link} tā vietā. Uzziniet, kāpēc vajadzētu "
+"reģistrēties${tooltip_register}."
 
 #. Default: "add all measures that have already been implemented"
 #: euphorie/content/utils.py:58
@@ -6575,12 +6588,12 @@ msgid "title_about"
 msgstr "Informācija"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Konta dzēšana"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-12-18 10:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -169,7 +169,7 @@ msgstr "Żid utent"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Miżura addizzjonali"
 
@@ -189,17 +189,21 @@ msgstr "Il-lingwi kollha"
 msgid "Almost done&hellip;"
 msgstr "Kważi lest/a&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 "Seħħ żball waqt li kienet qed tintbagħat il-posta elettronika ta' konferma."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -222,7 +226,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Int żgur li trid tkompli? Din l-azzjoni ma tistax tinbidel."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -317,7 +321,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Ikkonferma l-bidla tal-indirizz elettroniku tal-OiRA "
 
@@ -576,7 +580,7 @@ msgstr ""
 "tiegħek fuq valutazzjoni, u mbagħad tista' tmur lura għaliha meta jkun komdu "
 "għalik u terġa' taqbadha minn fejn ħallejtha."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Nixtieq naqsam dan miegħek"
 
@@ -607,11 +611,11 @@ msgstr "Informazzjoni"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Format tal-istampa invalidu. Jekk jogħġbok uża PNG, JPEG jew GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Password invalida"
 
@@ -682,7 +686,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Miżura"
@@ -948,7 +952,7 @@ msgstr "Irreferi għall-eżempji taħt il-formola."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Posponiment"
 
@@ -1092,11 +1096,11 @@ msgstr "L-evalwazzjonijiet tar-riskju"
 msgid "Risk assessments made with this tool"
 msgstr "Valutazzjonijiet tar-riskju li jsiru b’din l-għodda"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Riskju mhux preżenti"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Riskju preżenti"
 
@@ -1109,13 +1113,13 @@ msgid "Run slideshow"
 msgstr "Ibda s-slideshow"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Issejvja"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Issejvja l-bidliet"
@@ -1187,7 +1191,7 @@ msgstr "Tfakkira ta’ okkorrenza unika"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Miżuri standard"
 
@@ -1204,7 +1208,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Ibda l-mistoqsijiet"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1251,7 +1255,7 @@ msgstr ""
 "L-istruttura bażika ta’ Valutazzjoni tar-Riskji interattiva Onlajn "
 "tikkonsisti f’dan li ġej:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Ma kienx hemm bidliet x'jiġu ssejvjati."
 
@@ -1318,7 +1322,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Dan l-indirizz elettroniku mhux disponibbli."
 
@@ -1357,7 +1361,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1398,7 +1402,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Ma saritx żjara"
 
@@ -1413,6 +1417,10 @@ msgstr "Tella’ stampa li turi dan ir-riskju"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Tella’ l-istampa"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1550,7 +1558,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "I-islides tat-taħriġ lesti!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "L-indirizz elettroniku ġie aġġornat."
 
@@ -1559,7 +1567,7 @@ msgid "Your password for confirmation"
 msgstr "Il-password tiegħek għall-konferma"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Il-password tiegħek inbidlet."
 
@@ -1696,27 +1704,27 @@ msgid "about_partners_3_smb"
 msgstr "l-intrapriżi mikro u żgħar għandhom xi nuqqasijiet"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Iddeskrivi l-miżuri speċifiċi meħtieġa biex tnaqqas ir-riskju."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr "Iddeskrivi l-miżuri speċifiċi meħtieġa biex tnaqqas ir-riskju."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Iddeskrivi xi miżuri oħra biex tnaqqas ir-riskju."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Agħżel jew iddeskrivi xi miżuri oħra biex tnaqqas ir-riskju."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Għalkemm xi miżuri ma jiswewx flus, il-biċċa l-kbira jiswew. Għaldaqstant, "
@@ -1724,7 +1732,7 @@ msgstr ""
 "bżonn."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Aħtar persuna fil-kumpanija tiegħek biex tkun responsabbli mill-"
@@ -1733,7 +1741,7 @@ msgstr ""
 "passi jittieħdu."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Iddeskrivi: 1) x'inhu l-approċċ ġenerali tiegħek biex telimina jew (jekk ir-"
@@ -1742,7 +1750,7 @@ msgstr ""
 "telimina jew tnaqqas ir-riskju)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Iddeskrivi: 3) il-livell ta' kompetenza meħtieġ biex tiġi implimentata l-"
@@ -1833,7 +1841,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: dikjarazzjonijiet pożittivi, li jinsabu fil-moduli."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Żid"
 
@@ -1874,7 +1882,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Ikkanċella"
@@ -2295,14 +2303,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Jekk jogħġbok immarka kull ħaġa li tixtieq teskludi mit-taħriġ. Oġġetti li "
 "jidhru griżi mhux se jintwerew fuq il-karta tat-taħriġ."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "L-evalwazzjoni tar-riskju saret b'mod awtomatiku mill-għodda. Ser tkun "
@@ -2489,17 +2497,17 @@ msgid "effect_high"
 msgstr "Severità kbira (kbira ħafna)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Severità dgħajfa"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Severità sinifikanti"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Severità kbira (kbira ħafna) "
 
@@ -2546,7 +2554,7 @@ msgstr ""
 "'${email}' meta tikklikkja l-link ta' konferma hawn taħt."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Ikkonferma l-indirizz elettroniku l-ġdid tiegħek billi tikklikkja fuq il-"
@@ -2605,7 +2613,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 sa 249 impjegat"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Diġà jeżisti kont b'dan l-indirizz elettroniku."
 
@@ -2615,12 +2623,12 @@ msgid "error_existing_login"
 msgstr "Dan l-isem tal-login diġà meħud."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Daħħal il-baġit f'Euros sħaħ."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Daħħal indirizz elettroniku validu"
 
@@ -2636,65 +2644,65 @@ msgid "error_invalid_xml"
 msgstr "Tella' fajl XML validu"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Daħħal l-indirizz elettroniku tiegħek"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Daħħal password"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Il-passwords ma jaqblux"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Il-password għanda tkun twila mill-inqas 12-il karattru u teħtieġ li jkun "
 "fiha mill-inqas ittra żgħira waħda, ittra waħda kbira u numru wieħed."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Din id-data għandha tkun fid-data tal-bidu jew warajha."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Din id-data għandha tkun fid-data ta' tmiem jew qabilha."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Dan il-valur għandu jkun numru sħiħ pożittiv."
 
@@ -2804,7 +2812,7 @@ msgstr ""
 "trid taġġorna b'dawn il-bidliet."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2836,7 +2844,7 @@ msgstr "Rapport ta' identifikazzjoni ${title}"
 msgid "filename_report_timeline"
 msgstr "Pjan ta' azzjoni ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2857,7 +2865,7 @@ msgid "french"
 msgstr "Żewġ kriterji semplifikati"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Kważi qatt"
 
@@ -2867,57 +2875,57 @@ msgid "frequency_almostnever"
 msgstr "Kważi qatt"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Kostantement"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Mhux ta' spiss ħafna"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Darba fix-xahar"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Ta' spiss"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Darba fil-ġimgħa"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Rari"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Darba fis-sena"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Ta' spiss ħafna jew regolarment"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Mill-inqas darba kuljum"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regolarment"
@@ -2942,12 +2950,12 @@ msgid "header_additional_content"
 msgstr "Kontenut addizzjonali"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Riżorsi addizzjonali għall-evalwazzjoni tar-riskju"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Rizörsi addizzjonali għal din it-taqsima"
 
@@ -3191,23 +3199,23 @@ msgid "header_risk_aware"
 msgstr "Inti taf bir-riskji kollha?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "X'inhi s-severità tad-dannu?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "B'liema frekwenza n-nies huma esposti għal dan ir-riskju?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Agħżel il-prijorità ta' dan ir-riskju"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "X'inhu ċ-ċans li dan ir-riskju jimmaterjalizza ruħu?"
 
@@ -3273,7 +3281,7 @@ msgid "header_settings"
 msgstr "Konfigurazzjonijiet"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Miżuri standard"
 
@@ -3516,7 +3524,7 @@ msgid "help_authentication"
 msgstr "Dan it-test għandu jispjegalek kif tirreġistra u tilloggja."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Jekk jogħġbok wieġeb il-mistoqsijiet li ġejjin. Bħala riżultat tal-"
@@ -3549,7 +3557,7 @@ msgstr ""
 "ta' Għodda tal-OiRA eżistenti.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 "Indika l-frekwenza li biha dan ir-riskju jimmaterjalizza ruħu f'sitwazzjoni "
@@ -3563,12 +3571,12 @@ msgstr ""
 "jkunu jistgħu jibdlu l-prijorità."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Indika l-probabbiltà ta' dan ir-riskju f'sitwazzjoni normali."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Indika s-severità jekk dan ir-riskju jimmaterjalizza ruħu."
 
@@ -4183,13 +4191,13 @@ msgstr "Kont illokkjat"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Il-Pjan ta' Azzjoni"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Baġit"
@@ -4201,21 +4209,21 @@ msgstr "Il-Pjan ta' Azzjoni"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Tmiem tal-ippjanar"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Min hu responsabbli?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Bidu tal-ippjanar"
@@ -4238,7 +4246,7 @@ msgid "label_alphabetical"
 msgstr "Alfabetikament"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Evalwazzjoni"
 
@@ -4330,7 +4338,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4416,7 +4424,7 @@ msgid "label_delete_risk"
 msgstr "Int se tħassar ir-riskju: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Deskrizzjoni"
@@ -4462,7 +4470,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "L-Evalwazzjoni"
 
@@ -4488,7 +4496,7 @@ msgid "label_existing_measure"
 msgstr "Il-miżura diġà implimentata"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Miżuri diġà mplimentati"
@@ -4499,7 +4507,7 @@ msgid "label_exit"
 msgstr "Oħroġ"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Kompetenza"
 
@@ -4514,7 +4522,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Żid miżura oħra"
 
@@ -4619,7 +4627,7 @@ msgstr "L-istorja tal-editjar"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "L-Identifikazzjoni"
 
@@ -4629,7 +4637,7 @@ msgid "label_image"
 msgstr "Fajl tal-istampa"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Miżura implimentata"
 
@@ -4656,7 +4664,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Involvi"
 
@@ -4704,8 +4712,8 @@ msgstr "Aktar tagħrif dwar OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Referenzi legali u tal-politika"
 
@@ -4768,7 +4776,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Approċċ ġenerali (biex ir-riskju jiġi eliminat jew imnaqqas)"
@@ -4783,7 +4791,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Livell ta' kompetenza u/jew rekwiżiti meħtieġa"
@@ -4916,12 +4924,12 @@ msgstr "Le, huma meħtieġa aktar miżuri"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Noti"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4977,14 +4985,14 @@ msgid "label_password_confirm"
 msgstr "Erġa password"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Miżuri ppjanati"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "It-Tħejjija"
 
@@ -5076,13 +5084,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Ħassar din il-miżura"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Ir-Rapport"
 
@@ -5226,7 +5234,7 @@ msgid "label_select_assessment"
 msgstr "Agħżel valutazzjoni tar-riskju"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Agħżel waħda jew iktar mill-miżuri komuni pprovduti."
 
@@ -5246,7 +5254,7 @@ msgid "label_select_oira_tool"
 msgstr "Agħżel għodda tal-OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Agħżel miżuri standard"
 
@@ -5718,8 +5726,8 @@ msgid "menu_import"
 msgstr "Importa Għodda tal-OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Taħriġ"
 
@@ -5770,13 +5778,18 @@ msgstr ""
 "Din hija l-unika verżjoni tal-Għodda tal-OiRA u għalhekk ma tistax "
 "titħassar. Forsi ridt tneħħi l-Għodda tal-OiRA nnifisha?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Jekk jogħġbok imla din il-parti."
 
@@ -6029,7 +6042,7 @@ msgstr "Settings"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Stat"
 
@@ -6179,14 +6192,14 @@ msgstr ""
 "l-iskema ta' taħriġ tal-OiRA u l-help desk tal-OiRA jkunu lesti."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Dan il-kumment ħa jidher fir-rapport. Użah għal kull ħaġa oħra li tkun trid "
 "tikteb dwar dan ir-riskju."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Dawn in-noti se jkunu viżibbli fir-rapport u fit-taħriġ. Użaha għal kull "
@@ -6216,45 +6229,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Għolja"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Baxxa"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Medja"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Kbir"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Medju"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Żgħir"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Tlesti"
 
@@ -6323,7 +6336,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6336,7 +6349,7 @@ msgstr ""
 "ġejjin:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6405,25 +6418,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Dan huwa riskju ta' prijorità ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "għolja"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "baxxa"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "medja"
@@ -6439,7 +6452,7 @@ msgid "risk_show_na_na"
 msgstr "mhux applikabbli"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Miżura ${number}"
 
@@ -6504,46 +6517,46 @@ msgstr ""
 "raġunijiet ta' sigurtà jkun aħjar li tilloggja inti stess 'il barra."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Mhux severa ħafna"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Hemm bżonn tieqaf il-ħidma għal inqas minn 3 ijiem"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Kbira"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Hemm bżonn tieqaf il-ħidma għal iktar minn 3 ijiem"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Kbira ħafna"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Korriment irriversibbli, mard inkurabbli, mewt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Dgħajfa"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "M'hemmx bżonn titwaqqaf il-ħidma"
 
@@ -6618,8 +6631,8 @@ msgstr ""
 #: euphorie/client/browser/templates/new-session-test.pt:95
 msgid "testsession_register"
 msgstr ""
-"Jew ${register_link} minflok. Sir af għaliex għandek tirreġistra"
-"${tooltip_register}."
+"Jew ${register_link} minflok. Sir af għaliex għandek "
+"tirreġistra${tooltip_register}."
 
 #. Default: "add all measures that have already been implemented"
 #: euphorie/content/utils.py:58
@@ -6642,12 +6655,12 @@ msgid "title_about"
 msgstr "Dwar"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Ħassar il-kont"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:14+0200\n"
 "Last-Translator: Wichert Akkerman <wichert@wiggy.net>\n"
 "Language-Team: nl <LL@li.org>\n"
@@ -160,7 +160,7 @@ msgstr "Voeg gebruiker toe"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Aanvullende maatregel"
 
@@ -180,16 +180,20 @@ msgstr "Alle talen"
 msgid "Almost done&hellip;"
 msgstr "Bijna klaar&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Er is een fout opgetreden bij het versturen van de bevestings e-mail."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -213,7 +217,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -309,7 +313,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Bevestig RI&E e-mail adres wijziging"
 
@@ -571,7 +575,7 @@ msgstr ""
 "te maken. U kunt op elk moment stoppen en later weer verder gaan waar u "
 "gebleven was of wijzigen aanbrengen."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -602,11 +606,11 @@ msgstr "Informatie"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Onjuist bestandsformaat voor een afbeelding. Gebruik PNG, JPEG of GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Incorrect wachtwoord"
 
@@ -678,7 +682,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Maatregel"
@@ -947,7 +951,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Overgeslagen"
 
@@ -1087,11 +1091,11 @@ msgstr "RI&E’s"
 msgid "Risk assessments made with this tool"
 msgstr "Risicobeoordelingen die met deze tool zijn gemaakt"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Risico niet aanwezig"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Risico aanwezig"
 
@@ -1104,13 +1108,13 @@ msgid "Run slideshow"
 msgstr "Diavoorstelling tonen"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Opslaan"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Bewaar wijzigingen"
@@ -1182,7 +1186,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standaard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Standaard maatregelen"
 
@@ -1199,7 +1203,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Start de vragen"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1237,7 +1241,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1288,7 +1292,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Er waren geen wijzigingen om op te slaan."
 
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Dit e-mail adres is niet beschikbaar."
 
@@ -1341,7 +1345,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1382,7 +1386,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Niet bekeken"
 
@@ -1397,6 +1401,10 @@ msgstr "Invoegen afbeelding die het risico illustreert."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Invoegen afbeelding"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1524,7 +1532,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "U bent klaar met de slides van de training!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Uw e-mailadres is gewijzigd."
 
@@ -1533,7 +1541,7 @@ msgid "Your password for confirmation"
 msgstr "Uw wachtwoord ter bevestiging"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Uw wachtwoord is aangepast."
 
@@ -1663,27 +1671,27 @@ msgid "about_partners_3_smb"
 msgstr "MKB bedrijven hebben enige tekortkomingen"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Alhoewel sommige maatregelen niets zullen kosten, zijn aan de meeste "
@@ -1691,7 +1699,7 @@ msgstr ""
 "in de jaarlijkse begroting, indien nodig."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Wijs iemand in de organisatie aan die verantwoordelijk is voor de "
@@ -1701,7 +1709,7 @@ msgstr ""
 "uitgevoerd."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Bij de maatregel geeft u aan welke stappen genomen moeten worden om het "
@@ -1709,7 +1717,7 @@ msgstr ""
 "bij de bron) heeft als maatregel de voorkeur."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Beschrijf de kennis en vereisten die nodig zijn om dit uit te voeren, bijv "
@@ -1798,7 +1806,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Voeg toe"
 
@@ -1839,7 +1847,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annuleren"
@@ -2113,13 +2121,13 @@ msgstr "Type verwerkte gegevens"
 msgid "conditions_part5_entry"
 msgstr ""
 "De verwerking vindt plaats op basis van artikel 5, lid 1, punten a) en d), "
-"van <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv"
-"%3AOJ.L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Verordening "
-"(EU) 2018/1725</a> van het Europees Parlement en de Raad van 23 oktober 2018 "
-"betreffende de bescherming van natuurlijke personen in verband met de "
-"verwerking van persoonsgegevens door de instellingen, organen en instanties "
-"van de Unie en betreffende het vrije verkeer van die gegevens (hierna “de "
-"verordening” genoemd)."
+"van <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?"
+"uri=uriserv%3AOJ.L_.2018.295.01.0039.01."
+"ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Verordening (EU) 2018/1725</a> van het "
+"Europees Parlement en de Raad van 23 oktober 2018 betreffende de bescherming "
+"van natuurlijke personen in verband met de verwerking van persoonsgegevens "
+"door de instellingen, organen en instanties van de Unie en betreffende het "
+"vrije verkeer van die gegevens (hierna “de verordening” genoemd)."
 
 #. Default: "Lawfulness of processing"
 #: euphorie/client/browser/templates/conditions-bare.pt:66
@@ -2260,7 +2268,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Gelieve alles aan te kruisen wat u van de training zou willen uitsluiten. "
@@ -2268,7 +2276,7 @@ msgstr ""
 "trainingskaart."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "De tool heeft automatisch een risico-evaluatie uitgevoerd. U kunt de "
@@ -2457,17 +2465,17 @@ msgid "effect_high"
 msgstr "Blijvende gezondheidsschade"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Letsel zonder verzuim"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Letsel met verzuim"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Blijvende gezondheidsschade"
 
@@ -2514,7 +2522,7 @@ msgstr ""
 "'${email}' als u op onderstande link klikt."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Bevestig uw nieuwe e-mail adres door te klikken op de link in de e-mail die "
@@ -2579,7 +2587,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 tot 249 werknemers"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Er bestaat al een account met dit e-mail adres"
 
@@ -2589,12 +2597,12 @@ msgid "error_existing_login"
 msgstr "Deze gebruikersnaam bestaat al"
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Vul het budget in hele Euros in."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Vul een geldig e-mail adres in."
 
@@ -2609,65 +2617,65 @@ msgid "error_invalid_xml"
 msgstr "S.v.p. een geldig XML-bestand uploaden."
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Vul hier uw e-mail adres in"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Vul uw wachtwoord in"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Het wachtwoord moet ten minste 12 tekens lang zijn en ten minste één kleine "
 "letter, één hoofdletter en één cijfer bevatten."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2799,7 +2807,7 @@ msgstr ""
 "RI&E voordat u verder kunt gaan."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2836,7 +2844,7 @@ msgstr "Inventarisatie ${title}"
 msgid "filename_report_timeline"
 msgstr "Plan van aanpak ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2857,7 +2865,7 @@ msgid "french"
 msgstr "Vereenvoudigd (twee critiria)"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Bijna nooit"
 
@@ -2867,57 +2875,57 @@ msgid "frequency_almostnever"
 msgstr "Bijna nooit"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Voortdurend"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Niet vaak"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Een keer per maand"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Vaak"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Een keer per week"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Zeldzaam"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Eens per jaar"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Heel vaak of regelmatig"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Tenminste een keer per dag"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regelmatig"
@@ -2942,12 +2950,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Aanvullende bronnen om het risico te beoordelen"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Aanvullende bronnen voor deze module"
 
@@ -3190,23 +3198,23 @@ msgid "header_risk_aware"
 msgstr "Bent u zich bewust van alle risico's?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Wat is het effect?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Hoe vaak wordt men blootgesteld aan dit risico?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Geef de categorie van dit risico aan"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Hoe groot is de kans op dit risico?"
 
@@ -3270,7 +3278,7 @@ msgid "header_settings"
 msgstr "Instellingen"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standaard maatregelen"
 
@@ -3516,7 +3524,7 @@ msgstr ""
 "wachtwoord en de registratiepagina wordt een link naar deze tekst geplaatst."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Beantwoord de volgende vragen. Het systeem zal op grond van uw antwoorden de "
@@ -3547,7 +3555,7 @@ msgstr ""
 "kopie van een bestaande RI&E."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -3559,14 +3567,14 @@ msgstr ""
 "kan dit zelf alsnog wijzigen bij het invullen van de RI&E."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 "Geef een indicatie van de zwaarte van het effect (hoe schadelijk is het voor "
@@ -4194,13 +4202,13 @@ msgstr "Het account is geblokkeerd"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Plan van aanpak"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budget (in Euro)"
@@ -4212,21 +4220,21 @@ msgstr "Plan van aanpak"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Eind datum"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Wie is er verantwoordelijk?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Begindatum"
@@ -4249,7 +4257,7 @@ msgid "label_alphabetical"
 msgstr "Alfabetisch"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Beoordeling"
 
@@ -4341,7 +4349,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr "Advies"
 
@@ -4428,7 +4436,7 @@ msgstr ""
 "U staat op het punt om dit risico te verwijderen: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Beschrijving"
@@ -4474,7 +4482,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Evaluatie"
 
@@ -4500,7 +4508,7 @@ msgid "label_existing_measure"
 msgstr "Maatregel is al toegepast"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Reeds geïmplementeerde maatregelen"
@@ -4511,7 +4519,7 @@ msgid "label_exit"
 msgstr "Verlaten"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Benodigde kennis en vereisten"
 
@@ -4526,7 +4534,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Voeg een extra maatregel toe"
 
@@ -4631,7 +4639,7 @@ msgstr "Historie"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Inventarisatie"
 
@@ -4641,7 +4649,7 @@ msgid "label_image"
 msgstr "Afbeelding"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Uitgevoerde maatregel"
 
@@ -4668,7 +4676,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr "Validatie risicoanalyse intrekken"
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4716,8 +4724,8 @@ msgstr "Leer meer over OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Wet- en regelgeving"
 
@@ -4780,7 +4788,7 @@ msgstr "Omschrijving van de maatregel"
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Plan van aanpak"
@@ -4793,7 +4801,7 @@ msgstr "Preventie plan"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Benodigde kennis en vereisten"
@@ -4926,12 +4934,12 @@ msgstr "Nee, er zijn meer maatregelen nodig"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Notities"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4987,14 +4995,14 @@ msgid "label_password_confirm"
 msgstr "Opnieuw wachtwoord"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Geplande maatregelen"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Voorbereiding"
 
@@ -5086,13 +5094,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Verwijder"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Rapport"
 
@@ -5236,7 +5244,7 @@ msgid "label_select_assessment"
 msgstr "Een risicobeoordeling selecteren"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Selecteer één of meer van de bekende vaak voorkomende maatregelen."
 
@@ -5255,7 +5263,7 @@ msgid "label_select_oira_tool"
 msgstr "Selecteer een OiRA tool"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Selecteer standaardmaatregelen"
 
@@ -5732,8 +5740,8 @@ msgid "menu_import"
 msgstr "Importeer vragenlijst"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Training"
 
@@ -5785,13 +5793,18 @@ msgid "message_delete_no_last_survey"
 msgstr ""
 "De laatste (enige) versie van de branche-RI&E kan niet verwijderd worden."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Graag dit veld invullen."
 
@@ -6053,7 +6066,7 @@ msgstr "Instellingen"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Status"
 
@@ -6201,14 +6214,14 @@ msgstr ""
 "website, het trainingsrooster en de OiRA helpdesk beschikbaar zijn."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Deze commentaar zal zichtbaar zijn in het rapport. Gebruik het voor iets "
 "anders dat u over dit risico zou willen schrijven."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Deze aantekeningen zullen zichtbaar zijn in het rapport en de training. "
@@ -6239,45 +6252,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Hoog"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Laag"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Groot"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Klein"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Voltooid"
 
@@ -6346,7 +6359,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6359,7 +6372,7 @@ msgstr ""
 "volgende voordelen:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6426,25 +6439,25 @@ msgid "risk_present"
 msgstr "Dit risico is aanwezig."
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Dit is een risico in de categorie ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "hoog"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "laag"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "gemiddeld"
@@ -6460,7 +6473,7 @@ msgid "risk_show_na_na"
 msgstr "niet van toepassing"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Maatregel ${number}"
 
@@ -6527,46 +6540,46 @@ msgstr ""
 "invullen/wijzigen."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Niet ernstig"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Niet meer dan drie dagen te stoppen met werk"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Ernstig"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Meer dan 3 dagen werkonderbreiking vereist"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Zeer ernstig"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Ongeneesbare verwonding of ziekte, of dood"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Zwak"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Niet nog om te stoppen met werk"
 
@@ -6661,12 +6674,12 @@ msgid "title_about"
 msgstr "Over"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Verwijder account"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgstr "Voeg gebruiker toe"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Aanvullende maatregel"
 
@@ -184,16 +184,20 @@ msgstr "Alle talen"
 msgid "Almost done&hellip;"
 msgstr "Bijna klaar&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Er is een fout opgetreden bij het versturen van de bevestingse-mail."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -217,7 +221,7 @@ msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 "Weet u zeker dat u door wilt gaan? Deze actie kan niet worden teruggedraaid."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -312,7 +316,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Bevestig wijziging van OiRA-e-mailadres"
 
@@ -573,7 +577,7 @@ msgstr ""
 "Het is echter mogelijk om een risicoanalyse aan te vangen en op een later "
 "tijdstip, wanneer het beter uitkomt, vanaf dat punt weer verder te gaan."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Ik wil het volgende met u delen"
 
@@ -604,12 +608,12 @@ msgstr "Informatie"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Verkeerd bestandsformaat voor afbeelding. Gebruik a.u.b. PNG, JPEG of GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Ongeldig wachtwoord"
 
@@ -680,7 +684,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Maatregel"
@@ -945,7 +949,7 @@ msgstr "Verwijs naar de voorbeelden onder het formulier."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Uitgesteld"
 
@@ -1089,11 +1093,11 @@ msgstr "Risicobeoordelingen"
 msgid "Risk assessments made with this tool"
 msgstr "Risicobeoordelingen die met deze tool zijn gemaakt"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Aandacht"
 
@@ -1106,13 +1110,13 @@ msgid "Run slideshow"
 msgstr "Diavoorstelling tonen"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Opslaan"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Veranderingen opslaan"
@@ -1184,7 +1188,7 @@ msgstr "Invoeren eenmalige gebeurtenis"
 msgid "Standard"
 msgstr "Standaard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Standaard maatregelen"
 
@@ -1201,7 +1205,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Start de vragen"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1246,7 +1250,7 @@ msgid ""
 msgstr ""
 "De basisarchitectuur van een Online interactive Risk Assessment bestaat uit:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1296,7 +1300,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Er waren geen wijzigingen om op te slaan."
 
@@ -1312,7 +1316,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Dit e-mailadres is niet beschikbaar."
 
@@ -1350,7 +1354,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1391,7 +1395,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Onbeantwoord"
 
@@ -1406,6 +1410,10 @@ msgstr "Upload een afbeelding die het risico illustreert."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Invoegen afbeelding"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1539,7 +1547,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "U bent klaar met de slides van de training!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Uw e-mailadres werd bijgewerkt."
 
@@ -1548,7 +1556,7 @@ msgid "Your password for confirmation"
 msgstr "Uw wachtwoord ter bevestiging"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Uw wachtwoord werd gewijzigd."
 
@@ -1587,12 +1595,13 @@ msgstr ""
 #: euphorie/client/browser/templates/about.pt:70
 msgid "about_paragraph_1"
 msgstr ""
-"Ervaring toont ons dat ${key}. Daarom heeft EU-OSHA een ${easy} (het â€œOiRAâ"
-"€ - Online interactive Risk Assessment) ontwikkelt dat micro-ondernemingen "
-"en kleine ondernemingen kan helpen om een {step} aan te nemen â€“ starten "
-"met de ${identification} en ${evaluation} van risico's op de werkvloer, door "
-"middel van  het nemen van beslissingen over ${preventive_actions} en het "
-"ondernemen van actie, voor monitoring en ${reporting}."
+"Ervaring toont ons dat ${key}. Daarom heeft EU-OSHA een ${easy} (het "
+"â€œOiRAâ€ - Online interactive Risk Assessment) ontwikkelt dat micro-"
+"ondernemingen en kleine ondernemingen kan helpen om een {step} aan te nemen "
+"â€“ starten met de ${identification} en ${evaluation} van risico's op de "
+"werkvloer, door middel van  het nemen van beslissingen over "
+"${preventive_actions} en het ondernemen van actie, voor monitoring en "
+"${reporting}."
 
 #. Default: "easy-to-use and cost-free web application"
 #: euphorie/client/browser/templates/about.pt:42
@@ -1684,33 +1693,33 @@ msgid "about_partners_3_smb"
 msgstr "micro-ondernemingen en kleine ondernemingen hebben tekortkomingen"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 "Beschrijf de specifieke maatregelen die nodig zijn om het risico te "
 "verminderen."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Selecteer of beschrijf de specifieke maatregelen die nodig zijn om het "
 "risico te verminderen."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Beschrijf elke aanvullende maatregel om het risico te verminderen."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 "Selecteer of beschrijf elke aanvullende maatregel om het risico te "
 "verminderen."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Hoewel sommige maatregelen gratis zijn, zijn de meeste dat niet. De "
@@ -1718,7 +1727,7 @@ msgstr ""
 "jaarlijkse budgetronde, indien nodig."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Stel iemand aan in uw bedrijf die verantwoordelijk is voor de implementatie "
@@ -1727,7 +1736,7 @@ msgstr ""
 "te zorgen dat de stappen worden uitgevoerd."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Omschrijf: 1) wat is uw algemene aanpak om het risico te verhelpen (als het "
@@ -1736,7 +1745,7 @@ msgstr ""
 "implementeren."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Omschrijf: 3) het niveau van expertise dat is vereist om de maatregel te "
@@ -1829,7 +1838,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: positieve opmerkingen, die in modules zijn opgeslagen."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Toevoegen"
 
@@ -1870,7 +1879,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Annuleren"
@@ -2144,13 +2153,13 @@ msgstr "Type verwerkte gegevens"
 msgid "conditions_part5_entry"
 msgstr ""
 "De verwerking vindt plaats op basis van artikel 5, lid 1, punten a) en d), "
-"van <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv"
-"%3AOJ.L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Verordening "
-"(EU) 2018/1725</a> van het Europees Parlement en de Raad van 23 oktober 2018 "
-"betreffende de bescherming van natuurlijke personen in verband met de "
-"verwerking van persoonsgegevens door de instellingen, organen en instanties "
-"van de Unie en betreffende het vrije verkeer van die gegevens (hierna “de "
-"verordening” genoemd)."
+"van <a href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?"
+"uri=uriserv%3AOJ.L_.2018.295.01.0039.01."
+"ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Verordening (EU) 2018/1725</a> van het "
+"Europees Parlement en de Raad van 23 oktober 2018 betreffende de bescherming "
+"van natuurlijke personen in verband met de verwerking van persoonsgegevens "
+"door de instellingen, organen en instanties van de Unie en betreffende het "
+"vrije verkeer van die gegevens (hierna “de verordening” genoemd)."
 
 #. Default: "Lawfulness of processing"
 #: euphorie/client/browser/templates/conditions-bare.pt:66
@@ -2291,7 +2300,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Gelieve alles aan te kruisen wat u van de training zou willen uitsluiten. "
@@ -2299,7 +2308,7 @@ msgstr ""
 "trainingskaart."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "De tool heeft automatisch een risico-evaluatie uitgevoerd. U kunt de "
@@ -2490,17 +2499,17 @@ msgid "effect_high"
 msgstr "Blijvende gezondheidsschade"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Gering"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Gemiddeld"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Hoog (erg hoog)"
 
@@ -2547,7 +2556,7 @@ msgstr ""
 "'${email}' wanneer u klikt op onderstaande bevestigingslink."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Bevestig uw nieuwe e-mailadres door te klikken op de link in de e-mail die u "
@@ -2612,7 +2621,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 tot 249 werknemers"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Er bestaat al een account met dit e-mailadres."
 
@@ -2622,12 +2631,12 @@ msgid "error_existing_login"
 msgstr "Deze loginnaam bestaat al."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Vul het budget in hele euro's in."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Voer een geldig e-mailadres in"
 
@@ -2642,65 +2651,65 @@ msgid "error_invalid_xml"
 msgstr "Upload een geldig XML-bestand"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Voer uw e-mailadres in"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Voer een wachtwoord in"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Wachtwoorden komen niet overeen"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Het wachtwoord moet ten minste 12 tekens lang zijn en ten minste één kleine "
 "letter, één hoofdletter en één cijfer bevatten."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Deze datum moet op of na de startdatum zijn."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Deze datum moet op of vóór de einddatum zijn."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Deze waarde moet een positief geheel getal zijn."
 
@@ -2814,7 +2823,7 @@ msgstr ""
 "verdergaan, moet u deze wijzigingen bijwerken."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2851,7 +2860,7 @@ msgstr "Identificatierapport ${title}"
 msgid "filename_report_timeline"
 msgstr "Actieplan voor ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2872,7 +2881,7 @@ msgid "french"
 msgstr "Vereenvoudigde twee criteria"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Bijna nooit"
 
@@ -2882,57 +2891,57 @@ msgid "frequency_almostnever"
 msgstr "Bijna nooit"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Voortdurend"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Niet erg vaak"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Eenmaal per maand"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Vaak"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Eenmaal per week"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Zelden"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Eenmaal per jaar"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Erg vaak of regelmatig"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Minimaal eenmaal per jaar"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regelmatig"
@@ -2957,12 +2966,12 @@ msgid "header_additional_content"
 msgstr "Aanvullende inhoud"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Aanvullende bronnen om het risico te beoordelen"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Aanvullende bronnen voor deze module"
 
@@ -3206,23 +3215,23 @@ msgid "header_risk_aware"
 msgstr "Are you aware of all the risks?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Wat is de ernst van de schade?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Hoe vaak worden mensen blootgesteld aan dit risico?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Selecteer de prioriteit van dit risico"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Hoe groot is de kans dat dit risico zich voordoet?"
 
@@ -3286,7 +3295,7 @@ msgid "header_settings"
 msgstr "Instellingen"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standaardmaatregelen"
 
@@ -3529,7 +3538,7 @@ msgid "help_authentication"
 msgstr "Deze tekst moet uitleggen hoe de registratie en aanmelding verlopen."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Beantwoord de volgende vragen. Het systeem zal op grond van uw antwoorden de "
@@ -3562,7 +3571,7 @@ msgstr ""
 "wilt aanvangen met een exemplaar van een bestaand OiRA-instrument.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Geef aan hoe vaak dit risico voorkomt in een normale situatie."
 
@@ -3574,14 +3583,14 @@ msgstr ""
 "Hij/zij kan de prioriteit later nog wel wijzigen."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Geef aan hoe groot de kans is dat dit risico voorkomt in een normale "
 "situatie."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Geef de ernst aan wanneer dit risico zich voordoet."
 
@@ -4209,13 +4218,13 @@ msgstr "De account is vergrendeld"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Actieplan"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budget"
@@ -4227,21 +4236,21 @@ msgstr "Actieplan"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Einde van planning"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Wie is er verantwoordelijk?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Aanvang van planning"
@@ -4264,7 +4273,7 @@ msgid "label_alphabetical"
 msgstr "Alfabetisch"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Beoordeling"
 
@@ -4356,7 +4365,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr "Advies"
 
@@ -4443,7 +4452,7 @@ msgstr ""
 "U staat op het punt om dit risico te verwijderen: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Beschrijving"
@@ -4489,7 +4498,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Evaluatie"
 
@@ -4515,7 +4524,7 @@ msgid "label_existing_measure"
 msgstr "Maatregel is al toegepast"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Reeds geïmplementeerde maatregelen"
@@ -4526,7 +4535,7 @@ msgid "label_exit"
 msgstr "Verlaten"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Expertise"
 
@@ -4541,7 +4550,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Voeg een extra maatregel toe"
 
@@ -4646,7 +4655,7 @@ msgstr "Historiek"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identificatie"
 
@@ -4656,7 +4665,7 @@ msgid "label_image"
 msgstr "Afbeelding"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Uitgevoerde maatregel"
 
@@ -4683,7 +4692,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr "Validatie risicoanalyse intrekken"
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Participatie"
 
@@ -4731,8 +4740,8 @@ msgstr "Leer meer over OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Wet- en beleidsreferenties"
 
@@ -4795,7 +4804,7 @@ msgstr "Omschrijving van de maatregel"
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Algemene aanpak (om het risico te verhelpen of te verlagen)"
@@ -4809,7 +4818,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Niveau van expertise en/of vereisten nodig"
@@ -4943,12 +4952,12 @@ msgstr "Nee, er zijn meer maatregelen nodig"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Notities"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -5004,14 +5013,14 @@ msgid "label_password_confirm"
 msgstr "Opnieuw wachtwoord"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Geplande maatregelen"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Voorbereiding"
 
@@ -5103,13 +5112,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Verwijder deze maatregel"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Rapport"
 
@@ -5253,7 +5262,7 @@ msgid "label_select_assessment"
 msgstr "Een risicobeoordeling selecteren"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Selecteer één of meer van de bekende vaak voorkomende maatregelen."
 
@@ -5272,7 +5281,7 @@ msgid "label_select_oira_tool"
 msgstr "Selecteer een OiRA tool"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Selecteer standaardmaatregelen"
 
@@ -5749,8 +5758,8 @@ msgid "menu_import"
 msgstr "OiRA-instrument importeren"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Training"
 
@@ -5802,13 +5811,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "U kunt de enige versie van het OiRA-instrument niet verwijderen."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Gelieve dit veld in te vullen."
 
@@ -6085,7 +6099,7 @@ msgstr "Instellingen"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Bekijk uw voortgang"
 
@@ -6235,14 +6249,14 @@ msgstr ""
 "website, het OiRA-trainingschema en de OiRA-helpdesk beschikbaar zijn."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Deze commentaar zal zichtbaar zijn in het rapport. Gebruik het voor iets "
 "anders dat u over dit risico zou willen schrijven."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Deze aantekeningen zullen zichtbaar zijn in het rapport en de training. "
@@ -6273,45 +6287,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Hoog"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Laag"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Groot"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Gemiddeld"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Klein"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Voltooid"
 
@@ -6380,7 +6394,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6393,7 +6407,7 @@ msgstr ""
 "volgende voordelen:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6463,25 +6477,25 @@ msgid "risk_present"
 msgstr "Dit risico is aanwezig."
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Dit is een ${priority_value} prioriteitrisico."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "hoog"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "laag"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "gemiddeld"
@@ -6497,7 +6511,7 @@ msgid "risk_show_na_na"
 msgstr "niet van toepassing"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Maatregel ${number}"
 
@@ -6563,46 +6577,46 @@ msgstr ""
 "door uw browser te sluiten, maar het is beter om actief uit te loggen."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Niet vrij ernstig"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Nodig om werk gedurende minder dan 3 dagen te onderbreken"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Ernstig"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Nodig om werk gedurende meer dan 3 dagen te onderbreken"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Zeer ernstig"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Onomkeerbaar letsel, ongeneeslijke ziekte, overlijden"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Zwak"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Niet nodig om werk te onderbreken"
 
@@ -6701,12 +6715,12 @@ msgid "title_about"
 msgstr "Over"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Account verwijderen"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-28 11:02+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Norwegian\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -166,16 +166,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -198,7 +202,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -288,7 +292,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -539,7 +543,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -570,11 +574,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -643,7 +647,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -889,7 +893,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -1024,11 +1028,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -1041,13 +1045,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1116,7 +1120,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1133,7 +1137,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1171,7 +1175,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1216,7 +1220,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1232,7 +1236,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1267,7 +1271,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1308,7 +1312,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1322,6 +1326,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1437,7 +1445,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1446,7 +1454,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1546,42 +1554,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1653,7 +1661,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1694,7 +1702,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2032,12 +2040,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2199,17 +2207,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2254,7 +2262,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2308,7 +2316,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2318,12 +2326,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2338,63 +2346,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2484,7 +2492,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2512,7 +2520,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2533,7 +2541,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2543,57 +2551,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2614,12 +2622,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2861,23 +2869,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2941,7 +2949,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3182,7 +3190,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3207,7 +3215,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 
@@ -3217,12 +3225,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 
@@ -3711,13 +3719,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3729,21 +3737,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3766,7 +3774,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3858,7 +3866,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -3944,7 +3952,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -3990,7 +3998,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -4016,7 +4024,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4027,7 +4035,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4042,7 +4050,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4147,7 +4155,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4157,7 +4165,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4184,7 +4192,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4232,8 +4240,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4296,7 +4304,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4309,7 +4317,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4442,12 +4450,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4503,14 +4511,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4602,13 +4610,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4750,7 +4758,7 @@ msgid "label_select_assessment"
 msgstr "Velg en risikovurdering"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4769,7 +4777,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5228,8 +5236,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5278,13 +5286,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5515,7 +5528,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5658,12 +5671,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5690,45 +5703,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5793,7 +5806,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5803,7 +5816,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5864,25 +5877,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5898,7 +5911,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -5955,46 +5968,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6083,12 +6096,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:07+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Polish\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -167,16 +167,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -199,7 +203,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -289,7 +293,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -542,7 +546,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -573,11 +577,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -892,7 +896,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -1027,11 +1031,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -1044,13 +1048,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1119,7 +1123,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1174,7 +1178,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1219,7 +1223,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1235,7 +1239,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1325,6 +1329,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1440,7 +1448,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1449,7 +1457,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1549,42 +1557,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1656,7 +1664,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1697,7 +1705,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -1962,8 +1970,8 @@ msgstr "Tipo de dados tratados"
 #: euphorie/client/browser/templates/conditions-bare.pt:68
 msgid "conditions_part5_entry"
 msgstr ""
-"O tratamento tem por base o artigo 5.º, n.º 1, alíneas a) e d), do <a href="
-"\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
+"O tratamento tem por base o artigo 5.º, n.º 1, alíneas a) e d), do <a "
+"href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
 "L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Regulamento (UE) "
 "2018/1725</a>  do Parlamento Europeu e do Conselho, de 23 de outubro de "
 "2018, relativo à proteção das pessoas singulares no que diz respeito ao "
@@ -2108,12 +2116,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2278,17 +2286,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2333,7 +2341,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2387,7 +2395,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2397,12 +2405,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2417,63 +2425,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2563,7 +2571,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2591,7 +2599,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2612,7 +2620,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2622,57 +2630,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2693,12 +2701,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2940,23 +2948,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -3020,7 +3028,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3261,7 +3269,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3286,7 +3294,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 
@@ -3296,12 +3304,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 
@@ -3790,13 +3798,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3808,21 +3816,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3845,7 +3853,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3937,7 +3945,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4023,7 +4031,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -4069,7 +4077,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -4095,7 +4103,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4106,7 +4114,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4121,7 +4129,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4226,7 +4234,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4236,7 +4244,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4263,7 +4271,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4311,8 +4319,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4375,7 +4383,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4388,7 +4396,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4521,12 +4529,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4582,14 +4590,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4681,13 +4689,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4829,7 +4837,7 @@ msgid "label_select_assessment"
 msgstr "Wybierz ocenę ryzyka"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4848,7 +4856,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5307,8 +5315,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5357,13 +5365,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5594,7 +5607,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5737,12 +5750,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5769,45 +5782,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5872,7 +5885,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5882,7 +5895,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5943,25 +5956,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5977,7 +5990,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -6034,46 +6047,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6162,12 +6175,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-07-30 16:00+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgstr "Adicionar utilizador"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Medida adicional"
 
@@ -184,16 +184,20 @@ msgstr "Todas as línguas"
 msgid "Almost done&hellip;"
 msgstr "Quase a terminar&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Ocorreu um erro ao enviar o e-mail de confirmação."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -216,7 +220,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Tem a certeza que quer continuar? Esta ação não pode ser revertida."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -312,7 +316,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Confirmar alteração do endereço de e-mail OiRA"
 
@@ -572,7 +576,7 @@ msgstr ""
 "Contudo, pode dedicar o seu tempo conforme as suas disponibilidades, podendo "
 "fazer interrupções e continuar a avaliação quando for mais conveniente."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Clique para seguir ligação"
 
@@ -603,11 +607,11 @@ msgstr "Informação"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Formato de ficheiro inválido. Por favor use PNG, JPEG ou GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Palavra-passe inválida"
 
@@ -679,7 +683,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Medida"
@@ -942,7 +946,7 @@ msgstr "Consulte os exemplos abaixo do formulário."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Adiado"
 
@@ -1087,11 +1091,11 @@ msgstr "Avaliações de risco"
 msgid "Risk assessments made with this tool"
 msgstr "Avaliações de risco feitas com esta ferramenta"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "OK"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Atenção"
 
@@ -1104,13 +1108,13 @@ msgid "Run slideshow"
 msgstr "Ver slides"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Guardar"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Guardar alterações"
@@ -1182,7 +1186,7 @@ msgstr "Mensagem de opção de ocorrência única"
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Medidas sugeridas"
 
@@ -1199,7 +1203,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Iniciar o seu teste"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1245,7 +1249,7 @@ msgstr ""
 "A arquitetura de base de um instrumento interativo em linha de avaliação de "
 "risco consiste em:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1295,7 +1299,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Não existiam alterações para guardar."
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Este endereço de e-mail não está disponível."
 
@@ -1349,7 +1353,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1390,7 +1394,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Sem resposta"
 
@@ -1405,6 +1409,10 @@ msgstr "Adicione uma imagem que ilustre este risco."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Adicione imagem"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1536,7 +1544,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Terminaram os slides com o conteúdo da formação!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "O endereço de e-mail foi atualizado."
 
@@ -1545,7 +1553,7 @@ msgid "Your password for confirmation"
 msgstr "A sua palavra-passe para confirmação"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "A palavra-passe foi alterada corretamente."
 
@@ -1680,29 +1688,29 @@ msgid "about_partners_3_smb"
 msgstr "as micro e pequenas empresas têm algumas limitações"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Descreva as medidas específicas necessárias para reduzir o risco."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Selecione ou descreva as medidas específicas necessárias para reduzir o "
 "risco."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Descreva outra medida para reduzir o risco."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Selecione ou descreva outra medida para reduzir o risco."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Apesar de algumas medidas serem gratuitas, a maioria não. As medidas devem "
@@ -1710,7 +1718,7 @@ msgstr ""
 "orçamental anual."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Designe alguém na sua empresa como responsável pela implementação desta "
@@ -1718,7 +1726,7 @@ msgstr ""
 "e/ou responsabilidade para assegurar que os mesmos são executados."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Descreva: 1) qual é a sua abordagem geral para eliminar ou (se o risco for "
@@ -1726,7 +1734,7 @@ msgstr ""
 "para implementar esta abordagem (para eliminar ou reduzir o risco)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Descreva: 3) o nível de competência necessário para implementar a medida, "
@@ -1815,7 +1823,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: declarações afirmativas, contidas em módulos."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Adicionar"
 
@@ -1856,7 +1864,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Cancelar"
@@ -2125,8 +2133,8 @@ msgstr "Tipo de dados tratados"
 #: euphorie/client/browser/templates/conditions-bare.pt:68
 msgid "conditions_part5_entry"
 msgstr ""
-"O tratamento tem por base o artigo 5.º, n.º 1, alíneas a) e d), do <a href="
-"\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
+"O tratamento tem por base o artigo 5.º, n.º 1, alíneas a) e d), do <a "
+"href=\"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ."
 "L_.2018.295.01.0039.01.ENG&toc=OJ%3AL%3A2018%3A295%3ATOC\">Regulamento (UE) "
 "2018/1725</a> do Parlamento Europeu e do Conselho, de 23 de outubro de 2018, "
 "relativo à proteção das pessoas singulares no que diz respeito ao tratamento "
@@ -2272,7 +2280,7 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Por favor, assinalar os conteúdos que quer excluir da formação. Os conteúdos "
@@ -2280,7 +2288,7 @@ msgstr ""
 "formação."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "A avaliação do risco foi efetuada automaticamente pela ferramenta. Poderá "
@@ -2465,17 +2473,17 @@ msgid "effect_high"
 msgstr "Gravidade elevada (muito elevada)"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Gravidade fraca"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Gravidade significativa"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Gravidade elevada (muito elevada)"
 
@@ -2522,7 +2530,7 @@ msgstr ""
 "'${email}' ao clicar na ligação de confirmação em baixo."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Confirme o novo endereço de e-mail, clicando na ligação que será enviada "
@@ -2579,7 +2587,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 a 249 trabalhadores"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Já existe uma conta com este endereço de e-mail."
 
@@ -2589,12 +2597,12 @@ msgid "error_existing_login"
 msgstr "Este nome de login já existe."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Introduza o orçamento no seu todo em Euros."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Introduza um endereço de e-mail válido"
 
@@ -2610,65 +2618,65 @@ msgid "error_invalid_xml"
 msgstr "Carregue um ficheiro XML válido"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Introduza o seu endereço de e-mail"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Introduza uma palavra-passe"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "As palavras-passe não correspondem"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "A palavra-passe (password) tem que ter pelo menos 12 carateres, conter pelo "
 "menos uma letra minúscula, uma letra maiúscula e um dígito."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Esta data deve ser igual ou posterior à data inicial."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Esta data deve ser igual ou anterior à data final."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Este valor deve ser um número inteiro positivo."
 
@@ -2779,7 +2787,7 @@ msgstr ""
 "continuar, é necessário atualizar estas alterações."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2811,7 +2819,7 @@ msgstr "Relatório de identificação ${title}"
 msgid "filename_report_timeline"
 msgstr "Plano de ação para ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2832,7 +2840,7 @@ msgid "french"
 msgstr "Dois critérios simplificados"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Quase nunca"
 
@@ -2842,57 +2850,57 @@ msgid "frequency_almostnever"
 msgstr "Quase nunca"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Constantemente"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Não muito frequentemente"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Uma vez por mês"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Frequentemente"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Uma vez por semana"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Rara"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Uma vez por ano"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Muito frequentemente ou regularmente"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "No mínimo uma vez por dia"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regularmente"
@@ -2917,12 +2925,12 @@ msgid "header_additional_content"
 msgstr "Conteúdo adicional"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Recursos adicionais para a avaliação do risco"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Recursos adicionais para este mòdulo"
 
@@ -3165,23 +3173,23 @@ msgid "header_risk_aware"
 msgstr "Conhece todos os riscos?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Qual é a gravidade do dano?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Qual é a frequência de exposição a este risco?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Selecione a prioridade deste risco"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Qual é a probabilidade de ocorrência deste risco?"
 
@@ -3247,7 +3255,7 @@ msgid "header_settings"
 msgstr "Definições"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Medidas padrão"
 
@@ -3488,7 +3496,7 @@ msgid "help_authentication"
 msgstr "Este texto deve explicar como efetuar o registo e o login."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Queira responder às perguntas que se seguem. Em função das suas respostas, o "
@@ -3521,7 +3529,7 @@ msgstr ""
 "começar com uma cópia de uma Ferramenta OiRA existente.."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Indica a frequência de ocorrência do risco numa situação normal."
 
@@ -3533,12 +3541,12 @@ msgstr ""
 "ainda pode alterar a prioridade."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Indica a probabilidade de ocorrência deste risco numa siutação normal."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Indica a gravidade em caso de ocorrência do risco."
 
@@ -3762,8 +3770,8 @@ msgstr ""
 msgid "help_risk_type"
 msgstr ""
 "Prioridade do risco\" é um dos riscos elevados no setor. \"Risco\" está "
-"relacionado com o local de trabalho ou com o trabalho realizado. \"Política"
-"\" refere-se a acordos, procedimentos e decisões de gestão."
+"relacionado com o local de trabalho ou com o trabalho realizado. "
+"\"Política\" refere-se a acordos, procedimentos e decisões de gestão."
 
 #. Default: "Give the name of the person responsible for the OiRA tools of this sector."
 #: euphorie/content/browser/templates/sector_edit.pt:148
@@ -4147,13 +4155,13 @@ msgstr "A conta está bloqueada"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Plano de Ação"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Orçamento"
@@ -4165,21 +4173,21 @@ msgstr "Plano de Ação"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "A planear o fim"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Quem é o responsável?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "A planear o início"
@@ -4202,7 +4210,7 @@ msgid "label_alphabetical"
 msgstr "Por ordem alfabética"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Avaliação"
 
@@ -4294,7 +4302,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4380,7 +4388,7 @@ msgid "label_delete_risk"
 msgstr "O risco está prestes a ser eliminado: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Descrição"
@@ -4426,7 +4434,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Avaliação"
 
@@ -4452,7 +4460,7 @@ msgid "label_existing_measure"
 msgstr "Medida já executada"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Medidas já implementadas"
@@ -4463,7 +4471,7 @@ msgid "label_exit"
 msgstr "Sair"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Perícia"
 
@@ -4478,7 +4486,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Adicione outras medidas"
 
@@ -4583,7 +4591,7 @@ msgstr "Histórico"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identificação"
 
@@ -4593,7 +4601,7 @@ msgid "label_image"
 msgstr "Ficheiro de imagem"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Medida implementada"
 
@@ -4620,7 +4628,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Envolvimento"
 
@@ -4668,8 +4676,8 @@ msgstr "Saiba mais sobre a OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Referências legais e políticas"
 
@@ -4732,7 +4740,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Abordagem geral (para eliminar ou reduzir o risco)"
@@ -4745,7 +4753,7 @@ msgstr "Ação(ões) específica(s) necessária(s) para implementar esta abordag
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Nível de competência e/ou requisitos necessários"
@@ -4878,12 +4886,12 @@ msgstr "Não, são necessárias mais medidas"
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Notas"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4939,14 +4947,14 @@ msgid "label_password_confirm"
 msgstr "Coloque novamente a sua palavra-passe"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Medidas planeadas"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Preparação"
 
@@ -5038,13 +5046,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Apagar esta medida"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Relatório"
 
@@ -5186,7 +5194,7 @@ msgid "label_select_assessment"
 msgstr "Selecionar uma avaliação de riscos"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 "Selecione uma ou mais das medidas comuns conhecidas que foram fornecidas."
@@ -5207,7 +5215,7 @@ msgid "label_select_oira_tool"
 msgstr "Selecione uma ferramenta OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Selecione medidas sugeridas"
 
@@ -5680,8 +5688,8 @@ msgid "menu_import"
 msgstr "Importar a Ferramenta OiRA "
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Formação"
 
@@ -5733,13 +5741,18 @@ msgstr ""
 "Esta é a única versão da Ferramenta OiRA e, por isso, não pode ser apagada. "
 "Talvez pretendesse remover a Ferramenta OiRA?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Campo obrigatório."
 
@@ -5995,7 +6008,7 @@ msgstr "Definições"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Estado"
 
@@ -6143,14 +6156,14 @@ msgstr ""
 "OiRA, o plano de formação OiRA e o serviço de apoio OiRA estejam prontos."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Este comentário será visível no relatório. Utilize-o para qualquer outro "
 "assunto que possa querer escrever sobre este risco."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Este comentário será visível no relatório e na formação. Utilize este espaço "
@@ -6181,45 +6194,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Elevada"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Baixa"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Média"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Elevada"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Média"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Pequena"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Completo"
 
@@ -6287,7 +6300,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6299,7 +6312,7 @@ msgstr ""
 "Registe-se em apenas uma etapa e usufrua das seguintes vantagens:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6368,25 +6381,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Este é um risco de prioridade ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "elevada"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "baixa"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "média"
@@ -6402,7 +6415,7 @@ msgid "risk_show_na_na"
 msgstr "não aplicável"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Medida ${number}"
 
@@ -6467,46 +6480,46 @@ msgstr ""
 "efetuar uma saída de sessão ativa."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Não muito grave"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Necessidade de interromper o trabalho até 3 dias"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Grave"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Necessidade de interromper o trabalho mais de 3 dias"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Muito grave"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Lesões irreversíveis, doença incurável, morte"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Fraca"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Sem necessidade de interrupção do trabalho"
 
@@ -6605,12 +6618,12 @@ msgid "title_about"
 msgstr "Sobre"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Apagar conta"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:08+0200\n"
 "Last-Translator: JC Brand <brand@syslab.com>\n"
 "Language-Team: Romanian\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -167,16 +167,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -199,7 +203,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -289,7 +293,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -542,7 +546,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -573,11 +577,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -892,7 +896,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr ""
 
@@ -1027,11 +1031,11 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr ""
 
@@ -1044,13 +1048,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr ""
@@ -1119,7 +1123,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1174,7 +1178,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1219,7 +1223,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1235,7 +1239,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1325,6 +1329,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1440,7 +1448,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1449,7 +1457,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1549,42 +1557,42 @@ msgid "about_partners_3_smb"
 msgstr ""
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1656,7 +1664,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr ""
 
@@ -1697,7 +1705,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr ""
@@ -2035,12 +2043,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2205,17 +2213,17 @@ msgid "effect_high"
 msgstr ""
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr ""
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr ""
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr ""
 
@@ -2260,7 +2268,7 @@ msgid "email_change_intro"
 msgstr ""
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2314,7 +2322,7 @@ msgid "employee_numbers_50_to_249"
 msgstr ""
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr ""
 
@@ -2324,12 +2332,12 @@ msgid "error_existing_login"
 msgstr ""
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr ""
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr ""
 
@@ -2344,63 +2352,63 @@ msgid "error_invalid_xml"
 msgstr ""
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr ""
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr ""
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr ""
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2490,7 +2498,7 @@ msgid "expl_update"
 msgstr ""
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2518,7 +2526,7 @@ msgstr ""
 msgid "filename_report_timeline"
 msgstr ""
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2539,7 +2547,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr ""
 
@@ -2549,57 +2557,57 @@ msgid "frequency_almostnever"
 msgstr ""
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr ""
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr ""
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr ""
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr ""
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr ""
@@ -2620,12 +2628,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2867,23 +2875,23 @@ msgid "header_risk_aware"
 msgstr ""
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr ""
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr ""
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr ""
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr ""
 
@@ -2947,7 +2955,7 @@ msgid "header_settings"
 msgstr ""
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr ""
 
@@ -3188,7 +3196,7 @@ msgid "help_authentication"
 msgstr ""
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3213,7 +3221,7 @@ msgid "help_create_new_version"
 msgstr ""
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr ""
 
@@ -3223,12 +3231,12 @@ msgid "help_default_priority"
 msgstr ""
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr ""
 
@@ -3718,13 +3726,13 @@ msgstr ""
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr ""
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr ""
@@ -3736,21 +3744,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr ""
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr ""
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr ""
@@ -3773,7 +3781,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -3865,7 +3873,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -3951,7 +3959,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr ""
@@ -3997,7 +4005,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr ""
 
@@ -4023,7 +4031,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4034,7 +4042,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4049,7 +4057,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4154,7 +4162,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr ""
 
@@ -4164,7 +4172,7 @@ msgid "label_image"
 msgstr ""
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4191,7 +4199,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4239,8 +4247,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr ""
 
@@ -4303,7 +4311,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr ""
@@ -4316,7 +4324,7 @@ msgstr ""
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr ""
@@ -4449,12 +4457,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4510,14 +4518,14 @@ msgid "label_password_confirm"
 msgstr ""
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr ""
 
@@ -4609,13 +4617,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr ""
 
@@ -4757,7 +4765,7 @@ msgid "label_select_assessment"
 msgstr "Selectați o evaluare a riscurilor"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4776,7 +4784,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5235,8 +5243,8 @@ msgid "menu_import"
 msgstr ""
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5285,13 +5293,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr ""
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5522,7 +5535,7 @@ msgstr ""
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr ""
 
@@ -5665,12 +5678,12 @@ msgid "phase_launch"
 msgstr ""
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5697,45 +5710,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr ""
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr ""
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr ""
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr ""
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr ""
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr ""
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5800,7 +5813,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5810,7 +5823,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -5871,25 +5884,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr ""
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr ""
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr ""
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr ""
@@ -5905,7 +5918,7 @@ msgid "risk_show_na_na"
 msgstr ""
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr ""
 
@@ -5962,46 +5975,46 @@ msgid "session_title_tooltip"
 msgstr ""
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6090,12 +6103,12 @@ msgid "title_about"
 msgstr ""
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr ""
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-10-23 15:53+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,7 +162,7 @@ msgstr "Pridať užívateľa"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr "Bola pridaná kópia „${title}“ do vášho nástroja OiRA."
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Dodatočné opatrenie"
 
@@ -182,17 +182,21 @@ msgstr "Všetky jazyky"
 msgid "Almost done&hellip;"
 msgstr "Takmer hotovo&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Pri posielaní potvrdzujúceho e-mailu sa vyskytla chyba."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
 msgstr "Pri posielaní pokynov k obnove hesla sa vyskytla chyba."
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
+msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
 msgid "Archive"
@@ -214,7 +218,7 @@ msgstr "Naozaj chcete archivovať túto reláciu?"
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr "Naozaj chcete pokračovať? Táto činnosť sa nedá vrátiť späť."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -308,7 +312,7 @@ msgstr "Pripomienky"
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Potvrdiť zmenu e-mailovej adresy OiRA"
 
@@ -566,7 +570,7 @@ msgstr ""
 "nemu môžete vrátiť, keď vám to bude vyhovovať, a pokračovať od&nbsp;miesta, "
 "kde ste skončili."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Chcem sa s vami podeliť o nasledovné"
 
@@ -597,12 +601,12 @@ msgstr "Informácie"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 "Neplatný formát súboru pre obrázok. Použite formát PNG, JPEG alebo GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Neplatné heslo"
 
@@ -673,7 +677,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Opatrenie"
@@ -936,7 +940,7 @@ msgstr "Pozrite si príklady pod formulárom."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Odložené"
 
@@ -1079,11 +1083,11 @@ msgstr "Hodnotenia rizík"
 msgid "Risk assessments made with this tool"
 msgstr "Hodnotenia rizík pomocou tohto nástroja"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Riziko nie je prítomné"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Riziko je prítomné"
 
@@ -1096,13 +1100,13 @@ msgid "Run slideshow"
 msgstr "Spustiť prezentáciu"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Uložiť"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Uložiť zmeny"
@@ -1174,7 +1178,7 @@ msgstr "Výzva v prípade jedného výskytu"
 msgid "Standard"
 msgstr "Štandardné"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Štandardné opatrenia"
 
@@ -1191,7 +1195,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Začať s otázkami"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1236,7 +1240,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "Základnú architektúru online interaktívneho hodnotenia rizík tvorí:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1290,7 +1294,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr "Na prechod do identifikačnej fázy nie je dostatok informácií."
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Neexistovali žiadne zmeny na uloženie."
 
@@ -1306,7 +1310,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Táto e-mailová adresa nie je k dispozícii."
 
@@ -1345,7 +1349,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr "Táto otázka sa musí používateľa opýtať, či sa na neho vzťahuje profil."
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr "Túto požiadavku nebolo možné spracovať."
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Nenavštívené"
 
@@ -1401,6 +1405,10 @@ msgstr "Nahrať obrázok, ktorý znázorňuje toto riziko."
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Nahrať obrázok."
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1534,7 +1542,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "So snímkami zo školenia ste skončili!"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Vaša e-mailová adresa bola aktualizovaná."
 
@@ -1543,7 +1551,7 @@ msgid "Your password for confirmation"
 msgstr "Vaše heslo na potvrdenie"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Vaše heslo bolo úspešne zmenené."
 
@@ -1657,28 +1665,28 @@ msgid "about_partners_3_smb"
 msgstr "mikro a malé podniky majú určité nedostatky"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Opíšte konkrétne opatrenia požadované na zníženie rizika."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 "Vyberte alebo opíšte konkrétne opatrenia požadované na zníženie rizika."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Opíšte akékoľvek ďalšie opatrenie požadované na zníženie rizika."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Vyberte alebo opíšte akékoľvek ďalšie opatrenie na zníženie rizika."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Aj keď niektoré opatrenia sú bezplatné, za  väčšinu musíte zaplatiť. Preto "
@@ -1686,7 +1694,7 @@ msgstr ""
 "ich do ročného rozpočtu."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Vymenujte osobu vo vašej spoločnosti, ktorá bude niesť zodpovednosť za&nbsp;"
@@ -1694,7 +1702,7 @@ msgstr ""
 "opísané v pláne a/alebo zodpovednosť za zabezpečenie, že sa vykonávajú."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Opíšte: 1) aký je váš všeobecný prístup k odstráneniu alebo (ak sa riziku "
@@ -1702,7 +1710,7 @@ msgstr ""
 "prístupu (odstránenie alebo zmiernenie rizika)"
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Opíšte úroveň znalostí potrebných na zavedenie opatrenia, napr. „zdravý "
@@ -1793,7 +1801,7 @@ msgid "bullet_risks"
 msgstr "${Risks}: kladné vyhlásenia, ktoré sú uvedené v moduloch."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Pridať"
 
@@ -1834,7 +1842,7 @@ msgstr "Áno, archívna relácia"
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Zrušiť"
@@ -2246,14 +2254,14 @@ msgstr ""
 "identifikácie, použite tlačidlo „Pridať opatrenie“ v časti Riziko."
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Zaškrtnite všetko, čo by ste chceli vylúčiť zo školenia. Položky, ktoré sú "
 "sivé, sa na karte školenia nezobrazia."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Nástroj automaticky vykonal hodnotenie rizík. Ak to považujete za "
@@ -2451,17 +2459,17 @@ msgid "effect_high"
 msgstr "Vysoká (veľmi vysoká) závažnosť"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Nízka závažnosť"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Významná závažnosť"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Vysoká (veľmi vysoká) závažnosť"
 
@@ -2508,7 +2516,7 @@ msgstr ""
 "na ${url} budú zmenené na „${email}“."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Potvrďte svoju novú e-mailovú adresu kliknutím na tento odkaz v e-maile, "
@@ -2565,7 +2573,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 až 249 zamestnancov"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Konto s touto e-mailovou adresou už existuje."
 
@@ -2575,12 +2583,12 @@ msgid "error_existing_login"
 msgstr "Toto prihlasovacie meno sa už používa."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Zadajte rozpočet v celých eurách."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Zadajte platnú e-mailovú adresu"
 
@@ -2595,66 +2603,66 @@ msgid "error_invalid_xml"
 msgstr "Nahrajte platný súbor XML"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Zadajte svoju e-mailovú adresu"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Zadajte heslo"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Heslá sa nezhodujú"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Heslo musí mať aspoň 12 znakov a musí obsahovať aspoň jedno malé písmeno, "
 "jedno veľké písmeno a jednu číslicu."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 "Konto vám bude vytvorené, iba ak budete súhlasiť s podmienkami používania."
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr "Tento dátum musí byť v deň začiatku alebo po ňom."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr "Tento dátum musí byť v deň ukončenia alebo pred ním."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Táto hodnota musí byť kladné celé číslo."
 
@@ -2765,7 +2773,7 @@ msgstr ""
 "pokračovať, musíte sa informovať o týchto zmenách."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 "Toto riziko bolo automaticky nastavené ako prítomné. Toto nemôžete zmeniť."
@@ -2798,7 +2806,7 @@ msgstr "Správa o identifikácii ${title}"
 msgid "filename_report_timeline"
 msgstr "Akčný plán pre ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2819,7 +2827,7 @@ msgid "french"
 msgstr "Zjednodušené dve kritériá"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Takmer nikdy"
 
@@ -2829,57 +2837,57 @@ msgid "frequency_almostnever"
 msgstr "Takmer nikdy"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Vždy"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Nie veľmi často"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Raz za mesiac"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Často"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Raz za týždeň"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Zriedkavé"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Raz za rok"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Veľmi často alebo pravidelne"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Minimálne raz denne"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Pravidelne"
@@ -2904,12 +2912,12 @@ msgid "header_additional_content"
 msgstr "Dodatočný obsah"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Dodatočné zdroje na hodnotenie rizika"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Dodatočné zdroje pre tento modul"
 
@@ -3151,23 +3159,23 @@ msgid "header_risk_aware"
 msgstr "Viete o všetkých rizikách?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Aká je závažnosť tejto škody?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Ako často sú ľudia vystavení tomuto riziku?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Vyberte prioritu tohto rizika"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Aká je pravdepodobnosť výskytu tohto rizika?"
 
@@ -3233,7 +3241,7 @@ msgid "header_settings"
 msgstr "Nastavenia"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Štandardné opatrenia"
 
@@ -3479,7 +3487,7 @@ msgid "help_authentication"
 msgstr "Tento text má vysvetliť, ako sa zaregistrovať a prihlásiť."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Odpovedzte na nasledujúce otázky. Na základe vašich odpovedí systém vypočíta "
@@ -3513,7 +3521,7 @@ msgstr ""
 "existujúceho nástroja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Uveďte, ako často sa toto riziko vyskytuje v bežnej situácii."
 
@@ -3525,12 +3533,12 @@ msgstr ""
 "používateľ má stále možnosť prioritu zmeniť."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Uveďte, aký pravdepodobný je výskyt tohto rizika v bežnej situácii."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Uveďte závažnosť, ak sa vyskytne toto riziko."
 
@@ -4143,13 +4151,13 @@ msgstr "Konto je zablokované"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Akčný plán"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Rozpočet"
@@ -4161,21 +4169,21 @@ msgstr "Akčný plán"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Koniec plánovania"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Kto nesie zodpovednosť?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Začiatok plánovania"
@@ -4198,7 +4206,7 @@ msgid "label_alphabetical"
 msgstr "Abecedne"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Hodnotenie"
 
@@ -4290,7 +4298,7 @@ msgstr "Potvrdiť heslo"
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4376,7 +4384,7 @@ msgid "label_delete_risk"
 msgstr "Chystáte sa vymazať riziko: „${risk-name}“."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Opis"
@@ -4422,7 +4430,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Hodnotenie"
 
@@ -4448,7 +4456,7 @@ msgid "label_existing_measure"
 msgstr "Opatrenie už bolo zavedené"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Už realizované opatrenia"
@@ -4459,7 +4467,7 @@ msgid "label_exit"
 msgstr "Odísť"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Znalosti"
 
@@ -4474,7 +4482,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Pridať opatrenie navyše"
 
@@ -4579,7 +4587,7 @@ msgstr "História"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identifikácia"
 
@@ -4589,7 +4597,7 @@ msgid "label_image"
 msgstr "Súbor s obrázkami"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Zavedené opatrenie"
 
@@ -4616,7 +4624,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Zahrnúť"
 
@@ -4664,8 +4672,8 @@ msgstr "Viac informácií o projekte OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Právne odkazy a odkazy na zásady"
 
@@ -4730,7 +4738,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Všeobecný prístup (na odstránenie alebo zníženie rizika)"
@@ -4743,7 +4751,7 @@ msgstr "Konkrétne kroky potrebné na zavedenie tohto prístupu"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Potrebná úroveň znalostí a/alebo požiadaviek"
@@ -4877,12 +4885,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4938,14 +4946,14 @@ msgid "label_password_confirm"
 msgstr "Znova heslo"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Plánované opatrenia"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Príprava"
 
@@ -5037,13 +5045,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Vymazať toto opatrenie"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Správa"
 
@@ -5187,7 +5195,7 @@ msgid "label_select_assessment"
 msgstr "Vybrať hodnotenie rizika"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Vybrať jedno alebo viaceré uvedené známe spoločné opatrenia."
 
@@ -5207,7 +5215,7 @@ msgid "label_select_oira_tool"
 msgstr "Vybrať nástroj OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Vybrať štandardné opatrenia"
 
@@ -5682,8 +5690,8 @@ msgid "menu_import"
 msgstr "Importovať verziu nástroja OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Školenie"
 
@@ -5734,13 +5742,18 @@ msgstr ""
 "Toto je jediná verzia nástroja OiRA a preto sa nedávymazať. Možno chcete "
 "odstrániť samotný nástroj OiRA?"
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Vyplňte toto pole."
 
@@ -5994,7 +6007,7 @@ msgstr "Nastavenia"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Stav"
 
@@ -6144,14 +6157,14 @@ msgstr ""
 "vzdelávania OiRA a technickej podpory OiRA."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Tento komentár sa zobrazí v správe. Použite ho na akékoľvek ďalšie "
 "informácie, ktoré chcete uviesť o tomto riziku."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "These notes will be visible in the report and the training. Use it for "
@@ -6181,45 +6194,45 @@ msgstr "KOPÍROVAŤ"
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Vysoká"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Nízka"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Stredná"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Veľké"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Stredné"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Malé"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "Úroveň dokončenia: ${completion_percentage}&nbsp;%"
 
@@ -6287,7 +6300,7 @@ msgid "report_end_date"
 msgstr "Realizuje: ${date}"
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6297,7 +6310,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6366,25 +6379,25 @@ msgid "risk_present"
 msgstr "Riziko je prítomné."
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Priorita tohto rizika je ${priority_value}"
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "vysoká"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "nízka"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "stredná"
@@ -6400,7 +6413,7 @@ msgid "risk_show_na_na"
 msgstr "neuplatňuje sa"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Opatrenie ${number}"
 
@@ -6461,46 +6474,46 @@ msgstr ""
 "ho opäť začať v iný deň"
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Nie veľmi závažné"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Bolo potrebné prerušenie práce na menej ako 3 dni"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Závažné"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Bolo potrebné prerušenie práce na viac ako 3 dni"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Veľmi závažné"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Nezvratné poranenie, nevyliečiteľná choroba, úmrtie"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Nízke"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Nebolo potrebné prerušiť prácu"
 
@@ -6597,12 +6610,12 @@ msgid "title_about"
 msgstr "O nás"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Odstrániť konto"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-10-23 10:03+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgstr "Dodaj uporabnika"
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr "Dodaten ukrep"
 
@@ -184,16 +184,20 @@ msgstr "Vsi jeziki"
 msgid "Almost done&hellip;"
 msgstr "Skoraj končano&hellip;"
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Med pošiljanjem potrditvene e-pošte je prišlo do napake."
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -218,7 +222,7 @@ msgstr ""
 "Ali ste prepričani, da želite nadaljevati? Tega dejanja ni mogoče "
 "razveljaviti."
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -316,7 +320,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr "Potrdi spremembo e-poštnega naslova OiRA"
 
@@ -578,7 +582,7 @@ msgstr ""
 "Vendar pa si lahko za oceno vzamete toliko časa kot ga imate na voljo in se "
 "kasneje vrnete in nadaljujete, kjer ste prekinili."
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr "Z vami želim deliti naslednje"
 
@@ -609,11 +613,11 @@ msgstr "Informacije"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr "Napačen format slike. Prosim, uporabi PNG, JPEG ali GIF."
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Neveljavno geslo"
 
@@ -684,7 +688,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr "Ukrep"
@@ -949,7 +953,7 @@ msgstr "Oglejte si primere pod obrazcem."
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "Preloženo"
 
@@ -1092,11 +1096,11 @@ msgstr "Ocene tveganja"
 msgid "Risk assessments made with this tool"
 msgstr "Ocene tveganja, opravljene s tem orodjem"
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr "Urejeno"
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Neurejeno"
 
@@ -1109,13 +1113,13 @@ msgid "Run slideshow"
 msgstr "Zaženi diaprojekcijo"
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr "Shrani"
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Shrani spremembe"
@@ -1187,7 +1191,7 @@ msgstr "Enkraten takojšen pripetljaj "
 msgid "Standard"
 msgstr "Standardno"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr "Predlagani ukrepi"
 
@@ -1204,7 +1208,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr "Začnite z vprašanji"
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1248,7 +1252,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr "V osnovi spletno interaktivno oceno tveganja sestavljajo:"
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1298,7 +1302,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr "Nobene spremembe se niso shranile."
 
@@ -1314,7 +1318,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr "Ta e-poštni naslov ni na voljo."
 
@@ -1351,7 +1355,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1392,7 +1396,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr "Neodgovorjeno"
 
@@ -1407,6 +1411,10 @@ msgstr "Naloži sliko, ki predstavlja to tveganje"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
 msgstr "Naloži sliko"
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
+msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
 msgid "Use the report to:"
@@ -1542,7 +1550,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr "Končali ste z diapozitivi"
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr "Vaš e-poštni naslov je bil posodobljen."
 
@@ -1551,7 +1559,7 @@ msgid "Your password for confirmation"
 msgstr "Vaše geslo za potrditev"
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr "Vaše geslo je bilo uspešno spremenjeno."
 
@@ -1675,34 +1683,34 @@ msgid "about_partners_3_smb"
 msgstr "mikro in majhna podjetja imajo nekaj primanjkljajev"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr "Opiši specifične ukrepe za zmanjšanje tveganja."
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr "Izberi ali opiši specifične ukrepe za zmanjšanje tveganja."
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr "Opiši vse nadaljnje ukrepe za zmanjšanje tveganja."
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr "Izberi ali opiši vse nadaljnje ukrepe za zmanjšanje tveganja."
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Čeprav nekateri ukrepi nič ne stanejo, jih večina stane. Zato je treba imeti "
 "zanje zagotovljena sredstva; po potrebi jih vključite v letni proračun."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Določite nekoga v vašem podjetju, ki bo odgovoren za izvajanje tega ukrepa. "
@@ -1710,7 +1718,7 @@ msgstr ""
 "ukrepov in/ali bo odgovorna za njihovo izvajanje."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Opišite: 1) kakšen je vaš splošni pristop, da odpravite ali (če se tveganju "
@@ -1718,7 +1726,7 @@ msgstr ""
 "izvajanje tega pristopa (da odpravite ali zmanjšate tveganje)."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 "Opišite: 3) raven strokovnosti, potrebna za izvajanje ukrepa, npr. \"zdrava "
@@ -1805,7 +1813,7 @@ msgid "bullet_risks"
 msgstr "${Tveganja}: pozitivne izjave, ki jih vsebujejo moduli."
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Dodaj"
 
@@ -1846,7 +1854,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Prekliči"
@@ -2260,14 +2268,14 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 "Prosimo, označite vse, kar bi morda želeli izključiti iz usposabljanja. "
 "Elementi, ki so zatemnjeni, ne bodo prikazani na vadbeni kartici."
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 "Orodje je samodejno izvedlo oceno tveganja. Prednostno razvrstitev za to "
@@ -2449,17 +2457,17 @@ msgid "effect_high"
 msgstr "Velika (zelo velika) resnost"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Nizka"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Znatna"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Visoka (zelo visoka)"
 
@@ -2506,7 +2514,7 @@ msgstr ""
 "povezavo spremenila v '${email}'."
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 "Potrdite vaš nov e-poštni naslov, tako da kliknete na povezavo v e-pošti, ki "
@@ -2565,7 +2573,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50 do 249 zaposlenih"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Račun s tem e-poštnim naslovom že obstaja."
 
@@ -2575,12 +2583,12 @@ msgid "error_existing_login"
 msgstr "To uporabniško ime je že zasedeno."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Vnesite proračun v evrih brez decimalk."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Vnesite veljaven e-poštni naslov"
 
@@ -2595,68 +2603,68 @@ msgid "error_invalid_xml"
 msgstr "Naložite veljavno datoteko XML"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Vnesite svoj e-poštni naslov"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Vnesite geslo"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Gesli se ne ujemata"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 "Geslo mora biti dolgo vsaj 12 znakov in mora vsebovati vsaj eno malo črko, "
 "eno veliko črko in eno številko."
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 "Ta datum mora biti enak začetnemu datumu oziroma mora biti poznejši od njega."
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 "Ta datum mora biti enak končnemu datumu oziroma ne sme biti poznejši od "
 "njega."
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr "Ta vrednost mora biti pozitivno celo število."
 
@@ -2765,7 +2773,7 @@ msgstr ""
 "spremembe, narejene v orodju OiRA, združene v vašo sejo."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2797,7 +2805,7 @@ msgstr "Identifikacijsko poročilo ${title}"
 msgid "filename_report_timeline"
 msgstr "Načrt ukrepov ${title}"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2818,7 +2826,7 @@ msgid "french"
 msgstr "Poenostavljena dva kriterija"
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Skoraj nikoli"
 
@@ -2828,57 +2836,57 @@ msgid "frequency_almostnever"
 msgstr "Skoraj nikoli"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Nenehno"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr "Ne zelo pogosto"
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr "Enkrat mesečno"
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr "Pogosto"
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Enkrat tedensko"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr "Redko"
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Enkrat letno"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr "Zelo pogosto ali redno"
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Najmanj enkrat dnevno"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Redno"
@@ -2903,12 +2911,12 @@ msgid "header_additional_content"
 msgstr "Dodatna vsebina"
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr "Dodatni viri za ocenjevanje tveganja"
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr "Dodatni viri za ta modul"
 
@@ -3151,23 +3159,23 @@ msgid "header_risk_aware"
 msgstr "Ali se zavedate vseh tveganj?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Resnost"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Pogostost"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Prioriteta"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Verjetnost"
 
@@ -3233,7 +3241,7 @@ msgid "header_settings"
 msgstr "Nastavitve"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standardni ukrepi"
 
@@ -3474,7 +3482,7 @@ msgid "help_authentication"
 msgstr "To besedilo mora pojasniti, kako se registrirati in prijaviti."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 "Odgovorite na naslednja vprašanja. Sistem bo na podlagi vaših odgovorov "
@@ -3506,7 +3514,7 @@ msgstr ""
 "obstoječega orodja OiRA."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Označite, kako pogosto se to tveganje pojavi v običajni situaciji."
 
@@ -3518,13 +3526,13 @@ msgstr ""
 "Svojo prioriteto bo še vedno lahko spremenil/a."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr ""
 "Označite verjetnost, da bi se to tveganje pojavilo v običajni situaciji."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Označite stopnjo resnosti, če se to tveganje pojavi."
 
@@ -4114,13 +4122,13 @@ msgstr "Račun je zaklenjen"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Načrt ukrepov"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Potrebna sredstva"
@@ -4132,21 +4140,21 @@ msgstr "Načrt ukrepov"
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Načrtovani zaključek"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Kdo je odgovoren?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Načrtovani začetek"
@@ -4169,7 +4177,7 @@ msgid "label_alphabetical"
 msgstr "Po abecedi"
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr "Ocenjevanje"
 
@@ -4261,7 +4269,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4347,7 +4355,7 @@ msgid "label_delete_risk"
 msgstr "Izbrisali boste tveganje: &ldquo;${risk-name}&rdquo;."
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Opis"
@@ -4393,7 +4401,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Ocena"
 
@@ -4419,7 +4427,7 @@ msgid "label_existing_measure"
 msgstr "Že izveden ukrep"
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr "Že izvedeni ukrepi"
@@ -4430,7 +4438,7 @@ msgid "label_exit"
 msgstr "Izhod"
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr "Strokovnost"
 
@@ -4445,7 +4453,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr "Vaš dodan ukrep"
 
@@ -4550,7 +4558,7 @@ msgstr "Zgodovina"
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identifikacija"
 
@@ -4560,7 +4568,7 @@ msgid "label_image"
 msgstr "Slikovna datoteka"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr "Izvedeni ukrep"
 
@@ -4587,7 +4595,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr "Vključevanje"
 
@@ -4635,8 +4643,8 @@ msgstr "Več o orodju OiRA"
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Zakonodaja in drugi viri"
 
@@ -4699,7 +4707,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Splošni pristop (za odpravo ali zmanjšanje tveganja)"
@@ -4712,7 +4720,7 @@ msgstr "Specifični ukrepi, potrebni za izvajanje tega pristopa"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Raven potrebne strokovnosti in/ali zahteve"
@@ -4847,12 +4855,12 @@ msgstr "Ne, potrebnih je več ukrepov."
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr "Opombe"
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4908,14 +4916,14 @@ msgid "label_password_confirm"
 msgstr "Ponovi geslo"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr "Načrtovani ukrepi"
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Priprava"
 
@@ -5007,13 +5015,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr "Izbrišite ta ukrep"
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Poročilo"
 
@@ -5157,7 +5165,7 @@ msgid "label_select_assessment"
 msgstr "Izberite oceno tveganja"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr "Izberite enega ali več znanih splošnih ukrepov."
 
@@ -5177,7 +5185,7 @@ msgid "label_select_oira_tool"
 msgstr "Izberi orodje OiRA"
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr "Izberite ukrep(e)"
 
@@ -5650,8 +5658,8 @@ msgid "menu_import"
 msgstr "Uvozi orodje OiRA"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr "Usposabljanje"
 
@@ -5701,13 +5709,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Ne morete izbrisati samo različice orodja OiRA."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr "Prosimo, izpolnite polje."
 
@@ -5959,7 +5972,7 @@ msgstr "Nastavitve"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Status"
 
@@ -6109,14 +6122,14 @@ msgstr ""
 "izobraževalna shema OiRA in služba za pomoč uporabnikom OiRA."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 "Ta komentar bo viden v poročilu. Uporabite ga lahko za karkoli v zvezi z "
 "oceno tveganja."
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 "Te opombe bodo vidne v poročilu in usposabljanju. Tukaj lahko napišete "
@@ -6145,45 +6158,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Visoka"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Nizka"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Srednja"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Velika"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Srednja"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Majhna"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr "${completion_percentage}% Dokončano"
 
@@ -6251,7 +6264,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -6263,7 +6276,7 @@ msgstr ""
 "uporabljati. Registrirajte se v enem koraku in pridobite naslednje koristi:"
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6331,25 +6344,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "To je tveganje s prioriteto ${priority_value}."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "visoka"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "nizka"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "srednja"
@@ -6365,7 +6378,7 @@ msgid "risk_show_na_na"
 msgstr "ni smiselno"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Ukrep ${number}"
 
@@ -6428,46 +6441,46 @@ msgstr ""
 "zaprete svoj brskalnik. Zaradi varnosti je bolje, da se odjavite aktivno."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr "Ni zelo resna"
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr "Ne more delati manj kot 3 dni"
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr "Resna"
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr "Dlje kot 3 dni ne more delati"
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr "Zelo resna"
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr "Nepopravljive poškodbe, neozdravljiva bolezen, smrt"
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr "Nizka"
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr "Ne rabi prenehati z delom"
 
@@ -6566,12 +6579,12 @@ msgid "title_about"
 msgstr "Vizitka"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Izbriši račun"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Euphorie 13.0.0dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-04 09:34+0000\n"
+"POT-Creation-Date: 2024-04-26 21:41+0000\n"
 "PO-Revision-Date: 2013-06-27 22:15+0200\n"
 "Last-Translator: Robert <vansen@hotmail.com>\n"
 "Language-Team: sv <LL@li.org>\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Added a copy of \"${title}\" to your OiRA tool."
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:955
+#: euphorie/client/browser/templates/webhelpers.pt:976
 msgid "Additional Measure"
 msgstr ""
 
@@ -166,16 +166,20 @@ msgstr ""
 msgid "Almost done&hellip;"
 msgstr ""
 
-#: euphorie/client/browser/login.py:221
+#: euphorie/client/browser/login.py:224
 msgid "An account was created for you with email address ${email}"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:354
+#: euphorie/client/browser/settings.py:360
 msgid "An error occured while sending the confirmation email."
 msgstr "Ett fel har inträffat när lösenordspåminnelsen skulle skickas ut"
 
 #: euphorie/client/browser/reset_password.py:113
 msgid "An error occured while sending the password reset instructions"
+msgstr ""
+
+#: euphorie/client/browser/templates/risk_actionplan.pt:65
+msgid "Answer:"
 msgstr ""
 
 #: euphorie/client/browser/templates/more_menu.pt:44
@@ -198,7 +202,7 @@ msgstr ""
 msgid "Are you sure you want to continue? This action can not be reverted."
 msgstr ""
 
-#: euphorie/client/browser/risk.py:58
+#: euphorie/client/browser/risk.py:59
 msgid ""
 "Are you sure you want to delete this measure? This action can not be "
 "reverted."
@@ -292,7 +296,7 @@ msgstr ""
 msgid "Compact report (Word document)"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:379
+#: euphorie/client/browser/settings.py:385
 msgid "Confirm OiRA email address change"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgid ""
 "off."
 msgstr ""
 
-#: euphorie/client/browser/webhelpers.py:947
+#: euphorie/client/browser/webhelpers.py:959
 msgid "I wish to share the following with you"
 msgstr ""
 
@@ -574,11 +578,11 @@ msgstr "Information"
 msgid "Insert"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:1076
+#: euphorie/client/browser/risk.py:1137
 msgid "Invalid file format for image. Please use PNG, JPEG or GIF."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:270
+#: euphorie/client/browser/settings.py:276
 msgid "Invalid password"
 msgstr "Lösenord"
 
@@ -647,7 +651,7 @@ msgstr ""
 msgid "Maximum similarity between titles"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:952
+#: euphorie/client/browser/templates/webhelpers.pt:973
 #: euphorie/content/profiles/default/types/euphorie.solution.xml
 msgid "Measure"
 msgstr ""
@@ -893,7 +897,7 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risks_overview.pt:325
 #: euphorie/client/browser/templates/status_info.pt:262
-#: euphorie/client/browser/templates/webhelpers.pt:155
+#: euphorie/client/browser/webhelpers.py:113
 msgid "Postponed"
 msgstr "${count} frågorna har skjutits upp"
 
@@ -1028,14 +1032,14 @@ msgstr ""
 msgid "Risk assessments made with this tool"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:158
+#: euphorie/client/browser/webhelpers.py:114
 msgid "Risk not present"
 msgstr ""
 "Denna risk är inte närvarande inom din organisation, men eftersom "
 "branschorganisationen anser att detta är en av de fem mest kritiska riskerna "
 "måste den ingå i denna rapport."
 
-#: euphorie/client/browser/templates/webhelpers.pt:161
+#: euphorie/client/browser/webhelpers.py:115
 msgid "Risk present"
 msgstr "Du svarade nekande till ovanstående redovisning."
 
@@ -1048,13 +1052,13 @@ msgid "Run slideshow"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:206
-#: euphorie/client/browser/settings.py:212
+#: euphorie/client/browser/settings.py:218
 #: euphorie/client/browser/templates/panel-add-organisation.pt:62
 msgid "Save"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:230
-#: euphorie/client/browser/settings.py:247
+#: euphorie/client/browser/settings.py:253
 #: euphorie/client/browser/templates/account-settings.pt:45
 msgid "Save changes"
 msgstr "Spara ändringar"
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: euphorie/client/browser/templates/webhelpers.pt:762
+#: euphorie/client/browser/templates/webhelpers.pt:783
 msgid "Standard measures"
 msgstr ""
 
@@ -1140,7 +1144,7 @@ msgstr ""
 msgid "Start the questions"
 msgstr ""
 
-#: euphorie/client/browser/login.py:405
+#: euphorie/client/browser/login.py:408
 #: euphorie/client/browser/templates/new-session-test.pt:119
 msgid "Starting a test session is not available in this OiRA application."
 msgstr ""
@@ -1178,7 +1182,7 @@ msgid ""
 "The basic architecture of an Online interactive Risk Assessment consists of:"
 msgstr ""
 
-#: euphorie/client/browser/risk.py:68
+#: euphorie/client/browser/risk.py:69
 msgid ""
 "The current text in the fields 'Action plan', 'Prevention plan' and "
 "'Requirements' of this measure will be overwritten. This action cannot be "
@@ -1223,7 +1227,7 @@ msgstr ""
 msgid "There is not enough information to proceed to the identification phase"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:258
+#: euphorie/client/browser/settings.py:264
 msgid "There were no changes to be saved."
 msgstr ""
 
@@ -1239,7 +1243,7 @@ msgstr ""
 msgid "This certificate is presented to"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:434
+#: euphorie/client/browser/settings.py:440
 msgid "This email address is not available."
 msgstr ""
 
@@ -1274,7 +1278,7 @@ msgstr ""
 msgid "This question must ask the user if this profile applies to them."
 msgstr ""
 
-#: euphorie/client/browser/settings.py:465
+#: euphorie/client/browser/settings.py:471
 msgid "This request could not be processed."
 msgstr ""
 
@@ -1315,7 +1319,7 @@ msgstr ""
 msgid "Unlink"
 msgstr ""
 
-#: euphorie/client/browser/templates/webhelpers.pt:152
+#: euphorie/client/browser/webhelpers.py:112
 msgid "Unvisited"
 msgstr ""
 
@@ -1329,6 +1333,10 @@ msgstr ""
 
 #: euphorie/client/browser/templates/risk_identification_custom.pt:277
 msgid "Upload image"
+msgstr ""
+
+#: euphorie/content/browser/templates/risk_view.pt:122
+msgid "Use scaled answers instead of Yes/No"
 msgstr ""
 
 #: euphorie/client/browser/templates/report_landing.pt:184
@@ -1444,7 +1452,7 @@ msgstr ""
 msgid "You're done with the training slides!"
 msgstr ""
 
-#: euphorie/client/browser/settings.py:478
+#: euphorie/client/browser/settings.py:484
 msgid "Your email address has been updated."
 msgstr ""
 
@@ -1453,7 +1461,7 @@ msgid "Your password for confirmation"
 msgstr ""
 
 #: euphorie/client/browser/reset_password.py:297
-#: euphorie/client/browser/settings.py:273
+#: euphorie/client/browser/settings.py:279
 msgid "Your password was successfully changed."
 msgstr ""
 
@@ -1582,34 +1590,34 @@ msgid "about_partners_3_smb"
 msgstr "mikroföretag och små företag har vissa brister"
 
 #. Default: "Describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:362
+#: euphorie/client/browser/risk.py:363
 msgid "action_measures_false_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe the specific measures required to reduce the risk."
-#: euphorie/client/browser/risk.py:354
+#: euphorie/client/browser/risk.py:355
 msgid "action_measures_false_solutions_true"
 msgstr ""
 
 #. Default: "Describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:345
+#: euphorie/client/browser/risk.py:346
 msgid "action_measures_true_solutions_false"
 msgstr ""
 
 #. Default: "Select or describe any further measure to reduce the risk."
-#: euphorie/client/browser/risk.py:337
+#: euphorie/client/browser/risk.py:338
 msgid "action_measures_true_solutions_true"
 msgstr ""
 
 #. Default: "Although some measures do not cost any money, most do. The measures should therefore be budgeted for; include them in the annual budget round if necessary."
-#: euphorie/client/browser/templates/webhelpers.pt:902
+#: euphorie/client/browser/templates/webhelpers.pt:923
 msgid "actionplan_measure_budget_tooltip"
 msgstr ""
 "Även fast inte alla åtgärder kostar pengar, gör de flesta det. Åtgärderna "
 "bör därför budgeteras, inkludera dem i den årliga budgeten om nödvändigt."
 
 #. Default: "Appoint someone in your company to be responsible for the implementation of this measure. This person will have the authority to take the steps described in the Plan and/or the responsibility to ensure that they are carried out."
-#: euphorie/client/browser/templates/webhelpers.pt:884
+#: euphorie/client/browser/templates/webhelpers.pt:905
 msgid "actionplan_measure_responsible_tooltip"
 msgstr ""
 "Utse någon i ditt företag som ansvarar för genomförandet av denna åtgärd. "
@@ -1617,7 +1625,7 @@ msgstr ""
 "planen och/eller ansvaret för att se till att de genomförs."
 
 #. Default: "Describe: 1) what is your general approach to eliminate or (if the risk is not avoidable) reduce the risk; 2) the specific action(s) required to implement this approach (to eliminate or to reduce the risk)"
-#: euphorie/client/browser/templates/webhelpers.pt:979
+#: euphorie/client/browser/templates/webhelpers.pt:1000
 msgid "actionplan_measure_tooltip"
 msgstr ""
 "Skriv ner i planen vilken åtgärd du kommer att utföra med anledning av "
@@ -1630,7 +1638,7 @@ msgstr ""
 "eller haft relevant utbildning för att göra detta.."
 
 #. Default: "Describe the level of expertise needed to implement the measure, for instance &ldquo;common sense (no OSH knowledge required)&rdquo;, &ldquo;no specific OSH expertise, but minimum OSH knowledge or training and/or consultation of OSH guidance required&rdquo;, or &ldquo;OSH expert&rdquo;. You can also describe here any other additional requirement (if any)."
-#: euphorie/client/browser/templates/webhelpers.pt:1002
+#: euphorie/client/browser/templates/webhelpers.pt:1023
 msgid "actionplan_requirements_tooltip"
 msgstr ""
 
@@ -1702,7 +1710,7 @@ msgid "bullet_risks"
 msgstr ""
 
 #. Default: "Add"
-#: euphorie/client/browser/templates/webhelpers.pt:782
+#: euphorie/client/browser/templates/webhelpers.pt:803
 msgid "button_add"
 msgstr "Ladda upp"
 
@@ -1743,7 +1751,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: euphorie/client/browser/publish.py:287
-#: euphorie/client/browser/settings.py:275
+#: euphorie/client/browser/settings.py:281
 #: euphorie/client/browser/templates/confirmation-archive-session.pt:37
 msgid "button_cancel"
 msgstr "Avbryt"
@@ -2081,12 +2089,12 @@ msgid "deprecated_label_existing_measures"
 msgstr ""
 
 #. Default: "Please tick anything that you might like to exclude from the training. Items that are greyed out will not be displayed on the training card."
-#: euphorie/client/browser/templates/webhelpers.pt:662
+#: euphorie/client/browser/templates/webhelpers.pt:683
 msgid "description-training-configuration"
 msgstr ""
 
 #. Default: "The risk evaluation has been automatically done by the tool. You will be able to change the priority for this risk &ndash; if you consider it necessary &ndash; in the action plan."
-#: euphorie/client/browser/templates/webhelpers.pt:583
+#: euphorie/client/browser/templates/webhelpers.pt:604
 msgid "description_automatic_evaluation"
 msgstr ""
 
@@ -2269,17 +2277,17 @@ msgid "effect_high"
 msgstr "Hög (mycket hög) allvarlighetsgrad"
 
 #. Default: "Weak severity"
-#: euphorie/client/browser/templates/webhelpers.pt:416
+#: euphorie/client/browser/templates/webhelpers.pt:437
 msgid "effect_injury_no_absence"
 msgstr "Svag allvarlighetsgrad"
 
 #. Default: "Significant severity"
-#: euphorie/client/browser/templates/webhelpers.pt:422
+#: euphorie/client/browser/templates/webhelpers.pt:443
 msgid "effect_injury_with_absence"
 msgstr "Stark allvarlighetsgrad"
 
 #. Default: "High (very high) severity"
-#: euphorie/client/browser/templates/webhelpers.pt:428
+#: euphorie/client/browser/templates/webhelpers.pt:449
 msgid "effect_permanent_damage"
 msgstr "Hög (mycket hög) allvarlighetsgrad"
 
@@ -2324,7 +2332,7 @@ msgid "email_change_intro"
 msgstr "Ändra land/språk"
 
 #. Default: "Please confirm your new email address by clicking on the link in the email that will be sent in a few minutes to \"${email}\". Please note that the new email address is also your new login name."
-#: euphorie/client/browser/settings.py:440
+#: euphorie/client/browser/settings.py:446
 msgid "email_change_pending"
 msgstr ""
 
@@ -2378,7 +2386,7 @@ msgid "employee_numbers_50_to_249"
 msgstr "50-249 anställda"
 
 #. Default: "An account with this email address already exists."
-#: euphorie/client/browser/login.py:198
+#: euphorie/client/browser/login.py:201
 msgid "error_email_in_use"
 msgstr "Ett konto med denna e-postadress existerar redan."
 
@@ -2388,12 +2396,12 @@ msgid "error_existing_login"
 msgstr "Detta inloggningsnamn är redan taget."
 
 #. Default: "Please enter the budget in whole Euros."
-#: euphorie/client/browser/templates/webhelpers.pt:898
+#: euphorie/client/browser/templates/webhelpers.pt:919
 msgid "error_invalid_budget"
 msgstr "Ange budget i euro (ental)."
 
 #. Default: "Please enter a valid email address"
-#: euphorie/client/browser/login.py:161
+#: euphorie/client/browser/login.py:164
 msgid "error_invalid_email"
 msgstr "Ange en giltig e-postadress"
 
@@ -2408,63 +2416,63 @@ msgid "error_invalid_xml"
 msgstr "Ladda upp en giltig XML-fil"
 
 #. Default: "Please enter your email address"
-#: euphorie/client/browser/login.py:157
+#: euphorie/client/browser/login.py:160
 msgid "error_missing_email"
 msgstr "Ange din e-postadress"
 
 #. Default: "Please enter a password"
-#: euphorie/client/browser/login.py:165
+#: euphorie/client/browser/login.py:168
 msgid "error_missing_password"
 msgstr "Ange ett lösenord"
 
 #. Default: "Passwords do not match"
-#: euphorie/client/browser/login.py:169
+#: euphorie/client/browser/login.py:172
 #: euphorie/client/browser/reset_password.py:256
 msgid "error_password_mismatch"
 msgstr "Lösenorden stämmer inte överens"
 
 #. Default: "The password needs to be at least 12 characters long and needs to contain at least one lower case letter, one upper case letter and one digit."
-#: euphorie/client/browser/login.py:142
+#: euphorie/client/browser/login.py:145
 msgid "error_password_policy_violation"
 msgstr ""
 
 #. Default: "An accout can only be created for you if you accept the terms and conditions."
-#: euphorie/client/browser/login.py:177
+#: euphorie/client/browser/login.py:180
 msgid "error_terms_not_accepted"
 msgstr ""
 
 #. Default: "This date must be on or after the start date."
-#: euphorie/client/browser/risk.py:79
+#: euphorie/client/browser/risk.py:80
 msgid "error_validation_after_start_date"
 msgstr ""
 
 #. Default: "This date must be on or before the end date."
-#: euphorie/client/browser/risk.py:99
+#: euphorie/client/browser/risk.py:100
 msgid "error_validation_before_end_date"
 msgstr ""
 
 #. Default: "This value must be a valid date"
-#: euphorie/client/browser/webhelpers.py:1233
+#: euphorie/client/browser/webhelpers.py:1245
 msgid "error_validation_date"
 msgstr ""
 
 #. Default: "This value must be a valid date and time"
-#: euphorie/client/browser/webhelpers.py:1237
+#: euphorie/client/browser/webhelpers.py:1249
 msgid "error_validation_datetime"
 msgstr ""
 
 #. Default: "This value must be a valid email address"
-#: euphorie/client/browser/webhelpers.py:1244
+#: euphorie/client/browser/webhelpers.py:1256
 msgid "error_validation_email"
 msgstr ""
 
 #. Default: "This value must be a number"
-#: euphorie/client/browser/webhelpers.py:1251
+#: euphorie/client/browser/webhelpers.py:1263
 msgid "error_validation_number"
 msgstr ""
 
 #. Default: "This value must be a positive whole number."
-#: euphorie/client/browser/risk.py:89
+#: euphorie/client/browser/risk.py:90
 msgid "error_validation_positive_whole_number"
 msgstr ""
 
@@ -2571,7 +2579,7 @@ msgstr ""
 "utförda ändringar måste undersökningen slås ihop med din session."
 
 #. Default: "This risk was automatically set as being present. You cannot change this."
-#: euphorie/client/browser/templates/webhelpers.pt:288
+#: euphorie/client/browser/templates/webhelpers.pt:279
 msgid "explanation_risk_always_present"
 msgstr ""
 
@@ -2599,7 +2607,7 @@ msgstr "Identifiering ${title}.doc"
 msgid "filename_report_timeline"
 msgstr "Handlingsplan ${title}.doc"
 
-#. Default: "Compact ${title}"
+#. Default: "Compact report ${title}"
 #: euphorie/client/docx/views.py:317
 msgid "filename_short_report_actionplan"
 msgstr ""
@@ -2620,7 +2628,7 @@ msgid "french"
 msgstr ""
 
 #. Default: "Almost never"
-#: euphorie/client/browser/templates/webhelpers.pt:386
+#: euphorie/client/browser/templates/webhelpers.pt:407
 msgid "frequency_almost_never"
 msgstr "Nästan aldrig"
 
@@ -2630,57 +2638,57 @@ msgid "frequency_almostnever"
 msgstr "Nästan aldrig"
 
 #. Default: "Constantly"
-#: euphorie/client/browser/templates/webhelpers.pt:398
+#: euphorie/client/browser/templates/webhelpers.pt:419
 #: euphorie/content/risk.py:518
 msgid "frequency_constantly"
 msgstr "Konstant"
 
 #. Default: "Not very often"
-#: euphorie/client/browser/templates/webhelpers.pt:519
+#: euphorie/client/browser/templates/webhelpers.pt:540
 #: euphorie/content/risk.py:453
 msgid "frequency_french_not_often"
 msgstr ""
 
 #. Default: "Once per month"
-#: euphorie/client/browser/templates/webhelpers.pt:520
+#: euphorie/client/browser/templates/webhelpers.pt:541
 msgid "frequency_french_not_often_help"
 msgstr ""
 
 #. Default: "Often"
-#: euphorie/client/browser/templates/webhelpers.pt:531
+#: euphorie/client/browser/templates/webhelpers.pt:552
 #: euphorie/content/risk.py:456
 msgid "frequency_french_often"
 msgstr ""
 
 #. Default: "Once per week"
-#: euphorie/client/browser/templates/webhelpers.pt:532
+#: euphorie/client/browser/templates/webhelpers.pt:553
 msgid "frequency_french_often_help"
 msgstr "Konstant"
 
 #. Default: "Rare"
-#: euphorie/client/browser/templates/webhelpers.pt:507
+#: euphorie/client/browser/templates/webhelpers.pt:528
 #: euphorie/content/risk.py:449
 msgid "frequency_french_rare"
 msgstr ""
 
 #. Default: "Once per year"
-#: euphorie/client/browser/templates/webhelpers.pt:508
+#: euphorie/client/browser/templates/webhelpers.pt:529
 msgid "frequency_french_rare_help"
 msgstr "Regelbunden"
 
 #. Default: "Very often or regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:543
+#: euphorie/client/browser/templates/webhelpers.pt:564
 #: euphorie/content/risk.py:461
 msgid "frequency_french_regularly"
 msgstr ""
 
 #. Default: "Minimum once per day"
-#: euphorie/client/browser/templates/webhelpers.pt:544
+#: euphorie/client/browser/templates/webhelpers.pt:565
 msgid "frequency_french_regularly_help"
 msgstr "Regelbunden"
 
 #. Default: "Regularly"
-#: euphorie/client/browser/templates/webhelpers.pt:392
+#: euphorie/client/browser/templates/webhelpers.pt:413
 #: euphorie/content/risk.py:513
 msgid "frequency_regularly"
 msgstr "Regelbunden"
@@ -2701,12 +2709,12 @@ msgid "header_additional_content"
 msgstr ""
 
 #. Default: "Additional resources to assess the risk"
-#: euphorie/client/browser/templates/webhelpers.pt:606
+#: euphorie/client/browser/templates/webhelpers.pt:627
 msgid "header_additional_resources"
 msgstr ""
 
 #. Default: "Additional resources for this module"
-#: euphorie/client/browser/templates/webhelpers.pt:609
+#: euphorie/client/browser/templates/webhelpers.pt:630
 msgid "header_additional_resources_module"
 msgstr ""
 
@@ -2948,23 +2956,23 @@ msgid "header_risk_aware"
 msgstr "Är du medveten om alla risker?"
 
 #. Default: "What is the severity of the damage?"
-#: euphorie/client/browser/templates/webhelpers.pt:406
+#: euphorie/client/browser/templates/webhelpers.pt:427
 msgid "header_risk_effect"
 msgstr "Vad för slags allvarighetsgrad har skadan?"
 
 #. Default: "How often are people exposed to this risk?"
-#: euphorie/client/browser/templates/webhelpers.pt:376
+#: euphorie/client/browser/templates/webhelpers.pt:397
 msgid "header_risk_frequency"
 msgstr "Hur ofta är personer utsatta för denna risk?"
 
 #. Default: "Select the priority of this risk"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:207
-#: euphorie/client/browser/templates/webhelpers.pt:560
+#: euphorie/client/browser/templates/webhelpers.pt:581
 msgid "header_risk_priority"
 msgstr "Välj prioritet för denna risk"
 
 #. Default: "What is the chance of this risk occurring?"
-#: euphorie/client/browser/templates/webhelpers.pt:346
+#: euphorie/client/browser/templates/webhelpers.pt:367
 msgid "header_risk_probability"
 msgstr "Vad är chansen att denna risk uppstår?"
 
@@ -3028,7 +3036,7 @@ msgid "header_settings"
 msgstr "Inställningar"
 
 #. Default: "Standard measures"
-#: euphorie/content/browser/templates/risk_view.pt:132
+#: euphorie/content/browser/templates/risk_view.pt:138
 msgid "header_solutions"
 msgstr "Standardlösningar"
 
@@ -3273,7 +3281,7 @@ msgstr ""
 "lösenordspåminnelse och registrering av sidor."
 
 #. Default: "Please answer the following questions. As a result of your answers the system will calculate the priority of the risk. You will be able to modify the priority later."
-#: euphorie/client/browser/templates/webhelpers.pt:334
+#: euphorie/client/browser/templates/webhelpers.pt:355
 msgid "help_calculated_evaluation"
 msgstr ""
 
@@ -3302,7 +3310,7 @@ msgstr ""
 "starta med en kopia av en befintlig undersökning."
 
 #. Default: "Indicate how often this risk occurs in a normal situation."
-#: euphorie/client/browser/risk.py:837 euphorie/content/risk.py:442
+#: euphorie/client/browser/risk.py:891 euphorie/content/risk.py:442
 msgid "help_default_frequency"
 msgstr "Ange hur ofta denna risk inträffar i en normal situation."
 
@@ -3314,12 +3322,12 @@ msgstr ""
 "fortfarande ändra prioritet."
 
 #. Default: "Indicate how likely occurence of this risk is in a normal situation."
-#: euphorie/client/browser/risk.py:832 euphorie/content/risk.py:477
+#: euphorie/client/browser/risk.py:886 euphorie/content/risk.py:477
 msgid "help_default_probability"
 msgstr "Ange hur trolig förekomsten av denna risk är i en normal situation."
 
 #. Default: "Indicate the severity if this risk occurs."
-#: euphorie/client/browser/risk.py:841 euphorie/content/risk.py:413
+#: euphorie/client/browser/risk.py:895 euphorie/content/risk.py:413
 msgid "help_default_severity"
 msgstr "Ange allvarighetsgraden av att hantera denna risk om den inträffar."
 
@@ -3894,13 +3902,13 @@ msgstr "Kontot är låst"
 
 #. Default: "Action Plan"
 #: euphorie/client/browser/templates/login.pt:327
-#: euphorie/client/browser/webhelpers.py:1356
+#: euphorie/client/browser/webhelpers.py:1368
 msgid "label_action_plan"
 msgstr "Handlingsplan"
 
 #. Default: "Budget"
 #: euphorie/client/browser/report.py:146
-#: euphorie/client/browser/templates/webhelpers.pt:897
+#: euphorie/client/browser/templates/webhelpers.pt:918
 #: euphorie/client/docx/compiler.py:452
 msgid "label_action_plan_budget"
 msgstr "Budget (i euro)"
@@ -3912,21 +3920,21 @@ msgstr ""
 
 #. Default: "Planning end"
 #: euphorie/client/browser/report.py:123
-#: euphorie/client/browser/templates/webhelpers.pt:934
+#: euphorie/client/browser/templates/webhelpers.pt:955
 #: euphorie/client/docx/compiler.py:454
 msgid "label_action_plan_end"
 msgstr "Planerat slut"
 
 #. Default: "Who is responsible?"
 #: euphorie/client/browser/report.py:144
-#: euphorie/client/browser/templates/webhelpers.pt:883
+#: euphorie/client/browser/templates/webhelpers.pt:904
 #: euphorie/client/docx/compiler.py:450
 msgid "label_action_plan_responsible"
 msgstr "Vem är ansvarig?"
 
 #. Default: "Planning start"
 #: euphorie/client/browser/report.py:118
-#: euphorie/client/browser/templates/webhelpers.pt:918
+#: euphorie/client/browser/templates/webhelpers.pt:939
 #: euphorie/client/docx/compiler.py:453
 msgid "label_action_plan_start"
 msgstr "Planerad start"
@@ -3949,7 +3957,7 @@ msgid "label_alphabetical"
 msgstr ""
 
 #. Default: "Assessment"
-#: euphorie/client/browser/webhelpers.py:1323
+#: euphorie/client/browser/webhelpers.py:1335
 msgid "label_assessment"
 msgstr ""
 
@@ -4041,7 +4049,7 @@ msgstr ""
 #. Default: "Consultancy"
 #: euphorie/client/browser/templates/consultancy.pt:31
 #: euphorie/client/browser/templates/consultants.pt:26
-#: euphorie/client/browser/webhelpers.py:1375
+#: euphorie/client/browser/webhelpers.py:1387
 msgid "label_consultancy"
 msgstr ""
 
@@ -4127,7 +4135,7 @@ msgid "label_delete_risk"
 msgstr ""
 
 #. Default: "Description"
-#: euphorie/client/browser/templates/webhelpers.pt:810
+#: euphorie/client/browser/templates/webhelpers.pt:831
 #: euphorie/content/risk.py:90
 msgid "label_description"
 msgstr "Beskrivning"
@@ -4173,7 +4181,7 @@ msgstr ""
 
 #. Default: "Evaluation"
 #: euphorie/client/browser/templates/login.pt:325
-#: euphorie/client/browser/webhelpers.py:1326
+#: euphorie/client/browser/webhelpers.py:1338
 msgid "label_evaluation"
 msgstr "Utvärdering"
 
@@ -4199,7 +4207,7 @@ msgid "label_existing_measure"
 msgstr ""
 
 #. Default: "Already implemented measures"
-#: euphorie/client/browser/templates/webhelpers.pt:677
+#: euphorie/client/browser/templates/webhelpers.pt:698
 #: euphorie/client/browser/training.py:287
 msgid "label_existing_measures"
 msgstr ""
@@ -4210,7 +4218,7 @@ msgid "label_exit"
 msgstr ""
 
 #. Default: "Expertise"
-#: euphorie/client/browser/templates/webhelpers.pt:869
+#: euphorie/client/browser/templates/webhelpers.pt:890
 msgid "label_expertise"
 msgstr ""
 
@@ -4225,7 +4233,7 @@ msgid "label_export_etranslate_compatible"
 msgstr ""
 
 #. Default: "Add an extra measure"
-#: euphorie/client/browser/templates/webhelpers.pt:1101
+#: euphorie/client/browser/templates/webhelpers.pt:1122
 msgid "label_extra_add_measure"
 msgstr ""
 
@@ -4330,7 +4338,7 @@ msgstr ""
 
 #. Default: "Identification"
 #: euphorie/client/browser/templates/login.pt:323
-#: euphorie/client/browser/webhelpers.py:1325
+#: euphorie/client/browser/webhelpers.py:1337
 msgid "label_identification"
 msgstr "Identifiering"
 
@@ -4340,7 +4348,7 @@ msgid "label_image"
 msgstr "Bildfil"
 
 #. Default: "Implemented measure"
-#: euphorie/client/browser/templates/webhelpers.pt:807
+#: euphorie/client/browser/templates/webhelpers.pt:828
 msgid "label_implemented_measure"
 msgstr ""
 
@@ -4367,7 +4375,7 @@ msgid "label_invalidate_risk_assessment"
 msgstr ""
 
 #. Default: "Involve"
-#: euphorie/client/browser/webhelpers.py:1312
+#: euphorie/client/browser/webhelpers.py:1324
 msgid "label_involve"
 msgstr ""
 
@@ -4415,8 +4423,8 @@ msgstr ""
 
 #. Default: "Legal and policy references"
 #: euphorie/client/browser/templates/panel-contents-preview.pt:77
-#: euphorie/client/browser/templates/webhelpers.pt:594
-#: euphorie/content/browser/templates/risk_view.pt:127
+#: euphorie/client/browser/templates/webhelpers.pt:615
+#: euphorie/content/browser/templates/risk_view.pt:133
 msgid "label_legal_reference"
 msgstr "Rättsliga och politiska referenser"
 
@@ -4479,7 +4487,7 @@ msgstr ""
 
 #. Default: "General approach (to eliminate or reduce the risk)"
 #: euphorie/client/browser/report.py:128
-#: euphorie/client/browser/templates/webhelpers.pt:985
+#: euphorie/client/browser/templates/webhelpers.pt:1006
 #: euphorie/client/docx/compiler.py:435
 msgid "label_measure_action_plan"
 msgstr "Handlingsplan"
@@ -4492,7 +4500,7 @@ msgstr "Förebyggande plan"
 
 #. Default: "Level of expertise and/or requirements needed"
 #: euphorie/client/browser/report.py:136
-#: euphorie/client/browser/templates/webhelpers.pt:1006
+#: euphorie/client/browser/templates/webhelpers.pt:1027
 #: euphorie/client/docx/compiler.py:444
 msgid "label_measure_requirements"
 msgstr "Krav"
@@ -4625,12 +4633,12 @@ msgstr ""
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245
 #: euphorie/client/browser/templates/training.pt:330
-#: euphorie/client/browser/templates/webhelpers.pt:723
+#: euphorie/client/browser/templates/webhelpers.pt:744
 msgid "label_notes"
 msgstr ""
 
 #. Default: "Notifications"
-#: euphorie/client/browser/templates/preferences.pt:72
+#: euphorie/client/browser/templates/preferences.pt:75
 msgid "label_notifications"
 msgstr ""
 
@@ -4686,14 +4694,14 @@ msgid "label_password_confirm"
 msgstr "Bekräfta lösenord"
 
 #. Default: "Planned measures"
-#: euphorie/client/browser/templates/webhelpers.pt:696
+#: euphorie/client/browser/templates/webhelpers.pt:717
 #: euphorie/client/browser/training.py:290
 msgid "label_planned_measures"
 msgstr ""
 
 #. Default: "Preparation"
 #: euphorie/client/browser/templates/login.pt:321
-#: euphorie/client/browser/webhelpers.py:1294
+#: euphorie/client/browser/webhelpers.py:1306
 msgid "label_preparation"
 msgstr "Förberedelse"
 
@@ -4785,13 +4793,13 @@ msgid "label_remove_filters"
 msgstr ""
 
 #. Default: "Delete this measure"
-#: euphorie/client/browser/templates/webhelpers.pt:828
+#: euphorie/client/browser/templates/webhelpers.pt:849
 msgid "label_remove_measure"
 msgstr ""
 
 #. Default: "Report"
 #: euphorie/client/browser/templates/report_landing.pt:29
-#: euphorie/client/browser/webhelpers.py:1391
+#: euphorie/client/browser/webhelpers.py:1403
 msgid "label_report"
 msgstr "Rapport"
 
@@ -4933,7 +4941,7 @@ msgid "label_select_assessment"
 msgstr "Välj en riskbedömning"
 
 #. Default: "Select one or more of the known common measures provided."
-#: euphorie/client/browser/templates/webhelpers.pt:768
+#: euphorie/client/browser/templates/webhelpers.pt:789
 msgid "label_select_measure"
 msgstr ""
 
@@ -4952,7 +4960,7 @@ msgid "label_select_oira_tool"
 msgstr ""
 
 #. Default: "Select standard measures"
-#: euphorie/client/browser/templates/webhelpers.pt:1093
+#: euphorie/client/browser/templates/webhelpers.pt:1114
 msgid "label_select_standard_measures"
 msgstr ""
 
@@ -5416,8 +5424,8 @@ msgid "menu_import"
 msgstr "Importera undersökning"
 
 #. Default: "Training"
-#: euphorie/client/browser/templates/webhelpers.pt:647
-#: euphorie/client/browser/webhelpers.py:1407
+#: euphorie/client/browser/templates/webhelpers.pt:668
+#: euphorie/client/browser/webhelpers.py:1419
 msgid "menu_training"
 msgstr ""
 
@@ -5466,13 +5474,18 @@ msgstr ""
 msgid "message_delete_no_last_survey"
 msgstr "Du kan inte radera den enda undersökningens version."
 
+#. Default: "Due to an internal policy, these settings cannot be changed."
+#: euphorie/client/browser/templates/preferences.pt:80
+msgid "message_disallow_notification_settings"
+msgstr ""
+
 #. Default: "You can ${link_download_tool_contents}."
 #: euphorie/content/browser/templates/survey_view.pt:62
 msgid "message_download_tool_contents"
 msgstr ""
 
 #. Default: "Please fill out this field."
-#: euphorie/client/browser/webhelpers.py:1255
+#: euphorie/client/browser/webhelpers.py:1267
 msgid "message_field_required"
 msgstr ""
 
@@ -5704,7 +5717,7 @@ msgstr "Status"
 #. Default: "Status"
 #: euphorie/client/browser/templates/more_menu.pt:62
 #: euphorie/client/browser/templates/webhelpers.pt:62
-#: euphorie/client/browser/webhelpers.py:1422
+#: euphorie/client/browser/webhelpers.py:1434
 msgid "navigation_status"
 msgstr "Status"
 
@@ -5850,12 +5863,12 @@ msgstr ""
 "helpdesk finns på plats."
 
 #. Default: "These notes will be visible in the report. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:384
+#: euphorie/client/browser/risk.py:385
 msgid "placeholder_comment_field"
 msgstr ""
 
 #. Default: "These notes will be visible in the report and the training. Use it for anything else you might want to write about this risk."
-#: euphorie/client/browser/risk.py:378
+#: euphorie/client/browser/risk.py:379
 msgid "placeholder_comment_field_training"
 msgstr ""
 
@@ -5882,45 +5895,45 @@ msgstr ""
 
 #. Default: "High"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:225
-#: euphorie/client/browser/templates/webhelpers.pt:578
+#: euphorie/client/browser/templates/webhelpers.pt:599
 #: euphorie/content/risk.py:210
 msgid "priority_high"
 msgstr "Hög"
 
 #. Default: "Low"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:213
-#: euphorie/client/browser/templates/webhelpers.pt:566
+#: euphorie/client/browser/templates/webhelpers.pt:587
 #: euphorie/content/risk.py:208
 msgid "priority_low"
 msgstr "Låg"
 
 #. Default: "Medium"
 #: euphorie/client/browser/templates/risk_identification_custom.pt:219
-#: euphorie/client/browser/templates/webhelpers.pt:572
+#: euphorie/client/browser/templates/webhelpers.pt:593
 #: euphorie/content/risk.py:209
 msgid "priority_medium"
 msgstr "Medium"
 
 #. Default: "Large"
-#: euphorie/client/browser/templates/webhelpers.pt:368
+#: euphorie/client/browser/templates/webhelpers.pt:389
 #: euphorie/content/risk.py:489
 msgid "probability_large"
 msgstr "Stor"
 
 #. Default: "Medium"
-#: euphorie/client/browser/templates/webhelpers.pt:362
+#: euphorie/client/browser/templates/webhelpers.pt:383
 #: euphorie/content/risk.py:487
 msgid "probability_medium"
 msgstr "Medium"
 
 #. Default: "Small"
-#: euphorie/client/browser/templates/webhelpers.pt:356
+#: euphorie/client/browser/templates/webhelpers.pt:377
 #: euphorie/content/risk.py:485
 msgid "probability_small"
 msgstr "Liten"
 
 #. Default: "${completion_percentage}% Complete"
-#: euphorie/client/browser/webhelpers.py:331
+#: euphorie/client/browser/webhelpers.py:338
 msgid "progress_indicator_title"
 msgstr ""
 
@@ -5985,7 +5998,7 @@ msgid "report_end_date"
 msgstr ""
 
 #. Default: "by ${date}"
-#: euphorie/client/docx/compiler.py:1107
+#: euphorie/client/docx/compiler.py:1106
 msgid "report_end_date_short"
 msgstr ""
 
@@ -5995,7 +6008,7 @@ msgid "report_guest_register_intro"
 msgstr ""
 
 #. Default: "Comments:"
-#: euphorie/client/docx/compiler.py:1078
+#: euphorie/client/docx/compiler.py:1077
 msgid "report_heading_comments"
 msgstr ""
 
@@ -6062,25 +6075,25 @@ msgid "risk_present"
 msgstr ""
 
 #. Default: "This is a ${priority_value} priority risk."
-#: euphorie/client/browser/templates/risk_actionplan.pt:80
+#: euphorie/client/browser/templates/risk_actionplan.pt:88
 #: euphorie/client/docx/compiler.py:323
 msgid "risk_priority"
 msgstr "Detta är en ${priority} ."
 
 #. Default: "high"
-#: euphorie/client/browser/templates/risk_actionplan.pt:92
+#: euphorie/client/browser/templates/risk_actionplan.pt:100
 #: euphorie/client/docx/compiler.py:321
 msgid "risk_priority_high"
 msgstr "högt prioriterad risk"
 
 #. Default: "low"
-#: euphorie/client/browser/templates/risk_actionplan.pt:84
+#: euphorie/client/browser/templates/risk_actionplan.pt:92
 #: euphorie/client/docx/compiler.py:317
 msgid "risk_priority_low"
 msgstr "lågt prioriterad risk"
 
 #. Default: "medium"
-#: euphorie/client/browser/templates/risk_actionplan.pt:88
+#: euphorie/client/browser/templates/risk_actionplan.pt:96
 #: euphorie/client/docx/compiler.py:319
 msgid "risk_priority_medium"
 msgstr "medium prioriterad risk"
@@ -6096,7 +6109,7 @@ msgid "risk_show_na_na"
 msgstr "ej tillämplig"
 
 #. Default: "Measure ${number}"
-#: euphorie/content/browser/templates/risk_view.pt:143
+#: euphorie/content/browser/templates/risk_view.pt:149
 msgid "risk_solution_header"
 msgstr "Lösning ${number}"
 
@@ -6161,46 +6174,46 @@ msgstr ""
 "fått olika titlar."
 
 #. Default: "Not very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:460
+#: euphorie/client/browser/templates/webhelpers.pt:481
 #: euphorie/content/risk.py:424
 msgid "severity_not_severe"
 msgstr ""
 
 #. Default: "Need to stop working for less than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:461
+#: euphorie/client/browser/templates/webhelpers.pt:482
 msgid "severity_not_severe_help"
 msgstr ""
 
 #. Default: "Severe"
-#: euphorie/client/browser/templates/webhelpers.pt:471
+#: euphorie/client/browser/templates/webhelpers.pt:492
 #: euphorie/content/risk.py:426
 msgid "severity_severe"
 msgstr ""
 
 #. Default: "Need to stop working for more than 3 days"
-#: euphorie/client/browser/templates/webhelpers.pt:472
+#: euphorie/client/browser/templates/webhelpers.pt:493
 msgid "severity_severe_help"
 msgstr ""
 
 #. Default: "Very severe"
-#: euphorie/client/browser/templates/webhelpers.pt:483
+#: euphorie/client/browser/templates/webhelpers.pt:504
 #: euphorie/content/risk.py:430
 msgid "severity_very_severe"
 msgstr ""
 
 #. Default: "Irreversible injury, incurable illness, death"
-#: euphorie/client/browser/templates/webhelpers.pt:484
+#: euphorie/client/browser/templates/webhelpers.pt:505
 msgid "severity_very_severe_help"
 msgstr ""
 
 #. Default: "Weak"
-#: euphorie/client/browser/templates/webhelpers.pt:449
+#: euphorie/client/browser/templates/webhelpers.pt:470
 #: euphorie/content/risk.py:420
 msgid "severity_weak"
 msgstr ""
 
 #. Default: "No need to stop working"
-#: euphorie/client/browser/templates/webhelpers.pt:450
+#: euphorie/client/browser/templates/webhelpers.pt:471
 msgid "severity_weak_help"
 msgstr ""
 
@@ -6292,12 +6305,12 @@ msgid "title_about"
 msgstr "Om"
 
 #. Default: "Delete account"
-#: euphorie/client/browser/settings.py:288
+#: euphorie/client/browser/settings.py:294
 msgid "title_account_delete"
 msgstr "Dokumentation"
 
 #. Default: "Change email address"
-#: euphorie/client/browser/settings.py:324
+#: euphorie/client/browser/settings.py:330
 msgid "title_change_email"
 msgstr ""
 

--- a/src/euphorie/deployment/profiles/default/registry.xml
+++ b/src/euphorie/deployment/profiles/default/registry.xml
@@ -263,6 +263,15 @@
     </field>
     <value>False</value>
   </record>
+  <record name="euphorie.notifications__allow_user_settings">
+    <field type="plone.registry.field.Bool">
+      <title>Allow user to set own notification settings</title>
+      <default>True</default>
+      <missing_value>True</missing_value>
+      <required>False</required>
+    </field>
+    <value>True</value>
+  </record>
   <record name="euphorie.notification__email_from_address">
     <field type="plone.registry.field.ASCIILine">
       <description>Sender email address for OiRA notification and reminder mails.</description>

--- a/src/euphorie/upgrade/deployment/v1/20240426095318_notifications_allow_user_settings/registry.xml
+++ b/src/euphorie/upgrade/deployment/v1/20240426095318_notifications_allow_user_settings/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <record name="euphorie.notifications__allow_user_settings">
+    <field type="plone.registry.field.Bool">
+      <title>Allow user to set own notification settings</title>
+      <default>True</default>
+      <missing_value>True</missing_value>
+      <required>False</required>
+    </field>
+    <value>True</value>
+  </record>
+</registry>

--- a/src/euphorie/upgrade/deployment/v1/20240426095318_notifications_allow_user_settings/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20240426095318_notifications_allow_user_settings/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class NotificationsAllowUserSettings(UpgradeStep):
+    """Notifications allow user settings."""
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Ref: scrum-2193

Define a registry record to dissallow users to set their notification settings in the user profile, while still showing what is configured. Also show a info explaining why this cannot be changed.

![image](https://github.com/euphorie/Euphorie/assets/170891/e12b60ef-a663-4b3c-b97a-3a4dfdfb963e)


For the speficic site, this setting can simple be set via the registry.