### PR TITLE
Show organisation logo on training certificate

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,9 @@ Changelog
 - Add certificates overview
   Ref: scrum-2142
 
+- Show organisation logo on training certificate
+  Ref: scrum-2142
+
 
 
 16.1.2 (2024-03-20)

--- a/src/euphorie/client/browser/templates/training_certificate_inner.pt
+++ b/src/euphorie/client/browser/templates/training_certificate_inner.pt
@@ -35,6 +35,13 @@
           i18n:name="date"
     >${python:toLocalizedTime(certificate.time)}</time>.
   </p>
+  <p class="certificate-organisation"
+     tal:condition="view/organisation_logo"
+  >
+    <img class="certificate-organisation-logo"
+         src="${view/organisation_logo}"
+    />
+  </p>
   <table class="certificate-colofon">
     <tbody>
       <tr>

--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -728,6 +728,18 @@ class SlideQuestionSuccess(SlideQuestionIntro):
     def post(self):
         pass
 
+    @property
+    @view_memoize
+    def organisation_logo(self):
+        organisation = self.context.session.account.organisation
+        if not organisation or not organisation.image_filename:
+            return None
+        country_url = self.webhelpers.country_obj.absolute_url()
+        return (
+            f"{country_url}/@@organisation-logo/{organisation.organisation_id}"
+            f"?q={organisation.image_filename}"
+        )
+
     def __call__(self):
         training = self.get_or_create_training()
         if training.status not in ("correct", "success"):


### PR DESCRIPTION
Compare https://github.com/euphorie/Euphorie/blob/scrum-2142-certificate-logo/src/euphorie/client/browser/templates/organisation.pt#L87

Ref syslabcom/scrum#2142