### PR TITLE
Show training certificates from other users in my organisation

### DIFF
--- a/src/euphorie/client/browser/certificates.py
+++ b/src/euphorie/client/browser/certificates.py
@@ -1,6 +1,9 @@
+from euphorie.client.model import SurveySession
+from euphorie.client.model import Training
 from plone import api
 from plone.memoize.view import memoize
 from Products.Five import BrowserView
+from z3c.saconfig import Session
 
 
 class View(BrowserView):
@@ -8,18 +11,51 @@ class View(BrowserView):
 
     @property
     @memoize
-    def trainings_portlet(self):
-        return api.content.get_view(
-            name="portlet-my-trainings", context=self.context, request=self.request
+    def trainings(self):
+        """Get all trainings from all the current user's organisations."""
+        organisation_view = api.content.get_view(
+            name="organisation",
+            context=self.context,
+            request=self.request,
         )
+        account_ids = [
+            organisation.owner_id for organisation in organisation_view.organisations
+        ]
+        return [
+            training
+            for training in (
+                Session.query(Training)
+                .filter(
+                    Training.session_id == SurveySession.id,
+                    SurveySession.account_id.in_(account_ids),
+                )
+                .filter(Training.status == "correct")
+                .order_by(Training.time.desc())
+                .all()
+            )
+            if training.session.tool
+        ]
+
+    def get_certificate(self, training):
+        traversed_session = training.session.traversed_session
+        certificate_view = api.content.get_view(
+            name="training-certificate-inner",
+            context=traversed_session,
+            request=self.request,
+        )
+        return certificate_view.index(training_id=training.id)
 
     @property
     @memoize
     def my_certificates(self):
+        """Get all certificates that I am allowed to view, grouped by year."""
         certificates = {}
-        for training in self.trainings_portlet.my_certificates:
+        for training in self.trainings:
             year = training.time.year
-            link = f"{training.session.absolute_url()}/@@training-certificate-view"
-            content = self.trainings_portlet.get_certificate(training.session)
+            link = (
+                f"{training.session.absolute_url()}/@@training-certificate-view"
+                f"?training_id={training.id}"
+            )
+            content = self.get_certificate(training)
             certificates.setdefault(year, []).append({"link": link, "content": content})
         return certificates.items()

--- a/src/euphorie/client/browser/templates/training_certificate_inner.pt
+++ b/src/euphorie/client/browser/templates/training_certificate_inner.pt
@@ -1,9 +1,9 @@
 <article class="style-7 type- certificate ${python: 'pat-auto-scale' if request.getURL().endswith('/@@training-certificate-view') else ''}"
          tal:define="
            webhelpers nocall:view/webhelpers;
-           account webhelpers/get_current_account;
            toLocalizedTime nocall: context/@@plone/toLocalizedTime;
-           certificate view/get_or_create_training;
+           training_id request/training_id|options/training_id|nothing;
+           certificate python: view.get_training_by_id(training_id) if training_id else view.get_or_create_training();
          "
          i18n:domain="euphorie"
 >
@@ -21,7 +21,7 @@
     This certificate is presented to
   </p>
   <p class="certificate-user-name">
-    ${python: account.title}
+    ${python: certificate.account.title}
   </p>
   <p class="certificate-achievement"
      i18n:translate=""

--- a/src/euphorie/client/browser/templates/training_certificate_view.pt
+++ b/src/euphorie/client/browser/templates/training_certificate_view.pt
@@ -33,7 +33,7 @@
           </div>
           <div class="four columns">
             <a class="pat-button"
-               href="${here/absolute_url}/@@training-certificate"
+               href="${here/absolute_url}/@@training-certificate?training_id=${request/training_id}"
                target="new"
                i18n:translate=""
             >Print certificate</a>

--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -20,6 +20,7 @@ from random import sample
 from random import shuffle
 from sqlalchemy.orm.exc import NoResultFound
 from z3c.saconfig import Session
+from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
@@ -320,9 +321,23 @@ class TrainingView(BrowserView, survey._StatusHelper):
         questions = sample(all_questions, k=num_training_questions)
         return {q.getId(): None for q in questions}
 
+    def get_training_by_id(self, training_id):
+        """Return the training for this session with the given id."""
+        # check the session id to make sure we are not displaying a training in the
+        # context of a different session
+        session_id = self.webhelpers.session_id
+        try:
+            return (
+                Session.query(Training)
+                .filter(Training.session_id == session_id, Training.id == training_id)
+                .one()
+            )
+        except NoResultFound as exc:
+            raise NotFound from exc
+
     @memoize
     def get_or_create_training(self):
-        """Return the training for this session."""
+        """Return the current user's training for this session."""
         account_id = self.webhelpers.get_current_account().id
         session_id = self.webhelpers.session_id
         try:


### PR DESCRIPTION
The training certificate view was previously meant to only show the current user's certificates. Now it can take a parameter `training_id` that makes it display the training with the given id instead. The default is still to show the current user's certificate connected to the respective session (there can be only one such certificate per session). The parameter can also be passed to the `index()` method so that we don't have to fiddle with the request when displaying multiple certificates like in the overview page.

Ref syslabcom/scrum#2142