### PR TITLE
Do not pull in plone.namedfile[blobs].

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,7 +2,6 @@
 extends = versions-5.2.cfg
 parts = instance
 develop = .
-allow-unknown-extras = true
 show-picked-versions = true
 
 [instance]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "plone.dexterity",
         "plone.formwidget.namedfile",
         "plone.memoize",
-        "plone.namedfile[blobs]",
+        "plone.namedfile",
         "plone.api",
         "python-docx",
         "repoze.formapi",


### PR DESCRIPTION
In Plone 5.2 this is empty and in 6.0 it does not exist. No longer use `allow-unknown-extras` in our `buildout.cfg`.  That hides the error on install.