### PR TITLE
Define icons view in minimal main template.

### DIFF
--- a/src/euphorie/content/browser/templates/minimal_main_template.pt
+++ b/src/euphorie/content/browser/templates/minimal_main_template.pt
@@ -9,6 +9,7 @@
         tal:define="
           portal_state context/@@plone_portal_state;
           context_state context/@@plone_context_state;
+          icons python:context.restrictedTraverse('@@iconresolver', None);
           plone_view context/@@plone;
           plone_layout context/@@plone_layout;
           lang portal_state/language;


### PR DESCRIPTION
Otherwise in the overview-controlpanel pn Plone 6 you get:

    NameError: name 'icons' is not defined

With the new line, on Plone 5 the iconresolver view won't be found, so `icons` will be None. This is fine because icons is not used on Plone 5.