### PR TITLE
Retract other surveys in group when publishing a survey.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,12 @@ Changelog
 16.2.2 (unreleased)
 -------------------
 
+- Retract other surveys in group when publishing a survey.
+  Includes upgrade step to fix the current data, if needed, without touching the client side.
+  Fixes https://github.com/euphorie/Euphorie/issues/754
+  Ref: scrum-2440
+  [maurits]
+
 - Update prototype from commit 317e62820b35678055240ca911d24a3b45db44d6
   Ref: scrum-2333
   [reinhardt]

--- a/src/euphorie/client/browser/publish.py
+++ b/src/euphorie/client/browser/publish.py
@@ -185,6 +185,18 @@ def handleSurveyUnpublish(survey, event):
     """Event handler (subscriber) to take care of unpublishing a survey from
     the client."""
     surveygroup = aq_parent(survey)
+    # If this event handler is mistakenly triggered on a survey that is NOT
+    # the actually published survey of this group, then we should NOT remove
+    # anything from the client part.
+    if surveygroup.published != survey.id:
+        log.warning(
+            "Trying to unpublish survey %s, but %s is the actually published "
+            "survey of %s",
+            survey.id,
+            surveygroup.published,
+            "/".join(surveygroup.getPhysicalPath()),
+        )
+        return
     sector = aq_parent(surveygroup)
     country = aq_parent(sector)
 

--- a/src/euphorie/content/browser/surveygroup.py
+++ b/src/euphorie/content/browser/surveygroup.py
@@ -266,7 +266,7 @@ class Unpublish(BrowserView):
         wt = api.portal.get_tool("portal_workflow")
         if wt.getInfoFor(published_survey, "review_state") != "published":
             log.warning(
-                "Trying to unpublish survey %s which is not marked as " "published",
+                "Trying to unpublish survey %s which is not marked as published",
                 "/".join(published_survey.getPhysicalPath()),
             )
         else:

--- a/src/euphorie/content/surveygroup.py
+++ b/src/euphorie/content/surveygroup.py
@@ -10,6 +10,7 @@ https://admin.oiraproject.eu/sectors/eu/eu-private-security/private-security-eu
 from .. import MessageFactory as _
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from plone import api
 from plone.app.dexterity.behaviors.metadata import IBasic
 from plone.autoform import directives
 from plone.dexterity.content import Container
@@ -134,6 +135,13 @@ def handleSurveyPublish(survey, event):
         return
     surveygroup = aq_parent(aq_inner(survey))
     surveygroup.published = survey.id
+    # Retract all other surveys if needed, to make sure they are in draft state.
+    for content in surveygroup.contentValues():
+        if content.portal_type != "euphorie.survey":
+            continue
+        if content.id == survey.id:
+            continue
+        api.content.transition(obj=content, to_state="draft")
 
 
 def handleSurveyRemoved(survey, event):

--- a/src/euphorie/upgrade/deployment/v1/20240731180000_retract_unpublished_surveys/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20240731180000_retract_unpublished_surveys/upgrade.py
@@ -1,0 +1,63 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class RetractUnpublishedSurveys(UpgradeStep):
+    """Retract unpublished surveys.
+
+    Each surveygroup has an attribute 'published'.
+    This contains the id of a contained survey that is actually published
+    on the client side.
+    The review state of the contained surveys should match:
+
+    * The survey with this id must be in the 'published' state.
+    * All other surveys must be in the 'draft' state.
+
+    This upgrade step wants to make sure this is the case.
+
+    We should watch out though: I don't think it is a good idea to let this
+    upgrade step add/update/remove items on the client side.  This means we
+    must not publish any survey, but only retract surveys where needed.
+
+    So if a supposedly published survey does not have the published state,
+    we only print a warning.
+    """
+
+    def __call__(self):
+        catalog = api.portal.get_tool(name="portal_catalog")
+        for brain in catalog.unrestrictedSearchResults(
+            portal_type="euphorie.surveygroup"
+        ):
+            try:
+                surveygroup = brain.getObject()
+            except Exception:
+                logger.warning("Cannot get object for brain at %s", brain.getPath())
+                continue
+            published_id = surveygroup.published
+            for content in surveygroup.contentValues():
+                if content.portal_type != "euphorie.survey":
+                    continue
+                old_state = api.content.get_state(obj=content)
+                if content.id == published_id:
+                    if old_state != "published":
+                        logger.warning(
+                            "Survey is marked as the published tool version for its "
+                            "surveygroup, but its review state is %r. You should "
+                            "investigate: %s",
+                            old_state,
+                            brain.getPath(),
+                        )
+                    continue
+                if old_state == "published":
+                    logger.warning(
+                        "Survey has state 'published', but is not marked as the "
+                        "published tool version for its surveygroup. Reverting it "
+                        "to 'draft' state: %s",
+                        brain.getPath(),
+                    )
+                    api.content.transition(obj=content, to_state="draft")


### PR DESCRIPTION
Fixes https://github.com/euphorie/Euphorie/issues/754

Includes upgrade step to fix the current data, if needed, without touching the client side: I don't dare to add/update/remove any surveys on the client side.  That should be done by an editor.