### PR TITLE
get_current_account: catch exception when portal cannot be found.

### DIFF
--- a/src/euphorie/client/tests/test_model.py
+++ b/src/euphorie/client/tests/test_model.py
@@ -1,5 +1,6 @@
 from AccessControl.PermissionRole import _what_not_even_god_should_do
 from AccessControl.users import nobody
+from AccessControl.users import SimpleUser
 from datetime import timedelta
 from euphorie.client import config
 from euphorie.client import model
@@ -391,9 +392,11 @@ class AccountTests(DatabaseTests):
         session.add(account1)
         account1.group = group1
         group2.parent = group1
+        session.flush()
         from functools import partial
 
-        with mock.patch("plone.api.user.get_current", return_value=nobody):
+        user1 = SimpleUser(str(account1.id), "", ("Member",), [])
+        with mock.patch("plone.api.user.get_current", return_value=user1):
             add_survey = partial(model.SurveySession, account=account1)
             survey1 = add_survey(zodb_path="1")
             session.add(survey1)
@@ -421,7 +424,9 @@ class AccountTests(DatabaseTests):
         account2 = model.Account(loginname="account2")
         session.add(account2)
         account2.group = group2
-        with mock.patch("plone.api.user.get_current", return_value=nobody):
+        session.flush()
+        user1 = SimpleUser(str(account1.id), "", ("Member",), [])
+        with mock.patch("plone.api.user.get_current", return_value=user1):
             survey1 = model.SurveySession(
                 account=account1,
                 group=group1,


### PR DESCRIPTION
This can happen in unit tests without test layer.
For example in a buildout with osha.oira:

```
$ bin/test -s euphorie --test-path=/Users/maurits/syslab/quoira/oira/src/Euphorie/src -u
...
Error in test testAccountType (euphorie.client.tests.test_model.AccountTests)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.19/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.19/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.19/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/syslab/quoira/oira/src/Euphorie/src/euphorie/client/tests/test_model.py", line 294, in testAccountType
    (self.session, self.survey) = createSurvey()
  File "/Users/maurits/syslab/quoira/oira/src/Euphorie/src/euphorie/client/tests/test_model.py", line 18, in createSurvey
    survey = model.SurveySession(title="Session", zodb_path="survey", account=account)
  File "<string>", line 4, in __init__
  File "/Users/maurits/shared-eggs/cp38/SQLAlchemy-1.4.52-py3.8-macosx-14.4-x86_64.egg/sqlalchemy/orm/state.py", line 476, in _initialize_instance
    manager.dispatch.init(self, args, kwargs)
  File "/Users/maurits/shared-eggs/cp38/SQLAlchemy-1.4.52-py3.8-macosx-14.4-x86_64.egg/sqlalchemy/event/attr.py", line 346, in __call__
    fn(*args, **kw)
  File "/Users/maurits/shared-eggs/cp38/SQLAlchemy-1.4.52-py3.8-macosx-14.4-x86_64.egg/sqlalchemy/orm/events.py", line 236, in wrap
    return fn(target, *arg, **kw)
  File "/Users/maurits/syslab/quoira/oira/src/osha.oira/src/osha/oira/client/subscribers.py", line 39, in update_user_languages_subscriber
    account = get_current_account()
  File "/Users/maurits/syslab/quoira/oira/src/Euphorie/src/euphorie/client/model.py", line 1986, in get_current_account
    user_id = api.user.get_current().getId()
  File "/Users/maurits/shared-eggs/cp38/plone.api-2.1.0-py3.8.egg/plone/api/user.py", line 131, in get_current
    portal_membership = portal.get_tool("portal_membership")
  File "/Users/maurits/shared-eggs/cp38/decorator-5.1.1-py3.8.egg/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/Users/maurits/shared-eggs/cp38/plone.api-2.1.0-py3.8.egg/plone/api/validation.py", line 73, in wrapped
    return function(*args, **kwargs)
  File "/Users/maurits/shared-eggs/cp38/plone.api-2.1.0-py3.8.egg/plone/api/portal.py", line 105, in get_tool
    return getToolByName(get(), name)
  File "/Users/maurits/shared-eggs/cp38/plone.api-2.1.0-py3.8.egg/plone/api/portal.py", line 68, in get
    raise CannotGetPortalError(
plone.api.exc.CannotGetPortalError: Unable to get the portal object. More info on https://docs.plone.org/develop/plone.api/docs/api/exceptions.html#plone.api.exc.CannotGetPortalError
...
  Ran 133 tests with 0 failures, 3 errors, 0 skipped in 2.499 seconds.
```