### PR TITLE
Fix typo: succesful -> successful.

### DIFF
--- a/docs/client-api.rst
+++ b/docs/client-api.rst
@@ -111,7 +111,7 @@ In order to authenticate you must submit a JSON object with two keys:
 * ``password``: the users password
 
 If authentication failed an error response is returned with status code 403.
-If authentication is succesful a JSON response is returned with an
+If authentication is successful a JSON response is returned with an
 authentication token and a list of existing sessions::
 
    {

--- a/docs/cms-api.rst
+++ b/docs/cms-api.rst
@@ -56,7 +56,7 @@ In order to authenticate you must submit a JSON object with two keys:
 * ``password``: the users password
 
 If authentication failed an error response is returned with status code 403.
-If authentication is succesful a JSON response is returned with an
+If authentication is successful a JSON response is returned with an
 authentication token and basic information on the user::
 
    {

--- a/src/euphorie/client/browser/publish.py
+++ b/src/euphorie/client/browser/publish.py
@@ -172,7 +172,7 @@ def PublishToClient(survey, preview=False):
 
 
 def handleSurveyPublish(survey, event):
-    """Event handler (subscriber) for succesfull workflow transitions for
+    """Event handler (subscriber) for successfull workflow transitions for
     :py:obj:`ISurvey` objects. This handler copies the survey to the
     client.
     """
@@ -305,7 +305,7 @@ class PublishSurvey(form.Form):
                     "text_message_publish_success": _(
                         "message_publish_success",
                         default=(
-                            "Succesfully published the OiRA Tool. It can be accessed "
+                            "Successfully published the OiRA Tool. It can be accessed "
                             "at"
                         ),
                     ),
@@ -370,7 +370,7 @@ class PreviewSurvey(form.Form):
                     "text_message_preview_success": _(
                         "message_preview_success",
                         default=(
-                            "Succesfully created a preview for the OiRA Tool. It can "
+                            "Successfully created a preview for the OiRA Tool. It can "
                             "be accessed at"
                         ),
                     ),

--- a/src/euphorie/client/tests/stories/CreateAndPublishSurvey.txt
+++ b/src/euphorie/client/tests/stories/CreateAndPublishSurvey.txt
@@ -45,7 +45,7 @@ We must confirm we want to publish:
 '...Are you sure you want to publish this OiRA Tool?...'
 >>> browser.getControl(name="form.buttons.button_publish").click()
 >>> browser.contents
-'...Succesfully published the OiRA Tool. It can be accessed at...'
+'...Successfully published the OiRA Tool. It can be accessed at...'
 
 Now lets add a risk:
 
@@ -70,4 +70,4 @@ Lets publish our updates now:
 >>> button.click()
 >>> browser.getControl(name="form.buttons.button_publish").click()
 >>> browser.contents
-'...Succesfully published the OiRA Tool. It can be accessed at...'
+'...Successfully published the OiRA Tool. It can be accessed at...'

--- a/src/euphorie/client/tests/test_training_questions.py
+++ b/src/euphorie/client/tests/test_training_questions.py
@@ -281,7 +281,7 @@ class TestTrainingQuestions(EuphorieIntegrationTestCase):
                 self.assertListEqual(view.failed_questions, ["Life on Mars?"])
 
             # There is a certificate view but we cannot see it
-            # if we have not completed the training succesfully
+            # if we have not completed the training successfully
             with self._get_view(
                 "training-certificate", traversed_session, self.request.clone()
             ) as view:

--- a/src/euphorie/content/behaviour/dirtytree.py
+++ b/src/euphorie/content/behaviour/dirtytree.py
@@ -6,7 +6,7 @@ It can be useful to know if a content tree has any unpublished changes. This
 behaviour manages that by tracking creation, deletion, moving and modification
 of content objects and updating a dirty flag on the first parent object which
 provides the :py:obj:`IDirtyTreeRoot` marker interface. The flag is reset on
-succesfull workflow transitions.
+successfull workflow transitions.
 """
 
 from Acquisition import aq_base

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -586,7 +586,7 @@ class ImportSurvey(AutoExtensibleForm, form.Form):
             )
 
         IStatusMessage(self.request).addStatusMessage(
-            _("upload_success", default="Succesfully imported the OiRA Tool"),
+            _("upload_success", default="Successfully imported the OiRA Tool"),
             type="success",
         )
         state = getMultiAdapter((survey, self.request), name="plone_context_state")

--- a/src/euphorie/content/surveygroup.py
+++ b/src/euphorie/content/surveygroup.py
@@ -122,7 +122,7 @@ class SurveyGroup(Container):
 
 
 def handleSurveyPublish(survey, event):
-    """Event handler (subscriber) for succesfull workflow transitions for
+    """Event handler (subscriber) for successfull workflow transitions for
     :py:obj:`ISurvey` objects. This handler performs necessary housekeeping
     tasks on the parent :py:class:`SurveyGroup`.
 

--- a/src/euphorie/content/tests/stories/CreateEditPublish.txt
+++ b/src/euphorie/content/tests/stories/CreateEditPublish.txt
@@ -68,4 +68,4 @@ We must confirm we want to publish:
 '...Are you sure you want to publish this OiRA Tool?...'
 >>> browser.getControl(name="form.buttons.button_publish").click()
 >>> browser.contents
-'...Succesfully published the OiRA Tool. It can be accessed at...'
+'...Successfully published the OiRA Tool. It can be accessed at...'

--- a/src/euphorie/content/versioning.py
+++ b/src/euphorie/content/versioning.py
@@ -2,7 +2,7 @@ from Products.CMFCore.utils import getToolByName
 
 
 def handleSurveyPublish(survey, event):
-    """Event handler (subscriber) for succesfull workflow transitions for
+    """Event handler (subscriber) for successfull workflow transitions for
     :py:obj:`ISurvey` objects. This handler archives the current version.
     """
     if event.action not in ["publish", "update"]:

--- a/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/bg/LC_MESSAGES/euphorie.po
@@ -5857,12 +5857,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Успешно създаден преглед за OiRA инструмента. Достъпен е на адрес"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Успешно публикуване на OiRA инструмента. Достъпен е на"
@@ -6774,7 +6774,7 @@ msgstr ""
 "Сигурни ли сте, че искате да премахнете публикуването на този OiRA "
 "инструмент?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Успешно импортиран OiRA инстрмент"

--- a/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ca/LC_MESSAGES/euphorie.po
@@ -5838,14 +5838,14 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "S'ha creat una previsualització correcta de l'eina OiRA. S'hi pot accedir "
 "mitjançant"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "L'eina OiRA s'ha publicat correctament. S'hi pot accedir mitjançant"
@@ -6750,7 +6750,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Està segur que vol despublicar aquesta eina OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "L'eina OiRA s'ha importat correctament"

--- a/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/cs/LC_MESSAGES/euphorie.po
@@ -5734,12 +5734,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Úspěšně vytvořený náhled nástroje OiRA. Přístup k němu je možný na"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Úspěšně publikovaný nástroj OiRA. K dispozici na"
@@ -6639,7 +6639,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Jste si jist/a, že chcete zrušit publikování tohoto nástroje OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Úspěšně importovaný nástroj OiRA"

--- a/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/da/LC_MESSAGES/euphorie.po
@@ -5354,12 +5354,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6216,7 +6216,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -5768,14 +5768,14 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Die Vorschau für das Tool wurde erfolgreich erstellt. Sie kann hier erreich "
 "werden."
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "OiRA-Tool erfolgreich veröffentlicht. Es kann hier betrachtet werden"
@@ -6704,7 +6704,7 @@ msgstr ""
 "Sind sie sicher, dass Sie die Veröffentlichung dieses OiRA-Tools aufheben "
 "möchten?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA-Tool erfolgreich importiert."

--- a/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/el/LC_MESSAGES/euphorie.po
@@ -6026,14 +6026,14 @@ msgstr ""
 "κοστολόγηση των σχετικών συμβουλευτικών υπηρεσιών από τον/την πάροχό τους, "
 "εφόσον κάτι τέτοιο έχει προσυμφωνηθεί."
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Επιτυχής δημιουργία προεπισκόπησης για το εργαλείο OiRA. Διατίθεται στη "
 "διεύθυνση"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Επιτυχής δημοσίευση του εργαλείου OiRA. Μπορεί να γίνει πρόσβαση στο"
@@ -6989,7 +6989,7 @@ msgstr ""
 "Είστε βέβαιοι ότι θέλετε να αναιρέσετε τη δημοσίευση αυτού του Εργαλείου "
 "OiRA; "
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Η εισαγωγή του εργαλείου OiRA ολοκληρώθηκε με επιτυχία"

--- a/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/en/LC_MESSAGES/euphorie.po
@@ -5349,12 +5349,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6215,7 +6215,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/es/LC_MESSAGES/euphorie.po
@@ -5850,14 +5850,14 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Se ha creado correctamente una vista previa de la herramienta OiRA. Se puede "
 "acceder a ella en"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Herramienta OiRA publicada correctamente. Se puede acceder a través de"
@@ -6767,7 +6767,7 @@ msgid "unpublish_confirm"
 msgstr ""
 "¿Está seguro de que desea retirar la publicación de esta herramienta OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Herramienta OiRA importada con éxito"

--- a/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/et/LC_MESSAGES/euphorie.po
@@ -5353,12 +5353,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6215,7 +6215,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -5263,12 +5263,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6128,7 +6128,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fi/LC_MESSAGES/euphorie.po
@@ -5828,12 +5828,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "OiRA-työkalun esikatselu on luotu. Siihen pääsee osoitteesta"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "OiRA-työkalun julkaisu onnistui. Sen voi hakea osoitteesta"
@@ -6746,7 +6746,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Haluatko varmasti peruuttaa tämän OiRA-työkalun julkaisun?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA-työkalun tuonti onnistui"

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -5961,12 +5961,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr "Votre service externe pourrait éventuellement facturer un supplément."
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Aperçu créé avec succès pour l’outil OiRA. On peut y accéder sur"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Outil OiRA publié avec succès. Il est consultable à l’adresse"
@@ -6899,7 +6899,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Êtes-vous sûr de ne pas vouloir publier cet outil OiRA ?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Outil OiRA importé avec succès"

--- a/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hr/LC_MESSAGES/euphorie.po
@@ -5815,13 +5815,13 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Pretpregled za OiRA alat je uspješno stvoren. Može mu se pristupiti na adresi"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "OiRA alat je uspješno objavljen. Može mu se pristupiti na adresi"
@@ -6724,7 +6724,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Jeste li sugurni da želite poništiti objavu ovog OiRA alata?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Uspješno ste uvezli OiRA alat"

--- a/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/hu/LC_MESSAGES/euphorie.po
@@ -5907,12 +5907,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Sikerült létrehozni az OiRA eszköz előnézetét. Itt nyitható meg:"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Az OiRA eszköz közzététele sikeresen lezajlott. Itt nyitható meg:"
@@ -6823,7 +6823,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Biztosan szeretné megszüntetni ennek az OiRA eszköznek a közzétételét?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Az OiRA eszközt sikerült importálni"

--- a/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/is/LC_MESSAGES/euphorie.po
@@ -5709,13 +5709,13 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Prufueintak af þessu OiRA verkfæri hefur verið útbúið . Það er aðgengilegt á"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Sending OiRA áhaldsins tókst. Það er aðgengilegt á"
@@ -6620,7 +6620,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Ertu viss um að þú viljir draga til baka útgáfu á þessu OiRA verkfæri?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Upphleðsla á OiRA verkfærinu tókst"

--- a/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/it/LC_MESSAGES/euphorie.po
@@ -5896,13 +5896,13 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Anteprima creata con successo per lo strumento OiRA. È possibile accedere a"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Tool OiRA pubblicato con successo. È possibile accedere a"
@@ -6831,7 +6831,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Sicuro di voler mettere non pubblicato questo strumento OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Tool OiRA importato con successo"

--- a/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lt/LC_MESSAGES/euphorie.po
@@ -5796,12 +5796,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Sėkmingai sukurta OiRA priemonės peržiūra. Ją galima rasti adresu"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "OiRA priemonė sėkmingai išleista. Ją galima rasti adresu"
@@ -6707,7 +6707,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Ar tikrai norite pašalinti publikuojamą OiRA priemonę?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA priemonė sėkmingai įkelta"

--- a/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/lv/LC_MESSAGES/euphorie.po
@@ -5789,13 +5789,13 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "OiRA rīka priekšskatījums tika veiksmīgi izveidots. Tam var piekļūt vietnē:"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "OiRA rīks ir veiksmīgi publicēts. Tam var piekļūt šajā vietnē:"
@@ -6700,7 +6700,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Vai tiešām vēlaties atsaukt šī OiRA rīka publikāciju?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "OiRA rīka importēšana bija veiksmīga."

--- a/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/mt/LC_MESSAGES/euphorie.po
@@ -5855,12 +5855,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Inħoloq preview tal-Għodda tal-OiRA. Tista' tarah fi"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "L-Għodda tal-OiRA ppubblikata. Tista' taraha"
@@ -6774,7 +6774,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Żġur li tixtieq tneħħi din l-Għodda tal-OiRA mill-pubblikazzjoni?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "L-Għodda tal-OiRA ġiet importata"

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -5865,12 +5865,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr "Uw externe dienst kan mogelijk extra kosten aanrekenen."
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Er is een preview voor deze RI&E gemaakt. Deze kunt u bekijken op"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Het OiRA-instrument is gepubliceerd. Het kan worden geopend op"
@@ -6792,7 +6792,7 @@ msgstr ""
 "Weet u zeker dat u deze RI&E wil depubliceren? Hier zall de RI&E niet meer "
 "beschikbaar zijn in online client."
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "De RI&E is succesvol geïmporteerd"

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -5894,14 +5894,14 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr "Uw externe dienst kan mogelijk extra kosten aanrekenen."
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Er werd een voorbeeld gemaakt voor het OiRA-instrument. Het kan worden "
 "bekeken op"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Het OiRA-instrument is gepubliceerd. Het kan worden geopend op"
@@ -6832,7 +6832,7 @@ msgid "unpublish_confirm"
 msgstr ""
 "Weet u zeker dat u de publicatie van dit OiRA-instrument wilt ongedaan maken?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Het OiRA-instrument werd geïmporteerd"

--- a/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/no/LC_MESSAGES/euphorie.po
@@ -5351,12 +5351,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6213,7 +6213,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pl/LC_MESSAGES/euphorie.po
@@ -5430,12 +5430,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6292,7 +6292,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/pt/LC_MESSAGES/euphorie.po
@@ -5818,13 +5818,13 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 "Pré-visualização criada com sucesso para a Ferramenta OiRA. Está acessível em"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Ferramenta OiRA publicada com sucesso. Está acessível em"
@@ -6733,7 +6733,7 @@ msgid "unpublish_confirm"
 msgstr ""
 "Tem a certeza de que pretende anular a publicação desta Ferramenta OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Ferramenta OiRA importada com sucesso"

--- a/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/ro/LC_MESSAGES/euphorie.po
@@ -5358,12 +5358,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6220,7 +6220,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr ""
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr ""

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -5821,12 +5821,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Úspešne vytvorený náhľad nástroja OiRA. Je dostupný na"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Úspešne uverejnený nástroj OiRA. Je dostupný na"
@@ -6727,7 +6727,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Naozaj chcete zrušiť uverejnenie tohto nástroja OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Úspešne importovaný nástroj OiRA."

--- a/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sl/LC_MESSAGES/euphorie.po
@@ -5788,12 +5788,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr "Uspešno ustvarjen predogled orodja OiRA. Dostop do njega je mogoč na"
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr "Uspešno objavljeno orodje OiRA. Dostop do njega je mogoč na"
@@ -6698,7 +6698,7 @@ msgstr ""
 msgid "unpublish_confirm"
 msgstr "Ste prepričani, da želite preklicati objavo tega orodja OiRA?"
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Uspešno uvoženo orodje OiRA"

--- a/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sv/LC_MESSAGES/euphorie.po
@@ -5529,12 +5529,12 @@ msgstr ""
 msgid "message_possible_extra_cost"
 msgstr ""
 
-#. Default: "Succesfully created a preview for the OiRA Tool. It can be accessed at"
+#. Default: "Successfully created a preview for the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:370
 msgid "message_preview_success"
 msgstr ""
 
-#. Default: "Succesfully published the OiRA Tool. It can be accessed at"
+#. Default: "Successfully published the OiRA Tool. It can be accessed at"
 #: euphorie/client/browser/publish.py:305
 msgid "message_publish_success"
 msgstr ""
@@ -6424,7 +6424,7 @@ msgstr ""
 "kommer undersökningen att visas i online-klienten och finnas tillgänglig för "
 "alla användare."
 
-#. Default: "Succesfully imported the OiRA Tool"
+#. Default: "Successfully imported the OiRA Tool"
 #: euphorie/content/browser/upload.py:589
 msgid "upload_success"
 msgstr "Undersökningen har importerats"


### PR DESCRIPTION
I was looking for a message containing the word 'successful' but could not find it because it was spelled wrongly. :-). So I did a search and replace.