### PR TITLE
Similar titles: Store HTML as annotation until new search is triggered

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,10 @@ Changelog
   Ref: scrum-2669
   [reinhardt]
 
+- Similar titles: Store results until explicit refresh
+  Ref: scrum-2517
+  [reinhardt]
+
 
 16.2.1 (2024-07-31)
 -------------------

--- a/src/euphorie/content/browser/configure.zcml
+++ b/src/euphorie/content/browser/configure.zcml
@@ -470,6 +470,15 @@
       />
 
   <browser:page
+      name="similar-titles-stored"
+      for="*"
+      class=".similar_titles.SimilarTitlesStored"
+      template="templates/similar_titles.pt"
+      permission="cmf.ManagePortal"
+      layer="plonetheme.nuplone.skin.interfaces.NuPloneSkin"
+      />
+
+  <browser:page
       name="similar-titles-results"
       for="*"
       class=".similar_titles.SimilarTitlesResults"

--- a/src/euphorie/content/browser/configure.zcml
+++ b/src/euphorie/content/browser/configure.zcml
@@ -470,6 +470,15 @@
       />
 
   <browser:page
+      name="similar-titles-results"
+      for="*"
+      class=".similar_titles.SimilarTitlesResults"
+      template="templates/similar_titles_results.pt"
+      permission="cmf.ManagePortal"
+      layer="plonetheme.nuplone.skin.interfaces.NuPloneSkin"
+      />
+
+  <browser:page
       name="similar-titles-details"
       for="*"
       class=".similar_titles_details.SimilarTitlesDetails"

--- a/src/euphorie/content/browser/similar_titles.py
+++ b/src/euphorie/content/browser/similar_titles.py
@@ -191,6 +191,11 @@ class SimilarTitles(AutoExtensibleForm, form.Form):
         self.results_html = api.content.get_view(
             context=self.context, request=self.request, name="similar-titles-results"
         )()
+        self.show_results = True
+
+    @button.buttonAndHandler(_("Show last result"))
+    def handle_show_last_result(self, action):
+        self.show_results = True
 
     @button.buttonAndHandler(_("Cancel"), name="cancel")
     def handle_cancel(self, action):

--- a/src/euphorie/content/browser/similar_titles.py
+++ b/src/euphorie/content/browser/similar_titles.py
@@ -49,6 +49,7 @@ class SimilarTitles(AutoExtensibleForm, form.Form):
     schema = ISimilarTitleSchema
     ignoreContext = True
     form_name = _("Similar Titles OiRA Tool")
+    show_form = True
 
     label = _("Similar Titles OiRA Tool")
     description = _("This tool allows you to find objects with similar titles.")
@@ -123,16 +124,6 @@ class SimilarTitles(AutoExtensibleForm, form.Form):
         return paths
 
     @property
-    def results_html(self):
-        annotations = IAnnotations(api.portal.get())
-        return annotations.get("euphorie.content.similar_titles_html", "")
-
-    @results_html.setter
-    def results_html(self, value):
-        annotations = IAnnotations(api.portal.get())
-        annotations["euphorie.content.similar_titles_html"] = value
-
-    @property
     @memoize
     def similar_brains(self):
         self.initialize_nltk()
@@ -191,11 +182,10 @@ class SimilarTitles(AutoExtensibleForm, form.Form):
         self.results_html = api.content.get_view(
             context=self.context, request=self.request, name="similar-titles-results"
         )()
-        self.show_results = True
 
-    @button.buttonAndHandler(_("Show last result"))
-    def handle_show_last_result(self, action):
-        self.show_results = True
+    @button.buttonAndHandler(_("Show stored result"))
+    def handle_show_stored_result(self, action):
+        self.redirect(target=f"{self.context.absolute_url()}/@@similar-titles-stored")
 
     @button.buttonAndHandler(_("Cancel"), name="cancel")
     def handle_cancel(self, action):
@@ -209,3 +199,17 @@ class SimilarTitlesResults(SimilarTitles):
         if errors:
             self.status = self.formErrorsMessage
             return
+
+
+class SimilarTitlesStored(SimilarTitles):
+    show_form = False
+
+    @property
+    def results_html(self):
+        annotations = IAnnotations(api.portal.get())
+        return annotations.get("euphorie.content.similar_titles_html", "")
+
+    @results_html.setter
+    def results_html(self, value):
+        annotations = IAnnotations(api.portal.get())
+        annotations["euphorie.content.similar_titles_html"] = value

--- a/src/euphorie/content/browser/templates/similar_titles.pt
+++ b/src/euphorie/content/browser/templates/similar_titles.pt
@@ -58,7 +58,7 @@
           action="${request/getURL}"
           enctype="${view/enctype}"
           method="${view/method}"
-          tal:condition="python:not getattr(view, 'show_results', False)"
+          tal:condition="python:getattr(view, 'show_form', True)"
     >
       <fieldset>
         <tal:widget repeat="widget view/widgets/values"
@@ -101,7 +101,7 @@
       </div>
     </form>
 
-    <tal:results condition="python:getattr(view, 'show_results', False)"
+    <tal:results condition="python:getattr(view, 'results_html', None)"
                  replace="structure view/results_html|nothing"
     >
     </tal:results>

--- a/src/euphorie/content/browser/templates/similar_titles.pt
+++ b/src/euphorie/content/browser/templates/similar_titles.pt
@@ -58,6 +58,7 @@
           action="${request/getURL}"
           enctype="${view/enctype}"
           method="${view/method}"
+          tal:condition="python:not getattr(view, 'show_results', False)"
     >
       <fieldset>
         <tal:widget repeat="widget view/widgets/values"
@@ -100,7 +101,7 @@
       </div>
     </form>
 
-    <tal:results condition="python:getattr(view, 'results_html', None)"
+    <tal:results condition="python:getattr(view, 'show_results', False)"
                  replace="structure view/results_html|nothing"
     >
     </tal:results>

--- a/src/euphorie/content/browser/templates/similar_titles.pt
+++ b/src/euphorie/content/browser/templates/similar_titles.pt
@@ -100,39 +100,9 @@
       </div>
     </form>
 
-    <tal:results condition="python:getattr(view, 'similar_brains', None)">
-      <div class="results">
-        <tal:result repeat="result view/similar_brains">
-          <form action="${result/getURL}/@@similar-titles-details"
-                method="post"
-          >
-            <p>
-              <strong>
-                <a href="${result/getURL}">${result/Title}</a>
-              </strong>
-              <span class="tool">[${python: view.get_tool_for_brain(result).Title()}]</span>
-              <input class="details-button"
-                     type="submit"
-                     value="Details"
-                     i18n:attributes="value"
-              />
-            </p>
-            <ul>
-              <li tal:repeat="row python:view.similar_brains[result]">
-                <a href="${python:row[0].getURL()}">${python:row[0].Title}</a>
-                <span class="similarity"
-                      title="Similarity"
-                >${python:row[1]}</span>
-                <span class="tool">[${python: view.get_tool_for_brain(row[0]).Title()}]</span>
-                <input name="paths:list"
-                       type="hidden"
-                       value="${python:row[0].getPath()}"
-                />
-              </li>
-            </ul>
-          </form>
-        </tal:result>
-      </div>
+    <tal:results condition="python:getattr(view, 'results_html', None)"
+                 replace="structure view/results_html|nothing"
+    >
     </tal:results>
   </metal:content>
 </html>

--- a/src/euphorie/content/browser/templates/similar_titles_results.pt
+++ b/src/euphorie/content/browser/templates/similar_titles_results.pt
@@ -1,0 +1,32 @@
+<div class="results">
+  <tal:result repeat="result view/similar_brains">
+    <form action="${result/getURL}/@@similar-titles-details"
+          method="post"
+    >
+      <p>
+        <strong>
+          <a href="${result/getURL}">${result/Title}</a>
+        </strong>
+        <span class="tool">[${python: view.get_tool_for_brain(result).Title()}]</span>
+        <input class="details-button"
+               type="submit"
+               value="Details"
+               i18n:attributes="value"
+        />
+      </p>
+      <ul>
+        <li tal:repeat="row python:view.similar_brains[result]">
+          <a href="${python:row[0].getURL()}">${python:row[0].Title}</a>
+          <span class="similarity"
+                title="Similarity"
+          >${python:row[1]}</span>
+          <span class="tool">[${python: view.get_tool_for_brain(row[0]).Title()}]</span>
+          <input name="paths:list"
+                 type="hidden"
+                 value="${python:row[0].getPath()}"
+          />
+        </li>
+      </ul>
+    </form>
+  </tal:result>
+</div>


### PR DESCRIPTION
Note that the minimum and maximum similarity values are not stored. When you call the view the default values are displayed (0.5 and 1.0, resp.) but they may not match the results that are shown. I would say that's OK for now, but could be a possible future improvement.

Ref syslabcom/scrum#2517