### PR TITLE
Fix the CMS navigation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,12 @@ Changelog
 16.2.5 (unreleased)
 -------------------
 
+- Fix the plone.displayed_types registry record that was previously only updated
+  through upgrade steps.
+  This fixes the navigation on the CMS side for freshly installed sites and
+  for sites that have been deployed with recent versions of the package.
+  [ale-rt]
+
 - Report: Fix lists of risks (“parked” / not present)
   (`#2800 <https://github.com/syslabcom/scrum/issues/2800>`_)
   [reinhardt]
@@ -36,7 +42,7 @@ Changelog
 - The conditional fields have now widgets that can be customized as needed
   [ale-rt]
 
-- removed the target=_blank from the form that opens the email client. That broke the feature for firefox. 
+- removed the target=_blank from the form that opens the email client. That broke the feature for firefox.
   Fixes #2559
   [pilz]
 

--- a/src/euphorie/content/tests/stories/CopyFromOtherSector.txt
+++ b/src/euphorie/content/tests/stories/CopyFromOtherSector.txt
@@ -61,7 +61,7 @@ Paste module in own survey
 
 Lets go back to our own survey now:
 
->>> browser.getLink("OiRA", index=1).click()
+>>> browser.getLink("OiRA", index=2).click()
 >>> browser.getLink("Standard version").click()
 >>> authenticator = browser.getControl(name='_authenticator', index=0).value
 >>> browser.open("%s/@@paste?_authenticator=%s" % (browser.url, authenticator))

--- a/src/euphorie/deployment/profiles/default/registry.xml
+++ b/src/euphorie/deployment/profiles/default/registry.xml
@@ -374,4 +374,22 @@
   >
     <value>True</value>
   </record>
+  <record field="displayed_types"
+          interface="Products.CMFPlone.interfaces.controlpanel.INavigationSchema"
+          name="plone.displayed_types"
+  >
+    <value purge="false">
+      <element>euphorie.documentation</element>
+      <element>euphorie.folder</element>
+      <element>euphorie.help</element>
+      <element>euphorie.module</element>
+      <element>euphorie.page</element>
+      <element>euphorie.profilequestion</element>
+      <element>euphorie.risk</element>
+      <element>euphorie.solution</element>
+      <element>euphorie.survey</element>
+      <element>euphorie.surveygroup</element>
+      <element>euphorie.training_question</element>
+    </value>
+  </record>
 </registry>

--- a/src/euphorie/upgrade/deployment/v1/20241127135848_fix_navigation_in_cms/registry.xml
+++ b/src/euphorie/upgrade/deployment/v1/20241127135848_fix_navigation_in_cms/registry.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="ploneintranet"
+>
+  <record field="displayed_types"
+          interface="Products.CMFPlone.interfaces.controlpanel.INavigationSchema"
+          name="plone.displayed_types"
+  >
+    <value purge="false">
+      <element>euphorie.documentation</element>
+      <element>euphorie.folder</element>
+      <element>euphorie.help</element>
+      <element>euphorie.module</element>
+      <element>euphorie.page</element>
+      <element>euphorie.profilequestion</element>
+      <element>euphorie.risk</element>
+      <element>euphorie.solution</element>
+      <element>euphorie.survey</element>
+      <element>euphorie.surveygroup</element>
+      <element>euphorie.training_question</element>
+    </value>
+  </record>
+</registry>

--- a/src/euphorie/upgrade/deployment/v1/20241127135848_fix_navigation_in_cms/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v1/20241127135848_fix_navigation_in_cms/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixNavigationInCMS(UpgradeStep):
+    """Fix navigation in CMS."""
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Fix the plone.displayed_types registry record that was previously only updated  through upgrade steps, see:

- https://github.com/euphorie/Euphorie/blob/7fb70908f120554c9395a3bc6740053acf38a414/src/euphorie/deployment/upgrade/profiles/to_0020/registry.xml#L7
- https://github.com/euphorie/Euphorie/blob/7fb70908f120554c9395a3bc6740053acf38a414/src/euphorie/upgrade/deployment/v1/20220318135716_add_training_question/registry.xml#L7

This fixes the navigation on the CMS side for freshly installed sites and for sites that have been deployed with recent versions of the package.