### PR TITLE
Don't update titles of session-specific instances of profilequestions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Changelog
 - Removed leading empty lines from compact report
   (`#2815 <https://github.com/syslabcom/scrum/issues/2815>`_)
   [reinhardt]
+- Fix for profile questions (changed title)
+  (`#3038 <https://github.com/syslabcom/scrum/issues/3038>`_)
+  [reinhardt]
 
 
 16.2.6 (2025-01-10)

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -902,6 +902,12 @@ class SurveySession(BaseObject):
                 if item.zodb_path.find("custom-risks") >= 0:
                     continue
                 zodb_item = survey.restrictedTraverse(item.zodb_path.split("/"), None)
+                # Don't update session-specific instances of profilequestions
+                if (
+                    zodb_item.portal_type == "euphorie.profilequestion"
+                    and item.profile_index > -1
+                ):
+                    continue
                 if zodb_item and zodb_item.title != item.title:
                     item.title = zodb_item.title
         self.refreshed = datetime.datetime.now()


### PR DESCRIPTION
...from ZODB

Ref https://github.com/syslabcom/scrum/issues/3038