### PR TITLE
Notifications: Use `webhelpers.get_sessions_query()`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,10 @@ Changelog
   Ref: scrum-2726.
   [thet]
 
+- Don't try to send notifications for sessions of depublished tools.
+  (`#3024 <https://github.com/syslabcom/scrum/issues/3024>`_)
+  [reinhardt]
+
 
 16.2.7 (2025-01-15)
 -------------------

--- a/src/euphorie/client/tests/test_notifications.py
+++ b/src/euphorie/client/tests/test_notifications.py
@@ -113,6 +113,16 @@ class NotificationsSendingTests(EuphorieIntegrationTestCase):
         )
         survey_session.modified = datetime.datetime.now() - datetime.timedelta(days=366)
         Session.add(survey_session)
+        survey_session2 = SurveySession(
+            id=2,
+            title="Depublished",
+            zodb_path="nl/ict/depublished",
+            account=self.account,
+        )
+        survey_session2.modified = datetime.datetime.now() - datetime.timedelta(
+            days=366
+        )
+        Session.add(survey_session2)
         api.portal.set_registry_record("euphorie.notifications__enabled", True)
 
     def test_send_notification(self):


### PR DESCRIPTION
This makes sure the context filter is used by which any sessions of depublished tools are excluded.

Ref https://github.com/syslabcom/scrum/issues/3024