### PR TITLE
Markup alignment for usability testing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,9 @@ Changelog
   (`#2375 <https://github.com/syslabcom/scrum/issues/2375>`_)
   [reinhardt]
 
+- Updated resources from proto and applied a number of markup fixes in a review session with Daniel
+  [pilz]
+
 
 16.2.7 (2025-01-15)
 -------------------

--- a/src/euphorie/client/browser/templates/assessments.pt
+++ b/src/euphorie/client/browser/templates/assessments.pt
@@ -118,12 +118,18 @@
           <div class="portlet">
             <div class="content">
               <metal:assessments_list metal:define-macro="assessments_list">
+                <p tal:condition="not:sessions/count"
+                   class="pat-message info"
+                   i18n_translate="message_you_dont_have_any_risk_assessments_yet">
+                   You don’t have any risk assessments yet. Start by creating a new one.
+                </p>
                 <ul class="data-matrix ${python:'hd' if show_extra_fields else None}"
                     tal:define="
                       show_extra_fields show_extra_fields|python:False;
                       toLocalizedTime nocall: context/@@plone/toLocalizedTime;
                       get_archived_label nocall:view/get_archived_label|nocall:here/@@assessments/get_archived_label;
                     "
+                    tal:condition="sessions/count"
                 >
                   <li class="row ${python:'archived' if session.is_archived else None}"
                       title="${python: get_archived_label(session)}"

--- a/src/euphorie/client/browser/templates/assessments.pt
+++ b/src/euphorie/client/browser/templates/assessments.pt
@@ -91,7 +91,7 @@
         </metal:homescreen_navigation>
         <div id="application-content"
              tal:define="
-               sessions view/sessions;
+               sessions python:view.sessions.all();
                show_extra_fields python:True;
              "
         >
@@ -118,7 +118,7 @@
           <div class="portlet">
             <div class="content">
               <metal:assessments_list metal:define-macro="assessments_list">
-                <p tal:condition="not:sessions/count"
+              <p tal:condition="not: sessions"
                    class="pat-message info"
                    i18n_translate="message_you_dont_have_any_risk_assessments_yet">
                    You don’t have any risk assessments yet. Start by creating a new one.
@@ -129,7 +129,7 @@
                       toLocalizedTime nocall: context/@@plone/toLocalizedTime;
                       get_archived_label nocall:view/get_archived_label|nocall:here/@@assessments/get_archived_label;
                     "
-                    tal:condition="sessions/count"
+                    tal:condition="sessions"
                 >
                   <li class="row ${python:'archived' if session.is_archived else None}"
                       title="${python: get_archived_label(session)}"

--- a/src/euphorie/client/browser/templates/assessments.pt
+++ b/src/euphorie/client/browser/templates/assessments.pt
@@ -118,10 +118,11 @@
           <div class="portlet">
             <div class="content">
               <metal:assessments_list metal:define-macro="assessments_list">
-              <p tal:condition="not: sessions"
-                   class="pat-message info"
-                   i18n_translate="message_you_dont_have_any_risk_assessments_yet">
-                   You don’t have any risk assessments yet. Start by creating a new one.
+                <p class="pat-message info"
+                   i18n_translate="message_you_dont_have_any_risk_assessments_yet"
+                   tal:condition="not: sessions"
+                >
+                   You don&rsquo;t have any risk assessments yet. Start by creating a new one.
                 </p>
                 <ul class="data-matrix ${python:'hd' if show_extra_fields else None}"
                     tal:define="

--- a/src/euphorie/client/browser/templates/certificates.pt
+++ b/src/euphorie/client/browser/templates/certificates.pt
@@ -20,15 +20,20 @@
         </metal:homescreen_navigation>
         <div id="application-content">
           <div class="portlet">
-            <div class="content" tal:define="certificates view/certificates">
+            <div class="content"
+                 tal:define="
+                   certificates view/certificates;
+                 "
+            >
               <tal:cond condition="python: len(certificates) == 0">
                 <p class="pat-message info"
-                  i18n_translate="message_you_dont_have_any_certificates_yet">
-                  You haven’t earned any certificates yet.
+                   i18n_translate="message_you_dont_have_any_certificates_yet"
+                >
+                  You haven&rsquo;t earned any certificates yet.
                 </p>
-                <a class="pat-inject no-label"  
-                   data-pat-inject="history: record; source: #content; target: #content;" 
+                <a class="pat-inject no-label"
                    href="${webhelpers/base_url}/++resource++euphorie.resources/oira/help/${webhelpers/help_language}/pages/certificates.html#content"
+                   data-pat-inject="history: record; source: #content; target: #content;"
                    i18n:translate="message_learn_more_about_certificates"
                 >Learn more about certificates.</a>
               </tal:cond>

--- a/src/euphorie/client/browser/templates/certificates.pt
+++ b/src/euphorie/client/browser/templates/certificates.pt
@@ -20,8 +20,19 @@
         </metal:homescreen_navigation>
         <div id="application-content">
           <div class="portlet">
-            <div class="content">
-              <tal:year tal:repeat="item view/certificates">
+            <div class="content" tal:define="certificates view/certificates">
+              <tal:cond condition="python: len(certificates) == 0">
+                <p class="pat-message info"
+                  i18n_translate="message_you_dont_have_any_certificates_yet">
+                  You haven’t earned any certificates yet.
+                </p>
+                <a class="pat-inject no-label"  
+                   data-pat-inject="history: record; source: #content; target: #content;" 
+                   href="${webhelpers/base_url}/++resource++euphorie.resources/oira/help/${webhelpers/help_language}/pages/certificates.html#content"
+                   i18n:translate="message_learn_more_about_certificates"
+                >Learn more about certificates.</a>
+              </tal:cond>
+              <tal:year tal:repeat="item certificates">
                 <tal:year tal:define="
                             year python:item[0];
                             sessions python:item[1];

--- a/src/euphorie/client/browser/templates/module_identification_custom.pt
+++ b/src/euphorie/client/browser/templates/module_identification_custom.pt
@@ -56,7 +56,7 @@
           <tal:question tal:replace="structure module/question">question</tal:question>
         </article>
 
-        <p class="buttonBar"
+        <p class="button-bar"
            id="nav-bar"
         >
           <a class="pat-button back"

--- a/src/euphorie/client/browser/templates/module_identification_custom.pt
+++ b/src/euphorie/client/browser/templates/module_identification_custom.pt
@@ -56,9 +56,7 @@
           <tal:question tal:replace="structure module/question">question</tal:question>
         </article>
 
-        <p class="button-bar"
-           id="nav-bar"
-        >
+        <p class="button-bar">
           <a class="pat-button back"
              href="${view/previous_question_url}"
              i18n:translate="label_previous"

--- a/src/euphorie/client/browser/templates/more_menu.pt
+++ b/src/euphorie/client/browser/templates/more_menu.pt
@@ -32,6 +32,15 @@
           >History</a>
         </li>
         <li>
+          <a class="pat-modal close-panel icon-chart-line ${python: not has_tree and 'disabled' or ''}"
+             href="${python:status_url if has_tree else None}"
+             title="Status"
+             data-pat-modal="class: medium"
+             i18n:attributes="title navigation_status"
+             i18n:translate="navigation_status"
+          >Status</a>
+        </li>
+        <li>
           <a class="close-panel icon-trash pat-modal ${python: not can_delete and 'disabled' or ''}"
              href="${python:can_delete and delete_url or None}"
              title="Delete this session"
@@ -59,13 +68,18 @@
           >Duplicate</a>
         </li>
         <li>
-          <a class="pat-modal close-panel icon-chart-line ${python: not has_tree and 'disabled' or ''}"
-             href="${python:status_url if has_tree else None}"
-             title="Status"
-             data-pat-modal="class: medium"
-             i18n:attributes="title navigation_status"
-             i18n:translate="navigation_status"
-          >Status</a>
+          <a href="${here/absolute_url}/@@panel-contents-preview#document-content" 
+             class="pat-modal icon-eye close-panel" 
+             data-pat-modal="class: sheet"
+             i18n:translate="label_print_tool_preview"
+          >Preview or print the tool for preparation</a>   
+        </li>
+        <li>
+          <a class="pat-inject close-panel icon-cancel" 
+             href="${webhelpers/country_or_client_url}#content" 
+             data-pat-inject="history: record"
+             i18n:translate="label_exit"
+          >Exit</a>
         </li>
       </ul>
     </div>

--- a/src/euphorie/client/browser/templates/more_menu.pt
+++ b/src/euphorie/client/browser/templates/more_menu.pt
@@ -68,15 +68,15 @@
           >Duplicate</a>
         </li>
         <li>
-          <a href="${here/absolute_url}/@@panel-contents-preview#document-content" 
-             class="pat-modal icon-eye close-panel" 
+          <a class="pat-modal icon-eye close-panel"
+             href="${here/absolute_url}/@@panel-contents-preview#document-content"
              data-pat-modal="class: sheet"
              i18n:translate="label_print_tool_preview"
-          >Preview or print the tool for preparation</a>   
+          >Preview or print the tool for preparation</a>
         </li>
         <li>
-          <a class="pat-inject close-panel icon-cancel" 
-             href="${webhelpers/country_or_client_url}#content" 
+          <a class="pat-inject close-panel icon-cancel"
+             href="${webhelpers/country_or_client_url}#content"
              data-pat-inject="history: record"
              i18n:translate="label_exit"
           >Exit</a>

--- a/src/euphorie/client/browser/templates/new-session.pt
+++ b/src/euphorie/client/browser/templates/new-session.pt
@@ -78,7 +78,6 @@
                           data-pat-autosuggest="minimum-input-length:0"
                           i18n:attributes="placeholder label_select_oira_tool"
                   >
-                    <option value="">&nbsp;</option>
                     <metal:templates define-macro="templates_many">
                       <tal:surveys define="
                                      surveys root/survey_templates;

--- a/src/euphorie/client/browser/templates/portlet-available-tools.pt
+++ b/src/euphorie/client/browser/templates/portlet-available-tools.pt
@@ -39,7 +39,6 @@
                       i18n:attributes="placeholder label_select_oira_tool"
               >
                 <metal:templates define-macro="templates_many">
-                  <option value="">&nbsp;</option>
                   <tal:surveys define="
                                  surveys root/survey_templates;
                                ">

--- a/src/euphorie/client/browser/templates/portlet-my-ras.pt
+++ b/src/euphorie/client/browser/templates/portlet-my-ras.pt
@@ -107,8 +107,9 @@
         <tal:no-sessions condition="not:sessions_by_organisation">
           <article class="pat-rich">
             <p>
-              <a class="pat-modal icon-plus-circle" data-pat-modal="class: panel small"
+              <a class="pat-modal icon-plus-circle"
                  href="${here/absolute_url}/@@new-session.html#document-content"
+                 data-pat-modal="class: panel small"
               >${view/label_start_session}</a>
             </p>
           </article>

--- a/src/euphorie/client/browser/templates/portlet-my-ras.pt
+++ b/src/euphorie/client/browser/templates/portlet-my-ras.pt
@@ -107,7 +107,7 @@
         <tal:no-sessions condition="not:sessions_by_organisation">
           <article class="pat-rich">
             <p>
-              <a class="pat-modal icon-plus-circle"
+              <a class="pat-modal icon-plus-circle" data-pat-modal="class: panel small"
                  href="${here/absolute_url}/@@new-session.html#document-content"
               >${view/label_start_session}</a>
             </p>

--- a/src/euphorie/client/browser/templates/report.pt
+++ b/src/euphorie/client/browser/templates/report.pt
@@ -54,7 +54,7 @@
               </textarea>
             </label>
           </fieldset>
-          <p class="buttonBar">
+          <p class="button-bar">
             <button class="pat-button default"
                     id="report_comment_submit"
                     name="next"

--- a/src/euphorie/client/browser/templates/start.pt
+++ b/src/euphorie/client/browser/templates/start.pt
@@ -49,7 +49,7 @@
           </article>
 
           <article class="pat-rich">
-            <h1>${view/session/title}</h1>
+            <h1>${python: view.session.title or context.title}</h1>
             <section tal:condition="context/Description">
               <p>${context/Description}</p>
             </section>

--- a/src/euphorie/client/browser/templates/start.pt
+++ b/src/euphorie/client/browser/templates/start.pt
@@ -49,7 +49,7 @@
           </article>
 
           <article class="pat-rich">
-            <h1>${context/Title}</h1>
+            <h1>${view/session/title}</h1>
             <section tal:condition="context/Description">
               <p>${context/Description}</p>
             </section>

--- a/src/euphorie/client/browser/templates/webhelpers.pt
+++ b/src/euphorie/client/browser/templates/webhelpers.pt
@@ -166,7 +166,7 @@
     >
 
       <!-- Existing Measures -->
-      <fieldset class="pat-checklist pat-clone ${python:'pat-inject pat-autosubmit pat-subform' if (webhelpers.integrated_action_plan or webhelpers.use_training_module) else None}"
+      <fieldset class="measures-in-place pat-checklist pat-clone ${python:'pat-inject pat-autosubmit pat-subform' if (webhelpers.integrated_action_plan or webhelpers.use_training_module) else None}"
                 id="risk_identification_form"
                 disabled="${python:'disabled' if not webhelpers.can_edit_session else None}"
                 data-pat-clone="template: #in-place-measure-template; trigger-element: #add-in-place-measure-button; remove-behaviour: none"
@@ -268,7 +268,7 @@
       <div class="button-bar cloning"
            tal:condition="python:view.show_existing_measures"
       >
-        <button class="add-clone small pat-button icon-plus-circle"
+        <button class="add-clone pat-button icon-plus-circle"
                 id="add-in-place-measure-button"
                 title="${view/button_add_extra}"
                 type="button"

--- a/src/euphorie/client/tests/test_functional_country.py
+++ b/src/euphorie/client/tests/test_functional_country.py
@@ -35,7 +35,7 @@ class CountryFunctionalTests(EuphorieFunctionalTestCase):
             self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
         )
         self.assertEqual(
-            browser.getControl(name="survey").options, ["", "branche/vragenlijst"]
+            browser.getControl(name="survey").options, ["branche/vragenlijst"]
         )
 
         # Still Dutch
@@ -43,7 +43,7 @@ class CountryFunctionalTests(EuphorieFunctionalTestCase):
             self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
         )
         self.assertEqual(
-            browser.getControl(name="survey").options, ["", "branche/vragenlijst"]
+            browser.getControl(name="survey").options, ["branche/vragenlijst"]
         )
 
         # Now, switch to English
@@ -53,9 +53,7 @@ class CountryFunctionalTests(EuphorieFunctionalTestCase):
         browser.open(
             self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
         )
-        self.assertEqual(
-            browser.getControl(name="survey").options, ["", "sector/survey"]
-        )
+        self.assertEqual(browser.getControl(name="survey").options, ["sector/survey"])
 
     def test_must_select_valid_survey(self):
         self.loginAsPortalOwner()

--- a/src/euphorie/content/utils.py
+++ b/src/euphorie/content/utils.py
@@ -159,7 +159,7 @@ TOOL_TYPES = OrderedDict(
                 ),
                 "answer_no_integrated_ap": _(
                     "label_not_sufficient_integrated_ap",
-                    default="No, more measures are required <strong>(to be added below)</strong>",  # noqa: E501
+                    default="No, more measures are required (to be added below)",  # noqa: E501
                 ),
                 "answer_na": _("label_not_applicable", default="Not applicable"),
                 "custom_intro_extra": _(

--- a/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/de/LC_MESSAGES/euphorie.po
@@ -4826,8 +4826,7 @@ msgstr "Nein, weitere Maßnahmen sind notwendig"
 #: euphorie/content/utils.py:160
 msgid "label_not_sufficient_integrated_ap"
 msgstr ""
-"Nein, weitere Maßnahmen sind notwendig <strong>(weiter unten einzutragen)</"
-"strong>"
+"Nein, weitere Maßnahmen sind notwendig (weiter unten einzutragen)"
 
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245

--- a/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/fr/LC_MESSAGES/euphorie.po
@@ -5004,8 +5004,8 @@ msgstr "Non, des mesures sont à ajouter au plan d’actions"
 #: euphorie/content/utils.py:160
 msgid "label_not_sufficient_integrated_ap"
 msgstr ""
-"Non, des mesures sont à ajouter au plan d’actions <strong>(à compléter ci-"
-"dessous)</strong>"
+"Non, des mesures sont à ajouter au plan d’actions (à compléter ci-"
+"dessous)"
 
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245

--- a/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/sk/LC_MESSAGES/euphorie.po
@@ -4872,7 +4872,7 @@ msgstr "Nie, sú potrebné ďalšie opatrenia"
 #: euphorie/content/utils.py:160
 msgid "label_not_sufficient_integrated_ap"
 msgstr ""
-"Nie, sú potrebné ďalšie opatrenia <strong>(pridajte ich ďalej)</strong>"
+"Nie, sú potrebné ďalšie opatrenia (pridajte ich ďalej)"
 
 #. Default: "Notes"
 #: euphorie/client/browser/templates/training-slides.pt:245


### PR DESCRIPTION
I did a session with Daniel today and aligned markup with proto so that we are better prepared for the upcoming usability testing. 
These changes should be merged together with the PR to update the resources to the latest version - see https://github.com/euphorie/Euphorie/pull/792 (but is not directly coupled). The fixes are safe, and also work with an older version. Also, the proto update is safe, we clicked through, there was no visible breakage.