### PR TITLE
Don't allow editing training slides when user doesn't have edit permission on the session

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,10 @@ Changelog
 - Updated resources from proto and applied a number of markup fixes in a review session with Daniel
   [pilz]
 
+- Don't allow editing training slides when user doesn't have edit permisison on the session
+  (`#3188 <https://github.com/syslabcom/scrum/issues/3188>`_)
+  [reinhardt]
+
 
 16.2.7 (2025-01-15)
 -------------------

--- a/src/euphorie/client/browser/templates/training.pt
+++ b/src/euphorie/client/browser/templates/training.pt
@@ -181,7 +181,7 @@
                         <a class="card-edit-button pat-modal executed"
                            href="#modal-content-${counter}"
                            data-pat-modal="class: medium panel"
-                           tal:condition="python:slide_type=='risk'"
+                           tal:condition="python:slide_type=='risk' and can_edit"
                            i18n:translate="button_edit"
                         >Edit</a>
                         <span class="card-number">${training_view/number}
@@ -306,6 +306,7 @@
                           <div class="container">
 
                             <button class="pat-button default close-panel"
+                                    disabled="${python:'disabled' if not can_edit else None}"
                                     type="submit"
                                     i18n:translate="Save"
                             >Save</button>

--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -578,7 +578,10 @@ class TrainingView(BrowserView, survey._StatusHelper):
         survey = self.webhelpers._survey
         utils.setLanguage(self.request, survey, survey.language)
 
-        if self.request.environ["REQUEST_METHOD"] == "POST":
+        if (
+            self.request.environ["REQUEST_METHOD"] == "POST"
+            and self.webhelpers.can_edit_session
+        ):
             reply = self.request.form
             if "risk_id" in reply:
                 self.handle_measure_configuration(reply)


### PR DESCRIPTION
Ref syslabcom/scrum#3188