### PR TITLE
Additional image fields for modules and profile questions

### DIFF
--- a/news/2860.feature
+++ b/news/2860.feature
@@ -1,0 +1,1 @@
+Additional images for modules and profile questions

--- a/src/euphorie/content/module.py
+++ b/src/euphorie/content/module.py
@@ -96,6 +96,54 @@ class IModule(model.Schema, IRichDescription, IBasic):
         title=_("label_caption", default="Image caption"), required=False
     )
 
+    model.fieldset(
+        "secondary_images",
+        label=_("header_secondary_images", default="Secondary images"),
+        fields=["image2", "caption2", "image3", "caption3", "image4", "caption4"],
+    )
+
+    image2 = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption2 = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
+
+    image3 = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption3 = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
+
+    image4 = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption4 = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
+
     solution_direction = HtmlText(
         title=_("label_solution_direction", default="Solution"),
         description=_(

--- a/src/euphorie/content/profilequestion.py
+++ b/src/euphorie/content/profilequestion.py
@@ -23,6 +23,7 @@ from plone.app.dexterity.behaviors.metadata import IBasic
 from plone.autoform import directives
 from plone.dexterity.content import Container
 from plone.indexer import indexer
+from plone.namedfile import field as filefield
 from plone.supermodel import model
 from plonetheme.nuplone.z3cform.directives import depends
 from zope import schema
@@ -94,6 +95,68 @@ class IProfileQuestion(model.Schema, IRichDescription, IBasic):
         required=True,
     )
     directives.widget(label_multiple_occurances="euphorie.content.risk.TextLines4Rows")
+
+    image = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
+
+    model.fieldset(
+        "secondary_images",
+        label=_("header_secondary_images", default="Secondary images"),
+        fields=["image2", "caption2", "image3", "caption3", "image4", "caption4"],
+    )
+
+    image2 = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption2 = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
+
+    image3 = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption3 = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
+
+    image4 = filefield.NamedBlobImage(
+        title=_("label_image", default="Image file"),
+        description=_(
+            "help_image_upload",
+            default="Upload an image. Make sure your image is of format "
+            "png, jpg or gif and does not contain any special "
+            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+        ),
+        required=False,
+    )
+    caption4 = schema.TextLine(
+        title=_("label_caption", default="Image caption"), required=False
+    )
 
 
 @implementer(IProfileQuestion, IQuestionContainer)


### PR DESCRIPTION
Things to consider:

* We may want to put the image fields into a separate schema and include that in the risk, module and profile question schemata
* We may want to change the general approach to handling images. Maybe we should allow Image content objects and reference those in rich text fields, like in quaive?

Ref syslabcom/scrum#2860