### PR TITLE
Remove deprecated imports

### DIFF
--- a/src/euphorie/client/authentication.py
+++ b/src/euphorie/client/authentication.py
@@ -12,8 +12,8 @@ from AccessControl.class_init import InitializeClass
 from Acquisition import aq_parent
 from euphorie.content.user import IUser
 from plone import api
+from plone.base.utils import safe_text
 from plone.keyring.interfaces import IKeyManager
-from Products.CMFPlone.utils import safe_nativestring
 from Products.membrane.interfaces import IMembraneUserAuth
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
@@ -338,7 +338,7 @@ def authenticate(login, password):
     """
     if not login or not password:
         return None
-    password = safe_nativestring(password)
+    password = safe_text(password)
 
     login = login.lower()
     accounts = Session().query(model.Account).filter(model.Account.loginname == login)

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -11,9 +11,9 @@ from euphorie.content.survey import ISurvey
 from euphorie.content.utils import getRegionTitle
 from logging import getLogger
 from plone import api
+from plone.base.utils import safe_text
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from z3c.saconfig import Session
 from zExceptions import Unauthorized
@@ -335,7 +335,7 @@ class SessionBrowserNavigator(BrowserView):
             return ""
         if len(searchable_text) < 3:
             return ""
-        return f"%{safe_unicode(searchable_text)}%"
+        return f"%{safe_text(searchable_text)}%"
 
     @memoize
     def leaf_groups(self, groupid=None):

--- a/src/euphorie/client/browser/risk.py
+++ b/src/euphorie/client/browser/risk.py
@@ -23,12 +23,12 @@ from euphorie.content.utils import parse_scaled_answers
 from euphorie.htmllaundry.utils import strip_markup
 from io import BytesIO
 from plone import api
+from plone.base.utils import safe_text
 from plone.memoize.instance import memoize
 from plone.namedfile import NamedBlobImage
 from plone.namedfile.browser import DisplayFile
 from plone.scale.scale import scaleImage
 from Products.CMFPlone.utils import getAllowedSizes
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from sqlalchemy import and_
@@ -1146,7 +1146,7 @@ class ImageUpload(BrowserView):
                     return self.redirect()
                 self.context.image_data = new_data
                 self.context.image_data_scaled = None
-            new_name = safe_unicode(image.filename)
+            new_name = safe_text(image.filename)
             if self.context.image_filename != new_name:
                 self.context.image_filename = new_name
         elif self.request.form.get("image-remove"):

--- a/src/euphorie/client/browser/training.py
+++ b/src/euphorie/client/browser/training.py
@@ -12,9 +12,9 @@ from json import dumps
 from json import loads
 from logging import getLogger
 from plone import api
+from plone.base.utils import safe_text
 from plone.memoize.instance import memoize
 from plone.memoize.view import memoize as view_memoize
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from random import sample
 from random import shuffle
@@ -701,7 +701,7 @@ class SlideQuestion(SlideQuestionIntro):
         if not self.previous_question_id:
             self.initialize_training()
         training = self.get_or_create_training()
-        answer = safe_unicode(self.request.form["answer"])
+        answer = safe_text(self.request.form["answer"])
         answer_history = loads(training.answers)
         answer_history[self.question_id] = answer == self.question.right_answer
         training.answers = dumps(answer_history)

--- a/src/euphorie/client/docx/views.py
+++ b/src/euphorie/client/docx/views.py
@@ -12,8 +12,8 @@ from euphorie.content import MessageFactory as _
 from euphorie.content.survey import get_tool_type
 from io import BytesIO
 from plone import api
+from plone.base.utils import safe_text
 from plone.memoize.view import memoize
-from Products.CMFPlone.utils import safe_nativestring
 from Products.Five import BrowserView
 from sqlalchemy import sql
 from urllib.parse import quote
@@ -306,7 +306,7 @@ class ActionPlanDocxView(OfficeDocumentView):
             mapping={"title": self.context.session.title},
         )
         filename = translate(filename, context=self.request)
-        return safe_nativestring(filename) + ".docx"
+        return safe_text(filename) + ".docx"
 
 
 class ActionPlanShortDocxView(ActionPlanDocxView):
@@ -321,7 +321,7 @@ class ActionPlanShortDocxView(ActionPlanDocxView):
             mapping={"title": self.context.session.title},
         )
         filename = translate(filename, context=self.request)
-        return safe_nativestring(filename) + ".docx"
+        return safe_text(filename) + ".docx"
 
 
 class IdentificationReportDocxView(OfficeDocumentView):
@@ -362,4 +362,4 @@ class IdentificationReportDocxView(OfficeDocumentView):
             mapping=dict(title=self.context.session.title),
         )
         filename = translate(filename, context=self.request)
-        return safe_nativestring(filename) + ".docx"
+        return safe_text(filename) + ".docx"

--- a/src/euphorie/client/enum.py
+++ b/src/euphorie/client/enum.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from Products.CMFPlone.utils import safe_unicode
+from plone.base.utils import safe_text
 from sqlalchemy import types
 
 import uuid
@@ -91,14 +91,14 @@ class Enum(types.TypeDecorator):
         if value is None:
             return None
         else:
-            return safe_unicode(value)
+            return safe_text(value)
 
     def process_result_value(self, value, dialect):
         if value is None:
             return value
         if self.strict and value not in self.values:
             raise ValueError('"%s" not in Enum.values' % value)
-        return safe_unicode(value)
+        return safe_text(value)
 
 
 if __name__ == "__main__":

--- a/src/euphorie/client/mails/base.py
+++ b/src/euphorie/client/mails/base.py
@@ -7,10 +7,10 @@ from email.utils import formataddr
 from email.utils import formatdate
 from logging import getLogger
 from plone import api
+from plone.base.utils import safe_bytes
+from plone.base.utils import safe_text
 from plone.memoize.view import memoize
 from plone.rfc822.interfaces import IPrimaryFieldInfo
-from Products.CMFPlone.utils import safe_encode
-from Products.CMFPlone.utils import safe_nativestring
 from Products.Five import BrowserView
 from urllib.parse import quote
 
@@ -86,7 +86,7 @@ class BaseEmail(BrowserView):
         some zcml or with a plain python method.
         """
         html = markdown.markdown(self.index(), extensions=["nl2br"])
-        return safe_encode(stoneagehtml.compactify(html))
+        return safe_bytes(stoneagehtml.compactify(html))
 
     @property
     def text_email(self):
@@ -104,7 +104,7 @@ class BaseEmail(BrowserView):
             anchors.append(it["href"])
 
         text = "{}\n\n{}".format(
-            safe_nativestring(soup.get_text()),
+            safe_text(soup.get_text()),
             "\n".join(f"[{cnt + 1}] {it}" for cnt, it in enumerate(anchors)),
         )
 

--- a/src/euphorie/client/model.py
+++ b/src/euphorie/client/model.py
@@ -21,10 +21,9 @@ from euphorie.client.enum import Enum
 from OFS.interfaces import IApplication
 from plone import api
 from plone.app.event.base import localized_now
+from plone.base.utils import safe_text
 from plone.memoize import ram
 from plone.memoize.instance import memoize
-from Products.CMFPlone.utils import safe_nativestring
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from sqlalchemy import func
 from sqlalchemy import orm
@@ -629,7 +628,7 @@ class Account(BaseObject):
             return False
         if password == self.password:
             return True
-        password = safe_nativestring(password)
+        password = safe_text(password)
         return bcrypt.checkpw(password, self.password)
 
     def hash_password(self):
@@ -640,12 +639,12 @@ class Account(BaseObject):
             return
         if not password:
             return
-        password = safe_nativestring(password)
+        password = safe_text(password)
         if BCRYPTED_PATTERN.match(password):
             # The password is already encrypted, do not encrypt it again
             # XXX this is broken with passwords that are actually an hash
             return
-        self.password = safe_unicode(
+        self.password = safe_text(
             bcrypt.hashpw(
                 password,
                 bcrypt.gensalt(),
@@ -1249,10 +1248,7 @@ class SurveySession(BaseObject):
             return False
 
         return cls.zodb_path.in_(
-            {
-                safe_unicode("/".join(survey.getPhysicalPath()[-3:]))
-                for survey in surveys
-            }
+            {safe_text("/".join(survey.getPhysicalPath()[-3:])) for survey in surveys}
         )
 
     @property

--- a/src/euphorie/client/tests/stories/ChangeEmail.txt
+++ b/src/euphorie/client/tests/stories/ChangeEmail.txt
@@ -53,11 +53,11 @@ We should have received an email at jane@doe.name with a confirmation link:
 >>> str(mail_fixture.storage[0][0][1])
 'jane@doe.name'
 >>> mail_body=mail_fixture.storage[0][0][0].as_string()
->>> from Products.CMFPlone.utils import safe_nativestring
+>>> from plone.base.utils import safe_text
 >>> import quopri
 >>> import re
 >>> url=re.search('(http://nohost/plone/client/confirm.*)', mail_body).group()
->>> url = safe_nativestring(quopri.decodestring(url))
+>>> url = safe_text(quopri.decodestring(url))
 >>> url
 'http://nohost/plone/client/confirm-change?key=...'
 

--- a/src/euphorie/client/tests/test_risk.py
+++ b/src/euphorie/client/tests/test_risk.py
@@ -9,8 +9,8 @@ from euphorie.content.survey import Survey
 from euphorie.content.tests.utils import BASIC_SURVEY
 from euphorie.testing import EuphorieIntegrationTestCase
 from plone import api
+from plone.base.utils import safe_text
 from Products.CMFPlone.tests.dummy import Image
-from Products.CMFPlone.utils import safe_unicode
 from unittest import mock
 from zope.publisher.interfaces import NotFound
 
@@ -209,7 +209,7 @@ class TestRiskImageDownloadUpload(EuphorieIntegrationTestCase):
 
                 # Otherwise return the file
                 self.risk.image_data = Image.data
-                self.risk.image_filename = safe_unicode(Image.filename)
+                self.risk.image_filename = safe_text(Image.filename)
                 self.assertTrue(view().startswith(b"GIF"))
                 self.assertDictEqual(
                     view.request.response.headers,

--- a/src/euphorie/content/browser/export.py
+++ b/src/euphorie/content/browser/export.py
@@ -30,8 +30,8 @@ from lxml import etree
 from lxml import html
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
+from plone.base.utils import safe_bytes
 from plonetheme.nuplone.z3cform.directives import depends
-from Products.CMFPlone.utils import safe_bytes
 from z3c.form import button
 from z3c.form import form
 from zipfile import ZipFile

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -21,10 +21,10 @@ from euphorie.content.utils import IToolTypesInfo
 from io import BytesIO
 from markdownify import markdownify
 from plone.autoform.form import AutoExtensibleForm
+from plone.base.utils import safe_bytes
 from plone.dexterity.utils import createContentInContainer
 from plone.namedfile import field as filefield
 from plone.namedfile.file import NamedBlobImage
-from Products.CMFPlone.utils import safe_bytes
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form import button
 from z3c.form import form

--- a/src/euphorie/content/solution.py
+++ b/src/euphorie/content/solution.py
@@ -8,10 +8,10 @@ A standard Solution that a user can select for a particular risk.
 from .. import MessageFactory as _
 from euphorie.content import utils
 from plone.autoform import directives
+from plone.base.utils import safe_text
 from plone.dexterity.content import Item
 from plone.indexer import indexer
 from plone.supermodel import model
-from Products.CMFPlone.utils import safe_nativestring
 from zope import schema
 from zope.i18n import translate
 from zope.interface import implementer
@@ -124,7 +124,7 @@ class Solution(Item):
 
     def Title(self):
         survey = utils.getSurvey(self)
-        return safe_nativestring(
+        return safe_text(
             translate(
                 Solution.title, context=self.REQUEST, target_language=survey.language
             )

--- a/src/euphorie/content/tests/test_export.py
+++ b/src/euphorie/content/tests/test_export.py
@@ -10,7 +10,7 @@ from euphorie.content.training_question import TrainingQuestion
 from euphorie.testing import EuphorieIntegrationTestCase
 from io import BytesIO
 from lxml import etree
-from Products.CMFPlone.utils import safe_nativestring
+from plone.base.utils import safe_text
 from zipfile import ZipFile
 from zope.publisher.browser import TestRequest
 
@@ -34,7 +34,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportImage(root, image)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(node, pretty_print=True)),
+            safe_text(etree.tostring(node, pretty_print=True)),
             '<image xmlns="http://xml.simplon.biz/euphorie/survey/1.0">'
             "aG90IHN0dWZmIGhlcmU=\n</image>\n",
         )
@@ -46,7 +46,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view.include_images = True
         image = view.exportImage(root, image, "Captiøn")
         self.assertEqual(
-            safe_nativestring(etree.tostring(image, pretty_print=True)),
+            safe_text(etree.tostring(image, pretty_print=True)),
             '<image xmlns="http://xml.simplon.biz/euphorie/survey/1.0" '
             'content-type="image/gif" filename="test.gif" '
             'caption="Capti&#xF8;n">aG90IHN0dWZmIGhlcmU=\n'
@@ -63,7 +63,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportSolution(root, solution)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(node, pretty_print=True)),
+            safe_text(etree.tostring(node, pretty_print=True)),
             '<solution xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <description>&lt;p&gt;Test description&lt;/p&gt;"
             "</description>\n"
@@ -80,7 +80,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         node = view.exportSolution(root, solution)
         self.assertEqual(
-            safe_nativestring(etree.tostring(node, pretty_print=True)),
+            safe_text(etree.tostring(node, pretty_print=True)),
             '<solution xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <description>&lt;p&gt;T&#233;st description&lt;/p&gt;"
             "</description>\n"
@@ -102,7 +102,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportRisk(root, risk)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <risk type="top5">\n'
             "    <title>Can your windows be locked?</title>\n"
@@ -129,7 +129,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportRisk(root, risk)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <risk type="risk">\n'
             "    <title>Can your windows be locked?</title>\n"
@@ -160,7 +160,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportRisk(root, risk)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <risk type="risk">\n'
             "    <title>Can your windows be locked?</title>\n"
@@ -187,7 +187,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportRisk(root, risk)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <risk type="top5">\n'
             "    <title>Can your windows be locked?</title>\n"
@@ -217,7 +217,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view.include_images = True
         view.exportRisk(root, risk)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <risk type="top5">\n'
             "    <title>Can your windows be locked?</title>\n"
@@ -251,7 +251,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportRisk(root, risk)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <risk type="top5">\n'
             "    <title>Can your windows be locked?</title>\n"
@@ -281,7 +281,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportModule(root, module)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <module optional="false">\n'
             "    <title>Office buildings</title>\n"
@@ -298,7 +298,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         root = self.root()
         view = ExportSurvey(None, None)
         view.exportModule(root, module)
-        xml = safe_nativestring(etree.tostring(root, pretty_print=True))
+        xml = safe_text(etree.tostring(root, pretty_print=True))
         self.assertTrue(
             "<description>&lt;p&gt;Owning property brings risks."
             "&lt;/p&gt;</description>\n" in xml
@@ -315,7 +315,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportModule(root, module)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <module optional="true">\n'
             "    <title>Office buildings</title>\n"
@@ -336,7 +336,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportModule(root, module)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <module optional="false">\n'
             "    <title>Office buildings</title>\n"
@@ -358,7 +358,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view.include_images = True
         view.exportModule(root, module)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <module optional="false">\n'
             "    <title>Office buildings</title>\n"
@@ -388,7 +388,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportModule(root, module)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <module optional="false">\n'
             "    <title>Office buildings</title>\n"
@@ -422,7 +422,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportModule(root, module)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             '  <module optional="false">\n'
             "    <title>Office buildings</title>\n"
@@ -447,7 +447,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportProfileQuestion(root, profile)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"
@@ -471,7 +471,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportProfileQuestion(root, profile)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"
@@ -494,7 +494,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         root = self.root()
         view = ExportSurvey(None, None)
         view.exportProfileQuestion(root, profile)
-        xml = safe_nativestring(etree.tostring(root, pretty_print=True))
+        xml = safe_text(etree.tostring(root, pretty_print=True))
         self.assertTrue(
             "<description>&lt;p&gt;Owning property brings risks."
             "&lt;/p&gt;</description>" in xml
@@ -509,7 +509,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportProfileQuestion(root, profile)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"
@@ -538,7 +538,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportProfileQuestion(root, profile)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"
@@ -573,7 +573,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportProfileQuestion(root, profile)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"
@@ -601,7 +601,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportTrainingQuestion(root, training_question)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <training_question>\n"
             "    <title>What is the answer?</title>\n"
@@ -628,7 +628,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportSurvey(root, survey)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <survey>\n"
             "    <title>Generic sector</title>\n"
@@ -656,7 +656,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportSurvey(root, survey)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <survey>\n"
             "    <title>Generic sector</title>\n"
@@ -690,7 +690,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportSurvey(root, survey)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <survey>\n"
             "    <title>Generic sector</title>\n"
@@ -731,7 +731,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view = ExportSurvey(None, None)
         view.exportSurvey(root, survey)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <survey>\n"
             "    <title>Generic sector</title>\n"
@@ -848,7 +848,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportProfileQuestion(root, profile)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"
@@ -873,7 +873,7 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         node = view.exportProfileQuestion(root, profile)
         self.assertTrue(node in root)
         self.assertEqual(
-            safe_nativestring(etree.tostring(root, pretty_print=True)),
+            safe_text(etree.tostring(root, pretty_print=True)),
             '<root xmlns="http://xml.simplon.biz/euphorie/survey/1.0">\n'
             "  <profile-question>\n"
             "    <title>Office buildings</title>\n"

--- a/src/euphorie/content/utils.py
+++ b/src/euphorie/content/utils.py
@@ -4,10 +4,10 @@ from Acquisition import aq_parent
 from collections import OrderedDict
 from io import StringIO
 from plone import api
+from plone.base.utils import safe_text
 from plone.namedfile.interfaces import INamedBlobImage
 from plonetheme.nuplone import MessageFactory as NuPloneMessageFactory
 from plonetheme.nuplone.utils import checkPermission
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from zope.component import queryUtility
 from zope.i18nmessageid.message import Message
@@ -408,14 +408,14 @@ class UserExportCSV(BrowserView):
             sectors = [item for item in country.values() if ISector.providedBy(item)]
             for manager in managers:
                 data = dict(
-                    fullname=safe_unicode(manager.title).encode("utf-8"),
-                    email=safe_unicode(manager.contact_email).encode("utf-8"),
+                    fullname=safe_text(manager.title).encode("utf-8"),
+                    email=safe_text(manager.contact_email).encode("utf-8"),
                 )
                 writer.writerow(data)
             for sector in sectors:
                 data = dict(
-                    fullname=safe_unicode(sector.contact_name).encode("utf-8"),
-                    email=safe_unicode(sector.contact_email).encode("utf-8"),
+                    fullname=safe_text(sector.contact_name).encode("utf-8"),
+                    email=safe_text(sector.contact_email).encode("utf-8"),
                 )
                 writer.writerow(data)
         csv_data = buffer.getvalue()

--- a/src/euphorie/deployment/browser/search.py
+++ b/src/euphorie/deployment/browser/search.py
@@ -1,8 +1,8 @@
 from euphorie.content import MessageFactory as _
 from plone import api
+from plone.base.utils import safe_text
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
-from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 
 
@@ -54,7 +54,7 @@ class ContextSearch(BrowserView):
         if not qs:
             return
 
-        qs = f'"{safe_unicode(qs)}*"'
+        qs = f'"{safe_text(qs)}*"'
         path = "/".join(self.context.getPhysicalPath())
         query = {"SearchableText": qs, "portal_type": SEARCHED_TYPES, "path": path}
 

--- a/src/euphorie/deployment/commands/xmlimport.py
+++ b/src/euphorie/deployment/commands/xmlimport.py
@@ -5,8 +5,8 @@ from euphorie.client import publish
 from euphorie.content.upload import SurveyImporter
 from euphorie.content.user import UserProvider
 from optparse import OptionParser
+from plone.base.utils import safe_text
 from plone.namedfile.file import NamedBlobImage
-from Products.CMFPlone.utils import safe_unicode
 from Testing.makerequest import makerequest
 from zope.site import hooks
 
@@ -74,7 +74,7 @@ def GetSector(country, xml_sector, options):
     if options.logo is not None:
         sector.logo = NamedBlobImage(
             data=open(options.logo).read(),
-            filename=safe_unicode(os.path.basename(options.logo)),
+            filename=safe_text(os.path.basename(options.logo)),
         )
     if options.main_colour:
         sector.main_colour = options.main_colour

--- a/src/euphorie/deployment/tests/test_setup.py
+++ b/src/euphorie/deployment/tests/test_setup.py
@@ -1,6 +1,6 @@
 from euphorie.testing import EuphorieIntegrationTestCase
 from plone import api
-from Products.CMFPlone.utils import get_installer
+from plone.base.utils import get_installer
 from time import time
 
 


### PR DESCRIPTION
Some `safe_text` calls could be removed, but I think this is out of the scope for this PR.