### PR TITLE
#3384 shortcut create

### DIFF
--- a/news/3384.fix.rst
+++ b/news/3384.fix.rst
@@ -1,0 +1,1 @@
+When on the tools overview, there is no need to have the selection modal to pick a tool, because the users clicks the button from within the tool tile. Therefore we can skip the selection and create the chosen tool immediately.

--- a/src/euphorie/client/browser/templates/surveys.pt
+++ b/src/euphorie/client/browser/templates/surveys.pt
@@ -216,20 +216,32 @@
                     >Information</a>
                   </form>
 
-                  <p class="button-bar"
-                     tal:condition="not:is_anonymous"
+                  <form class="button-bar"
+                        action="${tool/absolute_url}/@@new-session.html#main"
+                        method="post"
+                        data-pat-inject="history: record"
+                        tal:condition="not:is_anonymous"
                   >
-                    <a class="default small pat-button pat-modal"
-                       href="${sector/absolute_url}/${tool_id}/@@new-session.html#document-content"
-                       data-pat-modal="class: panel small"
-                       i18n:translate="button_start_session"
-                    >Start risk assessment</a>
+                    <button class="default small pat-button focus"
+                            name="tool-button"
+                            type="submit"
+                            value="start-ra"
+                            i18n:translate="button_start_session"
+                    >Start risk assessment</button>
+                    <input name="survey"
+                           type="hidden"
+                           value="${tool_id}"
+                    />
+                    <input name="action"
+                           type="hidden"
+                           value="new"
+                    />
                     <a class="small pat-button pat-inject"
                        href="${tool/absolute_url}#content"
                        data-pat-inject="history: record"
                        i18n:translate="button_information"
                     >Information</a>
-                  </p>
+                  </form>
                 </div>
               </tal:tool>
             </div>


### PR DESCRIPTION
When on the tools overview, there is no need to have the selection modal, as users click the button from the tool tile. Therefore create immediately.