### PR TITLE
#3384 hide exit on dashboard

### DIFF
--- a/news/3384.fix.rst
+++ b/news/3384.fix.rst
@@ -1,0 +1,1 @@
+When the menu is opened from the dashboard, the exit action makes no sense (we only exit sessions). Added a check so that we can hide it.

--- a/src/euphorie/client/browser/templates/assessments.pt
+++ b/src/euphorie/client/browser/templates/assessments.pt
@@ -209,7 +209,7 @@
                       >Locked</a>
 
                       <a class="icon more-menu iconified icon-ellipsis pat-tooltip inactive"
-                         href="${session/absolute_url}/@@more_menu#more-menu"
+                         href="${session/absolute_url}/@@more_menu?from_dashboard#more-menu"
                          data-pat-tooltip="source: ajax; position-list: tr"
                          i18n:translate=""
                       >More</a>

--- a/src/euphorie/client/browser/templates/more_menu.pt
+++ b/src/euphorie/client/browser/templates/more_menu.pt
@@ -78,6 +78,7 @@
           <a class="pat-inject close-panel icon-cancel"
              href="${webhelpers/country_or_client_url}#content"
              data-pat-inject="history: record"
+             tal:condition="python:'from_dashboard' not in context.REQUEST.keys()"
              i18n:translate="label_exit"
           >Exit</a>
         </li>


### PR DESCRIPTION
When the menu is opened from the dashboard, the exit action makes no sense (we only exit sessions). Added a check so that we can hide it.