### PR TITLE
#3384 Add a check to the referrer if the menu is called from the dashboard.…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           ln -s versions-${{ matrix.config[2] }}.cfg versions.cfg
           bin/buildout -c .github.cfg
       - name: Pre commit
-        uses: pre-commit/action@v2.0.0
+        uses: pre-commit/action@v3.0.1
         if: ${{ matrix.config[1] == '3.12' }}
       - name: Test
         run: |

--- a/news/3384.fixed.rst
+++ b/news/3384.fixed.rst
@@ -1,0 +1,1 @@
+Add a check to the referrer if the menu is called from the dashboard. In that case, don't show the exit action.

--- a/src/euphorie/client/browser/templates/more_menu.pt
+++ b/src/euphorie/client/browser/templates/more_menu.pt
@@ -78,6 +78,7 @@
           <a class="pat-inject close-panel icon-cancel"
              href="${webhelpers/country_or_client_url}#content"
              data-pat-inject="history: record"
+             tal:condition="python:webhelpers.country_or_client_url != request.get('HTTP_REFERER', False)"
              i18n:translate="label_exit"
           >Exit</a>
         </li>


### PR DESCRIPTION
… In that case, don't show the exit action.

I used the referer as mentioned in https://github.com/euphorie/Euphorie/pull/829. 
I made a new pull request to keep the commit history a bit cleaner.  Hope that makes sense.
