### PR TITLE
#3384 consultancy

### DIFF
--- a/news/3384.added.rst
+++ b/news/3384.added.rst
@@ -1,0 +1,5 @@
+Added more guidelines for other use cases on the consultancy screen. Texts are only displayed to the right role.
+- The info that you can request consultancy is only for your own organisation. 
+- All external users cannot request validation, so they don't need to know about that when on the tool (and they are likely consultants anyway)
+- If user is consultant, inform that there is currently no validation requested. Otherwise the consultant keeps searching for work.
+

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -130,7 +130,7 @@
           </p>
         </tal:role_consultant>
 
-        <tal:comment tal:replace="nothing">The info about consultancy is only for your own organisation. All external users cannot request it, so they don't need it, and they are likely consultants anyway.</tal:comment>
+        <tal:comment tal:condition="nothing">The info about consultancy is only for your own organisation. All external users cannot request it, so they don't need it, and they are likely consultants anyway.</tal:comment>
         <ul class="link-list"
             tal:condition="not:external_user"
         >

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -19,6 +19,9 @@
              consultant context/session/consultancy/account|nothing;
              is_validated context/session/is_validated;
              current_user webhelpers/get_current_account;
+             current_user_organisation current_user/organisation;
+             current_session_organisation context/session/account/organisation;
+             external_user python: current_user_organisation != current_session_organisation;
              role_consultant python: consultant and current_user == consultant;
            "
       >
@@ -68,7 +71,7 @@
              tal:condition="python:consultant and not is_validated"
              i18n:translate="message_session_under_review"
           >
-				This risk assessment is currently under review by
+				    This risk assessment is currently under review by
             <a href="mailto:${consultant/email}"
                i18n:name="consultant"
             >${consultant/title}</a>.
@@ -93,7 +96,16 @@
           </div>
         </tal:role_user>
 
+        <tal:external_user tal:condition="python:external_user and not role_consultant">
+          <p class="pat-message notice"
+             i18n:translate="message_no_validation_requested"
+          >
+            No validation is requested at this time.
+          </p>
+        </tal:external_user>
+
         <tal:role_consultant tal:condition="role_consultant">
+          <!-- Current user is assigned consultant for this session -->
           <tal:not_validated tal:condition="not:is_validated">
             <p class="pat-message notice"
                i18n:translate="message_you_are_requested_to_validate_assessment"

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -36,8 +36,8 @@
           >
             Consultancy
           </h1>
-
-          <p tal:condition="not:role_consultant"
+          <tal:comment tal:replace="nothing">The info that you can request consultancy is only for your own organisation. All external users cannot request it, so they don't need it, and they are likely consultants anyway.</tal:comment>
+          <p tal:condition="not:external_user"
              i18n:translate="message_find_consultants"
           >
             It is possible to request assistance in completing a risk assessment or to have a risk analysis performed by you and validated by an OSH consultant. An OSH consultant can give your risk assessment an offical validation mark. A validation can only be requested by users with the permission level &lsquo;Manage&rsquo; or higher.
@@ -130,8 +130,9 @@
           </p>
         </tal:role_consultant>
 
+        <tal:comment tal:replace="nothing">The info about consultancy is only for your own organisation. All external users cannot request it, so they don't need it, and they are likely consultants anyway.</tal:comment>
         <ul class="link-list"
-            tal:condition="not:role_consultant"
+            tal:condition="not:external_user"
         >
           <li>
             <a class="pat-inject"

--- a/src/euphorie/client/browser/templates/consultancy.pt
+++ b/src/euphorie/client/browser/templates/consultancy.pt
@@ -36,7 +36,7 @@
           >
             Consultancy
           </h1>
-          <tal:comment tal:replace="nothing">The info that you can request consultancy is only for your own organisation. All external users cannot request it, so they don't need it, and they are likely consultants anyway.</tal:comment>
+          <tal:comment tal:condition="nothing">The info that you can request consultancy is only for your own organisation. All external users cannot request it, so they don't need it, and they are likely consultants anyway.</tal:comment>
           <p tal:condition="not:external_user"
              i18n:translate="message_find_consultants"
           >

--- a/src/euphorie/deployment/locales/euphorie.pot
+++ b/src/euphorie/deployment/locales/euphorie.pot
@@ -5298,6 +5298,10 @@ msgstr ""
 msgid "message_request_validation"
 msgstr ""
 
+#. Default: "No validation is requested at this time."
+msgid "message_no_validation_requested"
+msgstr ""
+
 #. Default: "Administrators can create, edit and remove user accounts. Administrators can also make risk assessments and edit existing ones, lock risk assessments, create trainings and take trainings."
 #: euphorie/client/browser/templates/panel-add-user-to-organisation.pt:55
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:70

--- a/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl/LC_MESSAGES/euphorie.po
@@ -5904,7 +5904,13 @@ msgstr ""
 "Klik op 'Validatieverzoek verzenden' om de geselecteerde OSH-consultant te "
 "vragen je risicoanalyse te beoordelen en te valideren."
 
-#. Default: "Administrators can create, edit and remove user accounts. Administrators can also make risk assessments and edit existing ones, lock risk assessments, create trainings and take trainings."
+#. Default: "No validation is requested at this time."
+msgid "message_no_validation_requested"
+msgstr "Op dit moment is er geen validatie vereist."
+
+#. Default: "Administrators can create, edit and remove user accounts.
+#. Administrators can also make risk assessments and edit existing ones, lock
+#. risk assessments, create trainings and take trainings."
 #: euphorie/client/browser/templates/panel-add-user-to-organisation.pt:55
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:70
 msgid "message_role_administrator"

--- a/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
+++ b/src/euphorie/deployment/locales/nl_BE/LC_MESSAGES/euphorie.po
@@ -5935,7 +5935,13 @@ msgstr ""
 "Klik op 'Validatieverzoek verzenden' om de geselecteerde OSH-consultant te "
 "vragen je risicoanalyse te beoordelen en te valideren."
 
-#. Default: "Administrators can create, edit and remove user accounts. Administrators can also make risk assessments and edit existing ones, lock risk assessments, create trainings and take trainings."
+#. Default: "No validation is requested at this time."
+msgid "message_no_validation_requested"
+msgstr "Op dit moment is er geen validatie vereist."
+
+#. Default: "Administrators can create, edit and remove user accounts.
+#. Administrators can also make risk assessments and edit existing ones, lock
+#. risk assessments, create trainings and take trainings."
 #: euphorie/client/browser/templates/panel-add-user-to-organisation.pt:55
 #: euphorie/client/browser/templates/panel-organisation-member-edit.pt:70
 msgid "message_role_administrator"


### PR DESCRIPTION
Show info on the consultancy view depending on the role of the user.
External users (consultants) don't need to know about the consultancy feature but they need to know if there is work for them to do or not at the moment.