### PR TITLE
Change the logo widget

### DIFF
--- a/news/+16ff4214.breaking.rst
+++ b/news/+16ff4214.breaking.rst
@@ -1,0 +1,4 @@
+Change the logo widget
+
+Do not use anymore the logo widget because the help text is not updated anymore.
+Update the field help text.

--- a/src/euphorie/content/sector.py
+++ b/src/euphorie/content/sector.py
@@ -67,16 +67,18 @@ class ISector(model.Schema, IUser, IBasic):
 
     directives.order_after(contact_email="contact_name")
 
-    directives.widget(
-        logo="euphorie.content.widgets.logo.LogoFieldWidget",
-    )
     logo = filefield.NamedBlobImage(
         title=_("label_logo", default="Logo"),
         description=_(
             "help_image_upload",
-            default="Upload an image. Make sure your image is of format "
-            "png, jpg or gif and does not contain any special "
-            "characters. The minimum size is 1000 (width) x 430 (height) pixels.",
+            default=(
+                "The logo will appear on the sector overview page of your country. "
+                "Make sure your image is of format png, jpg or gif and "
+                "does not contain any special characters. "
+                "The new logo will only become visible after "
+                "you have saved your changes and "
+                "published the OiRA tool."
+            ),
         ),
         required=False,
     )

--- a/src/euphorie/content/widgets/logo.py
+++ b/src/euphorie/content/widgets/logo.py
@@ -1,10 +1,11 @@
-from plone.formwidget.namedfile.widget import NamedImageWidget
-from z3c.form.widget import FieldWidget
+from zope.deferredimport import deprecated
 
 
-class LogoWidget(NamedImageWidget):
-    pass
-
-
-def LogoFieldWidget(field, request):
-    return FieldWidget(field, LogoWidget(request))
+deprecated(
+    (
+        "It will be removed in future versions. "
+        "Please use the regular image widget instead."
+    ),
+    LogoWidget="euphorie.content.widgets.logo_bbb:LogoWidget",
+    LogoFieldWidget="euphorie.content.widgets.logo_bbb:LogoFieldWidget",
+)

--- a/src/euphorie/content/widgets/logo_bbb.py
+++ b/src/euphorie/content/widgets/logo_bbb.py
@@ -1,0 +1,10 @@
+from plone.formwidget.namedfile.widget import NamedImageWidget
+from z3c.form.widget import FieldWidget
+
+
+class LogoWidget(NamedImageWidget):
+    pass
+
+
+def LogoFieldWidget(field, request):
+    return FieldWidget(field, LogoWidget(request))

--- a/src/euphorie/content/widgets/templates/logo.pt
+++ b/src/euphorie/content/widgets/templates/logo.pt
@@ -1,3 +1,7 @@
+<tal:comment condition="nothing">
+  This template will soon be removed.
+  Use the regular image widget instead.
+</tal:comment>
 <fieldset class="concise">
   <p class="legend"
      i18n:translate="label_logo"


### PR DESCRIPTION
Do not use anymore the logo widget because the help text is not updated anymore. Update the field help text.

Refs. https://github.com/syslabcom/scrum/issues/3061