### PR TITLE
Fix missing i18n:name that was preventing a translation to happen

### DIFF
--- a/news/844.bugfix.rst
+++ b/news/844.bugfix.rst
@@ -1,0 +1,1 @@
+Fix missing i18n:name that was preventing a translation to happen

--- a/src/euphorie/client/browser/templates/portlet-my-ras.pt
+++ b/src/euphorie/client/browser/templates/portlet-my-ras.pt
@@ -110,6 +110,7 @@
               <a class="pat-modal"
                  href="${here/absolute_url}/@@new-session.html#document-content"
                  data-pat-modal="class: panel medium"
+                 i18n:name="start_session"
               >${view/label_start_session}</a>
             </p>
             <p class="pat-message info"


### PR DESCRIPTION
Refs. https://github.com/syslabcom/scrum/issues/3475

Without this patch:
![image](https://github.com/user-attachments/assets/6dd3aa40-14f3-473c-87cb-ca994c16d847)

With this path:
![image](https://github.com/user-attachments/assets/88346c30-9850-4633-8be3-2b2bb353fd76)
