### PR TITLE
Allow backend users in client, take two

### DIFF
--- a/src/euphorie/client/authentication.py
+++ b/src/euphorie/client/authentication.py
@@ -328,24 +328,7 @@ class EuphorieAccountPlugin(BasePlugin):
         )
 
         if not sql_account:
-            # sql_account = self._create_account(email, credentials.get("password"))
-            password = credentials.get("password")
-            if not password:
-                # We need to store a password, but when the credentials were
-                # extracted by plone.session we do not have it. So create one.
-                reg = api.portal.get_tool(name="portal_registration")
-                password = reg.generatePassword()
-                log.debug("Generated password %r for user %r.", password, email)
-            sql_account = model.Account(
-                loginname=email,
-                tc_approved=1,
-                password=password,
-                account_type=config.FULL_ACCOUNT,
-            )
-            sa_session.add(sql_account)
-            # We flush the session, otherwise the account has no id yet.
-            sa_session.flush()
-            log.info("An SQL account %r was created for user %r.", email, login)
+            return
 
         return sql_account.id, email
 

--- a/src/euphorie/client/browser/publish.py
+++ b/src/euphorie/client/browser/publish.py
@@ -11,6 +11,7 @@ from euphorie.client import MessageFactory as _
 from euphorie.content.interfaces import ICustomRisksModule
 from euphorie.content.interfaces import ObjectPublishedEvent
 from euphorie.content.utils import IToolTypesInfo
+from euphorie.content.utils import survey_client_url
 from plone import api
 from plone.scale.storage import AnnotationStorage
 from plonetheme.nuplone.utils import getPortal
@@ -273,17 +274,7 @@ class PublishSurvey(form.Form):
 
     def client_url(self):
         """Return the URL this survey will have after it is published."""
-        client_url = api.portal.get_registry_record("euphorie.client_url", default="")
-        if client_url:
-            client_url = client_url.rstrip("/")
-        else:
-            client_url = getPortal(self.context).client.absolute_url()
-
-        source = aq_inner(self.context)
-        surveygroup = aq_parent(source)
-        sector = aq_parent(surveygroup)
-        country = aq_parent(sector)
-        return "/".join([client_url, country.id, sector.id, surveygroup.id])
+        return survey_client_url(aq_inner(self.context))
 
     @button.buttonAndHandler(_("button_cancel", default="Cancel"))
     def handleCancel(self, action):
@@ -337,18 +328,7 @@ class PreviewSurvey(form.Form):
 
     def preview_url(self):
         """Return the URL the preview will have."""
-        client_url = api.portal.get_registry_record("euphorie.client_url", default="")
-        if client_url:
-            client_url = client_url.rstrip("/")
-        else:
-            client_url = getPortal(self.context).client.absolute_url()
-
-        source = aq_inner(self.context)
-        surveygroup = aq_parent(source)
-        sector = aq_parent(surveygroup)
-        country = aq_parent(sector)
-
-        return "/".join([client_url, country.id, sector.id, "preview"])
+        return survey_client_url(aq_inner(self.context), preview=True)
 
     @button.buttonAndHandler(_("button_cancel", default="Cancel"))
     def handleCancel(self, action):

--- a/src/euphorie/content/browser/configure.zcml
+++ b/src/euphorie/content/browser/configure.zcml
@@ -461,6 +461,14 @@
       />
 
   <browser:page
+      name="create-client-account"
+      for="*"
+      class=".user.CreateClientAccount"
+      permission="zope2.View"
+      layer="plonetheme.nuplone.skin.interfaces.NuPloneSkin"
+      />
+
+  <browser:page
       name="similar-titles"
       for="*"
       class=".similar_titles.SimilarTitles"

--- a/src/euphorie/content/browser/user.py
+++ b/src/euphorie/content/browser/user.py
@@ -1,10 +1,19 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from euphorie.client import config
+from euphorie.client import model
+from euphorie.client.interfaces import IClientSkinLayer
 from euphorie.content import MessageFactory as _
 from plone import api
 from Products.Five import BrowserView
+from z3c.saconfig import Session
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
+
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class Lock(BrowserView):
@@ -46,3 +55,77 @@ class Lock(BrowserView):
 
         country = aq_parent(aq_inner(self.context))
         self.request.response.redirect("%s/@@manage-users" % country.absolute_url())
+
+
+class CreateClientAccount(BrowserView):
+    """Create client account for current backend user.
+
+    View name: @@create-client-account
+    """
+
+    def __call__(self):
+        if IClientSkinLayer.providedBy(self.request):
+            # This can only be called on the backend.
+            raise Unauthorized
+        if self.request.method != "POST":
+            raise Unauthorized
+        authenticator = getMultiAdapter(
+            (self.context, self.request), name="authenticator"
+        )
+        if not authenticator.verify():
+            raise Unauthorized
+        if api.user.is_anonymous():
+            raise Unauthorized
+
+        # Check if user has an email address.
+        user = api.user.get_current()
+        email = user.getProperty("email")
+        if not email:
+            api.portal.show_message(
+                message=_("Please set an email address first."),
+                request=self.request,
+                type="error",
+            )
+            portal_url = api.portal.get().absolute_url()
+            self.request.response.redirect(f"{portal_url}/@@settings")
+            return
+
+        # From here on, we always want to redirect to the current context at the end.
+        self.request.response.redirect(self.context.absolute_url())
+
+        # Check for existing account.
+        sa_session = Session()
+        sql_account = (
+            sa_session.query(model.Account)
+            .filter(model.Account.loginname == email)
+            .first()
+        )
+        if sql_account:
+            api.portal.show_message(
+                _(
+                    "message_user_unlocked",
+                    default="A client account for ${email} already exists.",
+                    mapping=dict(
+                        email=email,
+                    ),
+                ),
+                request=self.request,
+                type="warn",
+            )
+
+        else:
+            # Generate random password.
+            reg = api.portal.get_tool(name="portal_registration")
+            password = reg.generatePassword()
+            logger.info("Generated password %r for user %r.", password, email)
+            sql_account = model.Account(
+                loginname=email,
+                tc_approved=1,
+                password=password,
+                account_type=config.FULL_ACCOUNT,
+            )
+            sa_session.add(sql_account)
+            api.portal.show_message(
+                message=_("A client account was created."), request=self.request
+            )
+        return "done"

--- a/src/euphorie/deployment/tiles/templates/versions.pt
+++ b/src/euphorie/deployment/tiles/templates/versions.pt
@@ -17,28 +17,21 @@
   <div class="portletContent">
 
     <div class="to_client">
-      <h5 i18n:translate="header_legend">Client</h5>
-      <ul class="legend">
-        <li class="published"
-            i18n:translate="legend_published"
-        ><em class="sample published"
-              i18n:name="label"
-              i18n:translate="label_published"
-          >Published</em>
-          Version that is currently online</li>
-        <li class="current"
-            i18n:translate="legend_current"
-        ><em class="sample current"
-              i18n:name="label"
-              i18n:translate="label_current"
-          >Current</em>
-          Version you are currently reviewing</li>
+      <h5 i18n:translate="header_client">Client</h5>
+      <ul>
+        <li tal:condition="view/published_url|nothing">
+          <a href="${view/published_url}"
+             target="_blank"
+             i18n:translate=""
+          >Go to current online version</a>
+        </li>
+        <li tal:condition="view/preview_url|nothing">
+          <a href="${view/preview_url}"
+             target="_blank"
+             i18n:translate=""
+          >Go to current preview version</a>
+        </li>
       </ul>
-      <p i18n:translate="legend_updated"><em class="button icon upload"
-            i18n:name="label"
-            i18n:translate="label_update"
-        >Update</em>
-        = This version has changes that are currently unpublished. Click the update icon to bring all the changes live</p>
     </div>
 
     <form action="${group/url}/@@version-command"

--- a/src/euphorie/deployment/tiles/templates/versions.pt
+++ b/src/euphorie/deployment/tiles/templates/versions.pt
@@ -15,6 +15,32 @@
   <h3 i18n:translate="portlet_header_versions">Versions</h3>
 
   <div class="portletContent">
+
+    <div class="to_client">
+      <h5 i18n:translate="header_legend">Client</h5>
+      <ul class="legend">
+        <li class="published"
+            i18n:translate="legend_published"
+        ><em class="sample published"
+              i18n:name="label"
+              i18n:translate="label_published"
+          >Published</em>
+          Version that is currently online</li>
+        <li class="current"
+            i18n:translate="legend_current"
+        ><em class="sample current"
+              i18n:name="label"
+              i18n:translate="label_current"
+          >Current</em>
+          Version you are currently reviewing</li>
+      </ul>
+      <p i18n:translate="legend_updated"><em class="button icon upload"
+            i18n:name="label"
+            i18n:translate="label_update"
+        >Update</em>
+        = This version has changes that are currently unpublished. Click the update icon to bring all the changes live</p>
+    </div>
+
     <form action="${group/url}/@@version-command"
           method="post"
           tal:repeat="group view/surveys"

--- a/src/euphorie/deployment/tiles/templates/versions.pt
+++ b/src/euphorie/deployment/tiles/templates/versions.pt
@@ -19,6 +19,16 @@
     <div class="to_client">
       <h5 i18n:translate="header_client">Client</h5>
       <ul>
+        <li>
+          <form action="${context/absolute_url}/@@create-client-account"
+                method="post"
+          >
+            <button class="micro"
+                    type="submit"
+                    i18n:translate="button_create_client_account"
+            >Create client account with your email address</button>
+          </form>
+        </li>
         <li tal:condition="view/published_url|nothing">
           <a href="${view/published_url}"
              target="_blank"

--- a/src/euphorie/deployment/tiles/versions.py
+++ b/src/euphorie/deployment/tiles/versions.py
@@ -2,11 +2,21 @@ from Acquisition import aq_chain
 from Acquisition import aq_inner
 from euphorie.content.sector import getSurveys
 from euphorie.content.sector import ISector
+from euphorie.content.utils import survey_client_url
+from functools import cached_property
 from plone.tiles import Tile
 from plonetheme.nuplone.utils import checkPermission
 
 
 class SurveyVersions(Tile):
+    @cached_property
+    def published_url(self):
+        return survey_client_url(self.context, must_exist=True)
+
+    @cached_property
+    def preview_url(self):
+        return survey_client_url(self.context, must_exist=True, preview=True)
+
     def update(self):
         for sector in aq_chain(aq_inner(self.context)):
             if ISector.providedBy(sector):


### PR DESCRIPTION
This builds on PR #857.

I need to fix tests, but it seems to work.

It would be interesting if we could put this on a test server where LDAP is available, and where we have an LDAP account to test with.  From what I see in OSHA, LDAP users login with their email address, so I wonder if that works as expected here.

With this PR, we do not create an SQL account on login.  Instead, a backend user must explicitly click a button to create such an account.

For now, I have added a button and links in the "versions tile":

<img width="401" alt="Screenshot 2025-06-21 at 01 55 22" src="https://github.com/user-attachments/assets/a17f0aed-6987-4c3e-99bc-a1bdf831a9ba" />

We can move this somewhere else, and we could hide the button if an account already exists, but for now this gets the job done, so it can be tested.

I tested this locally by accessing the backend at 127.0.0.1, and defining the client_url as localhost.

I also started two zeo clients, but that is optional.  I accessed the backend at 127.0.0.1:9660 (zeoclient 1) and the client at localhost:7777 (zeoclient 2).  Then in the terminal where zeoclient2 was running, I would be sure that only client requests were handled.  That can be useful.

So if this approach sounds reasonable, it could be good to test it on a server with LDAP first, as I indicate above.  If that works, then we can polish the code.