### PR TITLE
Support Plone 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         "weasyprint",
         "z3c.form",
         "z3c.saconfig",
-        "z3c.schema",
         "zope.configuration",
         "zope.i18nmessageid",
         "zope.interface",

--- a/src/euphorie/client/browser/settings.py
+++ b/src/euphorie/client/browser/settings.py
@@ -19,6 +19,7 @@ from plone.autoform import directives
 from plone.autoform.form import AutoExtensibleForm
 from plone.memoize.instance import memoize
 from plone.protect.interfaces import IDisableCSRFProtection
+from plone.schema import Email
 from plone.supermodel import model
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
@@ -30,7 +31,6 @@ from z3c.form import button
 from z3c.form import form
 from z3c.form.interfaces import WidgetActionExecutionError
 from z3c.saconfig import Session
-from z3c.schema.email import RFC822MailAddress
 from zope import schema
 from zope.component import getAdapters
 from zope.i18n import translate
@@ -119,7 +119,7 @@ class AccountDeleteSchema(model.Schema):
 
 
 class EmailChangeSchema(model.Schema):
-    loginname = RFC822MailAddress(title=_("Email address/account name"), required=True)
+    loginname = Email(title=_("Email address/account name"), required=True)
     directives.widget("loginname", type="email")
 
     password = schema.Password(title=_("Your password for confirmation"), required=True)

--- a/src/euphorie/client/tests/test_settings.py
+++ b/src/euphorie/client/tests/test_settings.py
@@ -144,12 +144,12 @@ class NewEmailTests(EuphorieFunctionalTestCase):
 
     def testInvalidEmail(self):
         browser = self.browser
-        browser.open("http://nohost/plone/client/nl/new-email")
+        browser.open("http://nohost/plone/client/nl/new-email?set_language=en")
         browser.getControl(name="form.widgets.password").value = "Guest12345#!"
         browser.getControl(name="form.widgets.loginname").value = "one two"
         browser.getControl(name="form.buttons.save").click()
         self.assertEqual(browser.url, "http://nohost/plone/client/nl/new-email")
-        self.assertTrue("Not a valid email address" in browser.contents)
+        self.assertTrue("The specified email is not valid" in browser.contents)
 
     def testDuplicateEmail(self):
         browser = self.browser

--- a/versions-6.1.cfg
+++ b/versions-6.1.cfg
@@ -3,7 +3,7 @@ extends = https://dist.plone.org/release/6.1-latest/versions.cfg
 allow-picked-versions = true
 
 [versions]
-NuPlone = 4.0.1
+NuPlone = 4.0.2
 
 
 alembic = 1.15.1
@@ -52,9 +52,8 @@ ua-parser-builtins = 0.18.0.post1
 user-agents = 2.2.0
 weasyprint = 64.1
 webencodings = 0.5.1
-z3c.ptcompat = 4.0
-z3c.saconfig = 1.0
-z3c.schema = 2.0
+z3c.ptcompat = 5.0
+z3c.saconfig = 2.0
 zope.sqlalchemy = 3.1
 zopfli = 0.2.3.post1
 


### PR DESCRIPTION
Remove dependency from the obsolete package z3c.schema

This also makes the email fields consistent across the forms (they all use `plone.schema.Email` now).