### PR TITLE
Email reminder: Fix nav entry name

### DIFF
--- a/src/euphorie/client/browser/webhelpers.py
+++ b/src/euphorie/client/browser/webhelpers.py
@@ -1547,7 +1547,7 @@ class WebHelpers(BrowserView):
                     "disabled": disabled,
                     "class": f'{"active" if active else ""} {"disabled" if disabled else ""}',  # noqa: E501
                     "id": "reminder",
-                    "name": "involve",
+                    "name": "reminder",
                     "href": f"{url}/@@email-reminder#content",
                     "title": api.portal.translate(
                         _("navigation_email_reminder", default="Email reminder")


### PR DESCRIPTION
Needs design, something like

```
#steps>li>a.reminder:not(.onscreen-help):before {
    content:"\e894";
}
```

Ref syslabcom/scrum#3238