### PR TITLE
Survey upload: check for errors before handling upload.

### DIFF
--- a/news/+000f5356.bugfix.rst
+++ b/news/+000f5356.bugfix.rst
@@ -1,0 +1,1 @@
+Survey upload: check for errors before handling upload.

--- a/src/euphorie/content/browser/upload.py
+++ b/src/euphorie/content/browser/upload.py
@@ -573,6 +573,8 @@ class ImportSurvey(AutoExtensibleForm, form.Form):
     @button.buttonAndHandler(_("Upload"))
     def handleUpload(self, action):
         (data, errors) = self.extractData()
+        if errors:
+            return
         input = data["file"].data
         importer = self.importer_factory(self.context)
         try:


### PR DESCRIPTION
Otherwise you get an error when you leave the file blank:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 181, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 390, in publish_module
  Module ZPublisher.WSGIPublisher, line 284, in publish
  Module ZPublisher.mapply, line 98, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module z3c.form.form, line 238, in __call__
  Module plone.z3cform.fieldsets.extensible, line 62, in update
  Module plone.z3cform.patch, line 31, in GroupForm_update
  Module z3c.form.group, line 146, in update
  Module plone.app.z3cform.csrf, line 21, in execute
  Module z3c.form.action, line 99, in execute
  Module z3c.form.button, line 312, in __call__
  Module z3c.form.button, line 167, in __call__
  Module euphorie.content.browser.upload, line 576, in handleUpload
KeyError: 'file'
```