### PR TITLE
Fix error when creating backend user.

### DIFF
--- a/src/euphorie/client/authentication.py
+++ b/src/euphorie/client/authentication.py
@@ -26,6 +26,7 @@ from Products.PluggableAuthService.utils import classImplements
 from urllib.parse import urlencode
 from z3c.saconfig import Session
 from zope.component import getUtility
+from zope.globalrequest import getRequest
 from zope.publisher.interfaces.browser import IBrowserView
 
 import hashlib
@@ -214,7 +215,9 @@ class EuphorieAccountPlugin(BasePlugin):
         # a case, query like `get(user_id)` matches the 'id' column in Account
         # first. If the loginname that is an integer also corresponds to an id
         # in the Account table, we would find the wrong user.
-        if not IClientSkinLayer.providedBy(self.REQUEST):
+        request = getattr(self, "REQUEST", None) or getRequest()
+        if not IClientSkinLayer.providedBy(request):
+            # For example: a standard Plone user is being created on the backend.
             return None
         if not name:
             return (


### PR DESCRIPTION
I tried creating a user via `@@new-user` and got an error because our PAS plugin was immediately trying to create a client-side user in SQL:

```
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/cp311/plone.app.users-3.1.3-py3.11.egg/plone/app/users/browser/register.py", line 427, in handle_join_success
    registration.addMember(user_id, password, REQUEST=self.request)
  File "/Users/maurits/shared-eggs/cp311/Products.CMFCore-3.7-py3.11.egg/Products/CMFCore/RegistrationTool.py", line 161, in addMember
    mtool.addMember(id, password, roles, domains, properties)
  File "/Users/maurits/shared-eggs/cp311/Products.PlonePAS-8.0.5-py3.11.egg/Products/PlonePAS/tools/membership.py", line 140, in addMember
    acl_users._doAddUser(id, password, roles, domains)
  File "/Users/maurits/shared-eggs/cp311/Products.PlonePAS-8.0.5-py3.11.egg/Products/PlonePAS/pas.py", line 92, in _doAddUser
    retval = _old_doAddUser(login, password, roles, domains)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maurits/shared-eggs/cp311/Products.PluggableAuthService-3.0-py3.11.egg/Products/PluggableAuthService/PluggableAuthService.py", line 917, in _doAddUser
    user = self.getUser(login)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/maurits/shared-eggs/cp311/Products.PluggableAuthService-3.0-py3.11.egg/Products/PluggableAuthService/PluggableAuthService.py", line 216, in getUser
    return self._findUser(plugins, user_info['id'], user_info['login'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maurits/shared-eggs/cp311/Products.PluggableAuthService-3.0-py3.11.egg/Products/PluggableAuthService/PluggableAuthService.py", line 718, in _findUser
    user = self._createUser(plugins, user_id, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maurits/shared-eggs/cp311/Products.PluggableAuthService-3.0-py3.11.egg/Products/PluggableAuthService/PluggableAuthService.py", line 695, in _createUser
    user = factory.createUser(user_id, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maurits/syslab/quoira/oira/src/Euphorie/src/euphorie/client/authentication.py", line 90, in wrapper
    value = func(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maurits/syslab/quoira/oira/src/Euphorie/src/euphorie/client/authentication.py", line 217, in createUser
    if not IClientSkinLayer.providedBy(self.REQUEST):
                                       ^^^^^^^^^^^^
AttributeError: REQUEST
```

With a pdb:

```
(Pdb) pp aq_chain(self)
[
│   <EuphorieAccountPlugin at /Plone/acl_users/euphorie>,
│   <PluggableAuthService at /Plone/acl_users used for /Plone/portal_membership>,
│   <MembershipTool at /Plone/portal_membership>,
│   <PloneSite at /Plone>,
│   <Application at >
]
(Pdb) aq_chain(self)[-1]
<Application at >
(Pdb) aq_chain(self)[-1].REQUEST
'<Special Object Used to Force Acquisition>'
(Pdb) aq_chain(self)[-2].REQUEST
*** AttributeError: REQUEST
```

Let's use `getRequest` when the REQUEST cannot be found in the expected way. This is not on a client skin request, so the method will return None anyway.