### PR TITLE
Fix auto csrf protection for SQLAlchemy objects.

### DIFF
--- a/src/euphorie/content/protect.py
+++ b/src/euphorie/content/protect.py
@@ -1,17 +1,99 @@
 from plone.protect.auto import ProtectTransform
+from zope.interface import Interface
 from zope.sqlalchemy.datamanager import SessionDataManager
 
 
+class IDisableCSRFProtectionForSQL(Interface):
+    """Marker interface: disable auto CSRF on SQL objects in a request"""
+
+
 class EuphorieProtectTransform(ProtectTransform):
+    """plone.protect auto CSRF transform for Euphorie.
+
+    The standard Plone auto CSRF protection works fine for standard Plone
+    objects, but it ignores changes in SQLAlchemy items.
+    This override adds such protection, but detecting changed SQLALchemy
+    items, and adding them to the list of 'registered' Plone items that are
+    changed by this transaction.
+
+    These changes can be found in the session, in one of the attributes
+    'dirty', 'new', 'deleted'.  For example 'dirty' may be:
+
+        IdentitySet([<euphorie.client.model.SurveySession object at ...>])
+
+    But when a flush of the session has happened, the changes from before the
+    flush are not on the session, but are hidden in a transaction object,
+    which is different:
+
+        (Pdb) resource.tx._dirty
+        <WeakKeyDictionary at 0x14aaaf390>
+        (Pdb) !list(resource.tx._dirty)
+        [<sqlalchemy.orm.state.InstanceState object at 0x14a7af410>]
+        (Pdb) state = list(resource.tx._dirty)[0]
+        (Pdb) state
+        <sqlalchemy.orm.state.InstanceState object at 0x14a7af410>
+        (Pdb) state.obj
+        <weakref at 0x14ad29670; to 'SurveySession' at 0x14a7afcd0>
+        (Pdb) state.obj()
+        <euphorie.client.model.SurveySession object at 0x14a7afcd0>
+
+    It should be fine to just add the InstanceState objects from the weak
+    dictionary to the 'registered' list.  If anything is in this list on a
+    GET request, we will get redirected to the confirm-action view.
+
+    But it would be nice to add the actual SQLAlchemy items: they may have
+    been marked by `plone.protect.auto.safeWrite`.
+
+    Problem though: safeWrite fails when the object has no `_p_oid`.
+    And if you would change that function, you would still need to change
+    the `_check` method of the transform as it has this check:
+
+        if getattr(obj, "_p_oid", False) in safe_oids:
+            continue
+
+    We could create our own safeSQLWrite function and let this store for
+    example the `id(sql_object)` in a similar safe_oids list in the request or
+    maybe the session object.  Then check this list of safe identitites below
+    in our `_registered_objects` method: if an item is in the list, don't add
+    it to the `registered` list.
+
+    But if you get the same sql_object by doing a new query, its identity will
+    be different, so this would not work.  Maybe safeSQLWrite could write
+    the model name and the primary key.  But then we would need to figure
+    out which field per model is the primary key.  Could be doable.
+
+    Simpler would be to add a variant of IDisableCSRFProtection specific for
+    SQLAlchemy items.  If that marker interface is set, we would only return
+    the `_registered_objects` of our super class, without checking for SQL
+    items.  That seems simple enough.  And I think this might be needed in a
+    few cases, at least temporarily: there may be some existing cases of a
+    valid write-on-GET that worked so far, but that would break with our
+    restored csrf protection.
+
+    One more note of warning:: on the client side I get a Forbidden when I
+    get redirected to the confirm-action view.  We may need some changes there.
+    """
+
+    def _get_real_objects(self, tx, name):
+        return [state.obj() for state in getattr(tx, name, [])]
+
     def _registered_objects(self):
         registered = super()._registered_objects()
+        if IDisableCSRFProtectionForSQL.providedBy(self.request):
+            return registered
+
         app = self.request.PARENTS[-1]
         for name, conn in app._p_jar.connections.items():
             if name == "temporary":
                 continue
             for resource in conn.transaction_manager.get()._resources:
                 if isinstance(resource, SessionDataManager):
+                    # Get changed, new, and deleted items from the session.
                     registered.extend(resource.session.dirty)
                     registered.extend(resource.session.new)
                     registered.extend(resource.session.deleted)
+                    # Get changes that have been flushed already.
+                    for attr in ("_dirty", "_new", "_deleted"):
+                        registered.extend(self._get_real_objects(resource.tx, attr))
+
         return registered

--- a/src/euphorie/content/tests/test_protect.py
+++ b/src/euphorie/content/tests/test_protect.py
@@ -1,0 +1,179 @@
+from euphorie.testing import EuphorieFunctionalTestCase
+from euphorie.testing import EuphorieIntegrationTestCase
+from z3c.saconfig import Session
+from zope.interface import alsoProvides
+
+import transaction
+
+
+class BaseProtectTestCase(EuphorieIntegrationTestCase):
+    """setUp and methods used by the integration and functional test case."""
+
+    def setUp(self):
+        from euphorie.content.protect import EuphorieProtectTransform
+
+        super().setUp()
+        # The transform wants a 'published' and a 'request'.
+        # 'published' can be a view.  But really it is ignored, so let's take
+        # the portal.
+        self.transform = EuphorieProtectTransform(self.portal, self.request)
+        self.session = Session()
+        self._latest_group_id = 0
+        self.group_id = None
+
+    def _createItem(self):
+        """Create an SQL item.
+
+        At first I tried a SurveyTreeItem, but eventually ran into problems
+        because this would then automagically create a related Risk or Module.
+        A session flush in test_edit_with_flush in the functional test case
+        would fail with:
+
+            sqlalchemy.orm.exc.ObjectDeletedError: Instance '<Risk at ...>'
+            has been deleted, or its row is otherwise not present.
+
+        This error seems unrelated to what we are trying to test here.
+        So I try a simpler model.
+        """
+        from euphorie.client.model import Group
+
+        # There are several constraints we need to satisfy.
+        self._latest_group_id += 1
+        group_id = str(self._latest_group_id)
+        return Group(group_id=group_id)
+
+    def _getItem(self, group_id=None):
+        from euphorie.client.model import Group
+
+        group_id = group_id or self.group_id
+        return self.session.query(Group).filter(Group.group_id == group_id).first()
+
+
+class IntegrationTests(BaseProtectTestCase):
+
+    def test_start(self):
+        # Test the start situation: there are no registered objects in the
+        # current ZODB transaction.
+        self.assertEqual(self.transform._registered_objects(), [])
+
+    def test_add_standard(self):
+        item = self._createItem()
+        self.session.add(item)
+        self.assertEqual(self.transform._registered_objects(), [item])
+
+    def test_add_with_flush(self):
+        item = self._createItem()
+        self.session.add(item)
+        self.session.flush()
+        self.assertEqual(self.transform._registered_objects(), [item])
+
+
+class FunctionalTests(BaseProtectTestCase, EuphorieFunctionalTestCase):
+    """Functional test so we can do commits.
+
+    Here we want to add an item, commit this, and edit or delete it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        item = self._createItem()
+        self.session.add(item)
+        transaction.commit()
+        self.group_id = item.group_id
+
+    def test_start(self):
+        self.assertEqual(self.transform._registered_objects(), [])
+
+    def test_edit_standard(self):
+        # This is the start of a new transaction, so we need to get the item
+        # fresh from the session.
+        item = self._getItem()
+
+        # Change a column.
+        item.short_name = "changed"
+        self.assertEqual(self.transform._registered_objects(), [item])
+
+        # Check that the change is really there.
+        self.assertEqual(self._getItem().short_name, "changed")
+
+        # Check that the change stays there after a full commit.
+        transaction.commit()
+        self.assertEqual(self._getItem().short_name, "changed")
+
+    def test_edit_with_flush(self):
+        item = self._getItem()
+        item.short_name = "changed"
+        self.session.flush()
+        self.assertEqual(self.transform._registered_objects(), [item])
+        self.assertEqual(self._getItem().short_name, "changed")
+        transaction.commit()
+        self.assertEqual(self._getItem().short_name, "changed")
+
+    def test_delete_standard(self):
+        item = self._getItem()
+        self.session.delete(item)
+        self.assertEqual(self.transform._registered_objects(), [item])
+
+        # Check that the item is really deleted.
+        self.assertIsNone(self._getItem())
+        transaction.commit()
+        self.assertIsNone(self._getItem())
+
+    def test_delete_with_flush(self):
+        item = self._getItem()
+        self.session.delete(item)
+        self.session.flush()
+        self.assertEqual(self.transform._registered_objects(), [item])
+        self.assertIsNone(self._getItem())
+        transaction.commit()
+        self.assertIsNone(self._getItem())
+
+    def _do_csrf_check(self):
+        # Call the _check method of the transform.  This is called by
+        # transformIterable, but that does too much.  We do need to prepare
+        # the transform and the response a bit.
+        resp = self.request.response
+        resp.setHeader("Content-Type", "text/html")
+        self.transform.site = self.portal
+
+        # Do the check.
+        self.transform._check()
+
+    def test_delete_check(self):
+        item = self._getItem()
+        self.session.delete(item)
+        self.assertEqual(self.transform._registered_objects(), [item])
+
+        # Actually do the csrf check.
+        self._do_csrf_check()
+
+        # The write on GET was detected, so we get redirected.
+        resp = self.request.response
+        self.assertEqual(resp.status, 302)
+        self.assertIn("confirm-action", resp.getHeader("location"))
+
+        # The transaction was aborted, so the item still exists.
+        self.assertIsNotNone(self._getItem())
+
+    def test_delete_disable_csrf(self):
+        from euphorie.content.protect import IDisableCSRFProtectionForSQL
+
+        alsoProvides(self.request, IDisableCSRFProtectionForSQL)
+        item = self._getItem()
+        self.session.delete(item)
+        self.assertEqual(self.transform._registered_objects(), [])
+
+        # Actually do the csrf check.
+        self._do_csrf_check()
+
+        # The write on GET is accepted.
+        resp = self.request.response
+        self.assertEqual(resp.status, 200)
+
+        # The transaction was not aborted, so the item no longer exists.
+        self.assertIsNone(self._getItem())
+
+        # Rolling back the session or aborting the transaction brings back
+        # the item.
+        self.session.rollback()
+        self.assertIsNotNone(self._getItem())


### PR DESCRIPTION
Refs https://github.com/syslabcom/scrum/issues/3393

I added a marker interface `euphorie.content.protect.IDisableCSRFProtectionForSQL`. Can can provide this on a request to disable auto CSRF on SQL objects.
This marker interface may be needed, at least temporarily.  Some existing tests fail because apparently a write-on-GET is done.  For example:

```
Error in test test_policy_gets_high_priority (euphorie.client.tests.test_functional_client.SurveyTests.test_policy_gets_high_priority)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.11.12/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.11.12/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.11.12/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/Users/maurits/syslab/quoira/oira/src/Euphorie/src/euphorie/client/tests/test_functional_client.py", line 50, in test_policy_gets_high_priority
    browser.open("%s/1/1/@@identification" % session_url)
  File "/Users/maurits/shared-eggs/cp311/zope.testbrowser-7.0-py3.11.egg/zope/testbrowser/browser.py", line 252, in open
    self._processRequest(url, make_request)
  File "/Users/maurits/shared-eggs/cp311/zope.testbrowser-7.0-py3.11.egg/zope/testbrowser/browser.py", line 290, in _processRequest
    self._checkStatus()
  File "/Users/maurits/shared-eggs/cp311/zope.testbrowser-7.0-py3.11.egg/zope/testbrowser/browser.py", line 298, in _checkStatus
    raise HTTPError(self.url, code, msg, [], None)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```
