### PR TITLE
Add upgrade step to ensure all current content has a UID.

### DIFF
--- a/news/3987.bugfix.rst
+++ b/news/3987.bugfix.rst
@@ -1,0 +1,1 @@
+Add upgrade step to ensure all current content has a UID.  [maurits]

--- a/src/euphorie/upgrade/deployment/v19/20251006201600_ensure_uid/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v19/20251006201600_ensure_uid/upgrade.py
@@ -1,0 +1,38 @@
+from Acquisition import aq_base
+from ftw.upgrade import UpgradeStep
+from plone import api
+from plone.uuid.interfaces import ATTRIBUTE_NAME
+from plone.uuid.interfaces import IUUIDGenerator
+from zope.component import getUtility
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class EnsureUidIsSet(UpgradeStep):
+    """Ensure that all current content has a UID."""
+
+    def __call__(self):
+        """Upgrade step to set a UID if content does not have it yet."""
+        logger.info("Ensuring all items have a UID.")
+        catalog = api.portal.get_tool("portal_catalog")
+        generator = getUtility(IUUIDGenerator)
+        missing = 0
+        for brain in catalog.getAllBrains():
+            if brain.UID is not None:
+                continue
+            obj = brain.getObject()
+            if getattr(aq_base(obj), ATTRIBUTE_NAME, None):
+                continue
+            missing += 1
+            uuid = generator()
+            setattr(obj, ATTRIBUTE_NAME, uuid)
+            obj.reindexObject(idxs=["UID"])
+            if missing % 1000 == 0:
+                logger.info(
+                    "Progress: Have set a UID on %d items that were missing it.",
+                    missing,
+                )
+        logger.info("Have set a UID on %d items that were missing it.", missing)


### PR DESCRIPTION
Refs https://github.com/syslabcom/scrum/issues/3987

I ran this upgrade step on the staging site (http://test-admin-oira.osha.europa.eu/):

```
2025-10-06 20:59:55,456 INFO    [.:19][waitress-1] Ensuring all items have a UID.
2025-10-06 21:00:00,959 INFO    [.:34][waitress-1] Progress: Have set a UID on 1000 items that were missing it.
2025-10-06 21:00:06,090 INFO    [.:34][waitress-1] Progress: Have set a UID on 2000 items that were missing it.
2025-10-06 21:00:12,068 INFO    [.:34][waitress-1] Progress: Have set a UID on 3000 items that were missing it.
2025-10-06 21:00:21,384 INFO    [.:34][waitress-1] Progress: Have set a UID on 4000 items that were missing it.
2025-10-06 21:00:37,642 INFO    [.:34][waitress-1] Progress: Have set a UID on 5000 items that were missing it.
2025-10-06 21:00:41,137 INFO    [.:38][waitress-1] Have set a UID on 5554 items that were missing it.
```

Note that after this, the transaction still takes an extra minute or so, because the indexing queue needs to be processed.

And then the Miller Columns worked again.

I have undone the transaction, as I did not want to interfere with the data on staging, and it is good that someone else still has a site to test with.

Note: it would be nice if we could simply do a catalog query for `UID=None`, but that gives no results, so we need to get all brains, and check them.