### PR TITLE
Persist the dexterity default values

### DIFF
--- a/news/4553.bugfix.rst
+++ b/news/4553.bugfix.rst
@@ -1,0 +1,1 @@
+The default values of the survey created when adding a survey group are now persisted.

--- a/src/euphorie/content/browser/surveygroup.py
+++ b/src/euphorie/content/browser/surveygroup.py
@@ -222,6 +222,18 @@ class AddForm(DefaultAddForm):
         notify(ObjectClonedEvent(target[copy.id]))
         return copy
 
+    def persist_survey_fields(self, survey):
+        """Persist defaultFactory-backed survey fields on a new object.
+
+        Usually this is done by the applyChanges of the dexterity add form,
+        but since we create the survey while creating its container,
+        we need to do this manually here.
+        """
+        for name in ISurvey.names():
+            field = ISurvey[name]
+            if field.defaultFactory is not None:
+                setattr(survey, name, getattr(survey, name))
+
     def createAndAdd(self, data):
         obj = super().createAndAdd(data)
         obj = aq_inner(self.context)[obj.id]
@@ -249,6 +261,7 @@ class AddForm(DefaultAddForm):
 
             obj = aq_inner(self.context)[obj.id]
             survey = createContentInContainer(obj, "euphorie.survey", title=title)
+            self.persist_survey_fields(survey)
 
             self.immediate_view = survey.absolute_url()
         return obj

--- a/src/euphorie/content/tests/test_functional_surveygroup.py
+++ b/src/euphorie/content/tests/test_functional_surveygroup.py
@@ -1,4 +1,6 @@
+from Acquisition import aq_chain
 from Acquisition import aq_parent
+from contextlib import contextmanager
 from euphorie.content.browser.surveygroup import AddForm
 from euphorie.testing import EuphorieFunctionalTestCase
 from euphorie.testing import EuphorieIntegrationTestCase
@@ -8,6 +10,8 @@ from plone.folder.interfaces import IExplicitOrdering
 from Products.CMFCore.WorkflowCore import ActionSucceededEvent
 from zope import component
 from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 
 class SurveyGroupTests(EuphorieIntegrationTestCase):
@@ -200,6 +204,18 @@ class AddFormTests(EuphorieFunctionalTestCase):
         newid = container.invokeFactory(*args, **kwargs)
         return getattr(container, newid)
 
+    @contextmanager
+    def _get_add_form(self, container):
+        request = self.request.clone()
+        request.set("PARENTS", aq_chain(container))
+        old_request = getRequest()
+        try:
+            setRequest(request)
+            addform = AddForm(container, request)
+            yield addform
+        finally:
+            setRequest(old_request)
+
     def createModule(self):
         country = self.portal.sectors.nl
         sector = self._create(country, "euphorie.sector", "sector")
@@ -302,3 +318,46 @@ class AddFormTests(EuphorieFunctionalTestCase):
         )
         AddForm(container, request).copyTemplate(survey, target)
         self.assertEqual(target.evaluation_algorithm, "french")
+
+    def testCreateAndAddScratchPersistsDefaultFactoryBackedValues(self):
+        country = self.portal.sectors.nl
+        country.enable_web_training = True
+        sector = self._create(country, "euphorie.sector", "scratch-sector")
+
+        with self._get_add_form(sector) as addform:
+            addform.request.form["source"] = "scratch"
+            surveygroup = addform.createAndAdd({"title": "My tool"})
+
+        survey = surveygroup["standard"]
+        self.assertEqual(survey.__getattribute__("tool_type"), "classic")
+        self.assertTrue(survey.__getattribute__("enable_web_training"))
+
+    def testPersistSurveyFieldsWebTrainingFalse(self):
+        country = self.portal.sectors.nl
+        country.enable_web_training = False
+        sector = self._create(country, "euphorie.sector", "persist-fields-sector")
+        surveygroup = self._create(sector, "euphorie.surveygroup", "group")
+        survey = self._create(surveygroup, "euphorie.survey", "survey")
+
+        with self.assertRaises(AttributeError):
+            survey.__getattribute__("enable_web_training")
+
+        with self._get_add_form(sector) as addform:
+            addform.persist_survey_fields(survey)
+
+        self.assertFalse(survey.__getattribute__("enable_web_training"))
+
+    def testPersistSurveyFieldsWebTrainingTrue(self):
+        country = self.portal.sectors.nl
+        country.enable_web_training = True
+        sector = self._create(country, "euphorie.sector", "persist-fields-sector")
+        surveygroup = self._create(sector, "euphorie.surveygroup", "group")
+        survey = self._create(surveygroup, "euphorie.survey", "survey")
+
+        with self.assertRaises(AttributeError):
+            survey.__getattribute__("enable_web_training")
+
+        with self._get_add_form(sector) as addform:
+            addform.persist_survey_fields(survey)
+
+        self.assertTrue(survey.__getattribute__("enable_web_training"))

--- a/src/euphorie/upgrade/deployment/v19/20260324113000_persist_default_factory_values_on_surveys/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v19/20260324113000_persist_default_factory_values_on_surveys/upgrade.py
@@ -1,0 +1,39 @@
+from euphorie.content.survey import ISurvey
+from ftw.upgrade import UpgradeStep
+from logging import getLogger
+from plone import api
+
+
+logger = getLogger(__name__)
+
+
+class PersistDefaultFactoryValuesOnSurveys(UpgradeStep):
+    """Persist defaultFactory-backed values on existing surveys."""
+
+    # Extract the fields that have a defaultFactory
+    fields_to_persist = [
+        name for name in ISurvey.names() if ISurvey[name].defaultFactory is not None
+    ]
+
+    def persist(self, obj):
+        """Persist defaultFactory-backed values for the given survey."""
+        for field in self.fields_to_persist:
+            try:
+                # __getattribute__ bypasses the dexterity machinery
+                # that would invoke the defaultFactory when an attribute is missing
+                obj.__getattribute__(field)
+            except AttributeError:
+                logger.info(
+                    "Persisting defaultFactory value for field %r on survey %r",
+                    field,
+                    obj,
+                )
+                # Here getattr will invoke the defaultFactory
+                # and set the value on the object
+                setattr(obj, field, getattr(obj, field))
+
+    def __call__(self):
+        brains = api.content.find(portal_type="euphorie.survey")
+        objs = (brain.getObject() for brain in brains)
+        for obj in objs:
+            self.persist(obj)


### PR DESCRIPTION
When creating a new survey group, an initial survey is created manually.
Because of that, fields with `defaultFactory` are not persisted on the survey object.

This patch fixes that and provides an upgrade step to fix the existing objects.

Refs. https://github.com/syslabcom/scrum/issues/4553