### PR TITLE
Make the tests compatible with the latest Plone 6.2

### DIFF
--- a/news/+13800382.tests.rst
+++ b/news/+13800382.tests.rst
@@ -1,0 +1,1 @@
+Make the tests compatible with the latest Plone 6.2 [ale-rt]

--- a/src/euphorie/content/tests/test_export.py
+++ b/src/euphorie/content/tests/test_export.py
@@ -14,6 +14,8 @@ from plone.base.utils import safe_text
 from zipfile import ZipFile
 from zope.publisher.browser import TestRequest
 
+import html
+
 
 class MockImage:
     def __init__(self, data, filename=None, contentType=None):
@@ -46,10 +48,10 @@ class ExportSurveyTests(EuphorieIntegrationTestCase):
         view.include_images = True
         image = view.exportImage(root, image, "Captiøn")
         self.assertEqual(
-            safe_text(etree.tostring(image, pretty_print=True)),
+            html.unescape(safe_text(etree.tostring(image, pretty_print=True))),
             '<image xmlns="http://xml.simplon.biz/euphorie/survey/1.0" '
             'content-type="image/gif" filename="test.gif" '
-            'caption="Capti&#xF8;n">aG90IHN0dWZmIGhlcmU=\n'
+            'caption="Captiøn">aG90IHN0dWZmIGhlcmU=\n'
             "</image>\n",
         )
 


### PR DESCRIPTION
Fixes the tests currently failing on `main` after Plone 6.2.0rc1 was released.

See:

- https://github.com/euphorie/Euphorie/actions/runs/23709769598