### PR TITLE
Split language preference: UI can be in one language, surveys in another

### DIFF
--- a/news/3642.feature.rst
+++ b/news/3642.feature.rst
@@ -1,0 +1,6 @@
+Keep UI language and content language separate.
+Update language settings: `use_request_negotiation=True`.
+`utils.setLanguage`: set new `CONTENT_LANGUAGE` cookie instead of `I18N_LANGUAGE` cookie.
+When you visit a survey with a language, this sets a content preference, without changing the UI language.
+In user Preferences: support setting language preferences.
+[maurits]

--- a/src/euphorie/client/browser/country.py
+++ b/src/euphorie/client/browser/country.py
@@ -116,7 +116,7 @@ class SurveyTemplatesMixin:
         # this is a list of tuples of the form
         # (category name, survey object, survey id)
         survey_items = []
-        language = self.request.locale.id.language or ""
+        language = utils.getContentLanguagePref(self.request)
         for sector in aq_inner(self.context).values():
             if not IClientSector.providedBy(sector):
                 continue
@@ -199,7 +199,7 @@ class SessionsView(BrowserView, SurveyTemplatesMixin):
         self.surveys = []
         self.obsolete_surveys = []
 
-        language = self.request.locale.id.language or ""
+        language = utils.getContentLanguagePref(self.request)
         for sector in aq_inner(self.context).values():
             if not IClientSector.providedBy(sector):
                 continue
@@ -603,7 +603,7 @@ class PortletBase(BrowserView):
             return False
         if not survey.language:
             return True
-        language = self.request.locale.id.language or ""
+        language = utils.getContentLanguagePref(self.request)
         if survey.language == language:
             return True
         if survey.language.strip().startswith(language):

--- a/src/euphorie/client/browser/login.py
+++ b/src/euphorie/client/browser/login.py
@@ -7,7 +7,6 @@ existing guest accounts to normal accounts.
 """
 
 from ..country import IClientCountry
-from ..utils import setLanguage
 from .conditions import approvedTermsAndConditions
 from Acquisition import aq_chain
 from Acquisition import aq_inner
@@ -27,12 +26,11 @@ from Products.Five import BrowserView
 from Products.PlonePAS.events import UserLoggedInEvent
 from Products.statusmessages.interfaces import IStatusMessage
 from typing import cast
-from urllib.parse import parse_qs
 from urllib.parse import urlencode
-from urllib.parse import urlparse
 from urllib.parse import urlsplit
 from z3c.saconfig import Session
 from zExceptions import Unauthorized
+from zope.deprecation import deprecate
 from zope.lifecycleevent import notify
 
 import datetime
@@ -61,19 +59,12 @@ class Login(BrowserView):
             WebHelpers, api.content.get_view("webhelpers", self.context, self.request)
         )
 
+    @deprecate(
+        "setLanguage is ignored in favour of standard Plone handling. "
+        "Deprecated in version 19.2.2"
+    )
     def setLanguage(self, came_from):
-        qs = urlparse(came_from)[4]
-        params = parse_qs(qs)
-        lang = params.get("language")
-        if not lang:
-            if IClientCountry.providedBy(self.context):
-                lang = getattr(self.context, "language", None)
-            elif ISurvey.providedBy(self.context):
-                lang = self.context.language
-        if lang:
-            if isinstance(lang, str):
-                lang = [lang]
-            setLanguage(self.request, self.context, lang=lang[0])
+        pass
 
     def login(self, account, remember):
         pas = getToolByName(self.context, "acl_users")
@@ -316,7 +307,6 @@ class Login(BrowserView):
         form = self.request.form
 
         came_from = self.webhelpers.get_came_from(default=self.webhelpers.country_url)
-        self.setLanguage(came_from)
 
         account = get_current_account()
 
@@ -480,7 +470,6 @@ class CreateTestSession(Tryout):
             context.absolute_url(),
             urlencode({"came_from": came_from}),
         )
-        setLanguage(self.request, self.context)
         if self.request.environ["REQUEST_METHOD"] == "POST":
             if not self.allow_guest_accounts:
                 flash = IStatusMessage(self.request).addStatusMessage

--- a/src/euphorie/client/browser/settings.py
+++ b/src/euphorie/client/browser/settings.py
@@ -13,7 +13,10 @@ from euphorie.client.model import AccountChangeRequest
 from euphorie.client.model import get_current_account
 from euphorie.client.model import NotificationSubscription
 from euphorie.client.utils import CreateEmailTo
+from euphorie.client.utils import getContentLanguagePref
 from euphorie.client.utils import randomString
+from euphorie.client.utils import setLanguage
+from operator import itemgetter
 from plone import api
 from plone.autoform import directives
 from plone.autoform.form import AutoExtensibleForm
@@ -160,6 +163,22 @@ class Preferences(AutoExtensibleForm, form.Form):
         )
 
     @property
+    def show_language_preferences(self):
+        # Show the language preferences panel.
+        # This at least shows the UI preference.
+        # Maybe also content preference:
+        # for that, see show_content_language_preference below.
+        return api.portal.get_registry_record(
+            "euphorie.language_preferences__enabled", default=True
+        )
+
+    @property
+    def show_content_language_preference(self):
+        return api.portal.get_registry_record(
+            "euphorie.content_language_preference__enabled", default=True
+        )
+
+    @property
     @memoize
     def current_user(self):
         return get_current_account()
@@ -217,6 +236,42 @@ class Preferences(AutoExtensibleForm, form.Form):
             )
         )
 
+    @property
+    @memoize
+    def supported_languages(self):
+        ltool = api.portal.get_tool("portal_languages")
+        items = ltool.listSupportedLanguages()
+        all_langs = ltool.getAvailableLanguages()
+        items = [(lang[0], all_langs[lang[0]].get("native", lang[1])) for lang in items]
+        items.sort(key=itemgetter(1))
+        return items
+
+    def get_current_ui_language(self):
+        ui_language = self.request.get("ui_language")
+        if ui_language:
+            return ui_language
+        return api.portal.get_current_language()
+
+    def get_current_content_language(self):
+        content_language = self.request.get("content_language")
+        if content_language:
+            return content_language
+        return getContentLanguagePref(self.request)
+
+    def update_language_preferences(self):
+        ui_language = self.request.get("ui_language")
+        if ui_language:
+            lt = api.portal.get_tool("portal_languages")
+            res = lt.setLanguageCookie(lang=ui_language, request=self.request)
+            if res is None and "-" in ui_language:
+                ui_language = ui_language.split("-")[0]
+                res = lt.setLanguageCookie(lang=ui_language, request=self.request)
+
+        if self.show_content_language_preference:
+            content_language = self.request.get("content_language")
+            if content_language:
+                setLanguage(self.request, self.context, content_language)
+
     @button.buttonAndHandler(_("Save"), name="save")
     def handleSave(self, action):
         flash = IStatusMessage(self.request).addStatusMessage
@@ -235,6 +290,9 @@ class Preferences(AutoExtensibleForm, form.Form):
                     self.subscribe_notification(notification.id)
                 else:
                     self.unsubscribe_notification(notification.id)
+
+        if self.show_language_preferences:
+            self.update_language_preferences()
 
 
 class AccountSettings(AutoExtensibleForm, form.Form):

--- a/src/euphorie/client/browser/templates/preferences.pt
+++ b/src/euphorie/client/browser/templates/preferences.pt
@@ -61,6 +61,63 @@
             </fieldset>
 
             <fieldset class="form-panel pat-collapsible true section horizontal"
+                      id="patterns-label-language-prefs"
+                      data-pat-collapsible="store: local; scroll-selector: self; scroll-offset: 100px"
+                      tal:condition="view/show_language_preferences"
+            >
+              <h3 class="form-separation-header collapsible-open"
+                  i18n:translate="title_language_prefs"
+              >Language preferences
+              </h3>
+              <div class="panel-content">
+                <label>
+                  <tal:label i18n:translate="label_ui_language">UI language</tal:label>
+                  <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
+                       data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
+                       i18n:translate="help_ui_language"
+                  >The UI language is used for showing the user interface.
+                  Initially this is determined by the language preference of your browser.
+                  This does not influence the language of the contents, especially which surveys are shown.
+                  This preference resets after quitting your browser.
+                  </dfn>
+                  <select name="ui_language"
+                          tal:define="
+                            current view/get_current_ui_language;
+                          "
+                  >
+                    <option selected="${python:lang[0] == current}"
+                            value="${python:lang[0]}"
+                            tal:repeat="lang view/supported_languages"
+                    >${python:lang[1]}
+                    </option>
+                  </select>
+                </label>
+                <label tal:condition="view/show_content_language_preference">
+                  <tal:label i18n:translate="label_content_language">Content language</tal:label>
+                  <dfn class="icon help help-icon pat-tooltip tooltip-active-click"
+                       data-pat-tooltip="class: info; trigger: click; source: content; position-list: tl"
+                       i18n:translate="help_content_language"
+                  >The content language determines which surveys you see on the dashboard.
+                  Visiting a survey in a different language (via the Tools tab) will automatically update this setting.
+                  This preference resets after quitting your browser.
+                  </dfn>
+                  <select name="content_language"
+                          tal:define="
+                            current view/get_current_content_language;
+                          "
+                  >
+                    <option selected="${python:lang[0] == current}"
+                            value="${python:lang[0]}"
+                            tal:repeat="lang view/supported_languages"
+                    >${python:lang[1]}
+                    </option>
+                  </select>
+                </label>
+
+              </div>
+            </fieldset>
+
+            <fieldset class="form-panel pat-collapsible true section horizontal"
                       id="label-notifications"
                       data-pat-collapsible="store: local; scroll-selector: self; scroll-offset: 100px"
                       tal:define="

--- a/src/euphorie/client/tests/test_client.py
+++ b/src/euphorie/client/tests/test_client.py
@@ -28,12 +28,7 @@ class ViewTests(EuphorieIntegrationTestCase):
             form = {}
 
             def __init__(self, language):
-                self.language = language
-
-            def __getattr__(self, key):
-                if key in ["request", "locale", "id"]:
-                    return self
-                raise AttributeError(key)
+                self.cookies = {"CONTENT_LANGUAGE": language}
 
         with self._get_view("view", country) as view:
             view.request = Request(language)

--- a/src/euphorie/client/tests/test_dashboard.py
+++ b/src/euphorie/client/tests/test_dashboard.py
@@ -34,6 +34,7 @@ class TestDashboard(EuphorieIntegrationTestCase):
 
         with api.env.adopt_user(user=self.account):
             with self._get_view("portlet-available-tools", country) as view:
+                view.request.cookies["CONTENT_LANGUAGE"] = "nl"
                 self.assertListEqual(
                     [survey.getId() for survey in view.surveys],
                     ["software-development"],
@@ -75,7 +76,6 @@ class TestDashboard(EuphorieIntegrationTestCase):
 
                 # Check we can filter by language
                 view.request.__annotations__.clear()
-                view.request.locale.id.language = "nl"
                 another_one.language = "en"
                 self.assertListEqual(
                     [survey.getId() for survey in view.surveys],
@@ -96,11 +96,35 @@ class TestDashboard(EuphorieIntegrationTestCase):
                     ["another-one", "software-development"],
                 )
 
+                # If we prefer English content, the Dutch ones are not shown.
+                view.request.cookies["CONTENT_LANGUAGE"] = "en"
+                view.request.__annotations__.clear()
+                self.assertListEqual(
+                    [survey.getId() for survey in view.surveys],
+                    [],
+                )
+
+                # Language neutral is always shown.
+                view.request.__annotations__.clear()
+                another_one.language = ""
+                self.assertListEqual(
+                    [survey.getId() for survey in view.surveys],
+                    ["another-one"],
+                )
+
+                view.request.__annotations__.clear()
+                view.request.cookies["CONTENT_LANGUAGE"] = "nl"
+                self.assertListEqual(
+                    [survey.getId() for survey in view.surveys],
+                    ["another-one", "software-development"],
+                )
+
     def test_portlet_my_ras(self):
         country = self.portal.client.nl
 
         with api.env.adopt_user(user=self.account):
             with self._get_view("portlet-my-ras", country) as view:
+                view.request.cookies["CONTENT_LANGUAGE"] = "nl"
                 # The portlet by default hides the archived sessions
                 self.assertTrue(view.hide_archived)
 
@@ -123,6 +147,19 @@ class TestDashboard(EuphorieIntegrationTestCase):
                 # If the checbox is marked, the sessions are hidden again
                 view.request.set("hide_archived", "1")
                 self.assertTrue(view.hide_archived)
+                self.assertEqual(
+                    len(view.sessions_by_organisation[self.account.organisation]), 1
+                )
+
+                view.request.__annotations__.clear()
+
+                # The prefered content language has no influence on the RAS portlet.
+                view.request.cookies["CONTENT_LANGUAGE"] = "en"
+                self.assertEqual(
+                    len(view.sessions_by_organisation[self.account.organisation]), 1
+                )
+                view.request.__annotations__.clear()
+                view.request.cookies["CONTENT_LANGUAGE"] = "nl"
                 self.assertEqual(
                     len(view.sessions_by_organisation[self.account.organisation]), 1
                 )

--- a/src/euphorie/client/tests/test_functional_client.py
+++ b/src/euphorie/client/tests/test_functional_client.py
@@ -148,6 +148,6 @@ class SurveyTests(EuphorieFunctionalTestCase):
         browser.getControl(name="answer").value = ["no"]
         # No evaluation is necessary
         self.assertIn(
-            "De tool heeft automatisch een risico-evaluatie uitgevoerd",
+            "The risk evaluation has been automatically done by the tool.",
             browser.contents,
         )

--- a/src/euphorie/client/tests/test_functional_country.py
+++ b/src/euphorie/client/tests/test_functional_country.py
@@ -24,36 +24,36 @@ class CountryFunctionalTests(EuphorieFunctionalTestCase):
         self.loginAsPortalOwner()
         addSurvey(self.portal, survey)
         addSurvey(self.portal, survey_nl)
-        browser = self.get_browser()
-        # Pass the language as URL parameter to ensure that we get the NL
-        # version
-        browser.open("%s?language=nl" % self.portal.client.absolute_url())
+
+        # Prefer Dutch as language for the UI.
+        browser = self.get_browser(language="nl")
+        browser.open(self.portal.client.absolute_url())
         registerUserInClient(browser, link="Registreer")
+
         # We need to manually open the portlet view as the test browser
         # does not handle JavaScript.
-        browser.open(
-            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
-        )
-        self.assertEqual(
-            browser.getControl(name="survey").options, ["branche/vragenlijst"]
-        )
+        country_url = self.portal.client["nl"].absolute_url()
+        browser.open(f"{country_url}/@@portlet-available-tools")
 
-        # Still Dutch
-        browser.open(
-            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
-        )
-        self.assertEqual(
-            browser.getControl(name="survey").options, ["branche/vragenlijst"]
-        )
-
-        # Now, switch to English
-        browser.open("%s?language=en" % self.portal.client["nl"].absolute_url())
-        # We need to manually open the portlet view as the test browser
-        # does not handle JavaScript.
-        browser.open(
-            self.portal.client["nl"].absolute_url() + "/@@portlet-available-tools"
-        )
+        # For content, the site prefers English.  The browser language is only
+        # used for the UI.
         self.assertEqual(browser.getControl(name="survey").options, ["sector/survey"])
+
+        # The Tools tab *does* show surveys in all languages, still with Dutch
+        # as UI language.
+        browser.open(f"{country_url}/surveys")
+        self.assertTrue(browser.getLink(url="sector/survey", text="Informatie"))
+        dutch_link = browser.getLink(url="branche/vragenlijst", text="Informatie")
+        self.assertTrue(dutch_link)
+
+        # Clicking the Dutch link will set a content language preference cookie.
+        dutch_link.click()
+
+        # Now look at the portlet again.
+        browser.open(f"{country_url}/@@portlet-available-tools")
+        self.assertEqual(
+            browser.getControl(name="survey").options, ["branche/vragenlijst"]
+        )
 
     def test_must_select_valid_survey(self):
         self.loginAsPortalOwner()

--- a/src/euphorie/client/tests/utils.py
+++ b/src/euphorie/client/tests/utils.py
@@ -48,7 +48,7 @@ def testRequest():
     return request
 
 
-def registerUserInClient(browser, link="Registreer"):
+def registerUserInClient(browser, link="Register"):
     browser.getLink(link).click()
     browser.getControl(name="email").value = "guest@example.com"
     browser.getControl(name="password1:utf8:ustring").value = "Guest12345#!"

--- a/src/euphorie/client/utils.py
+++ b/src/euphorie/client/utils.py
@@ -12,7 +12,6 @@ from email.mime.text import MIMEText
 from euphorie.client import model
 from euphorie.content.utils import StripMarkup
 from plone import api
-from Products.CMFCore.utils import getToolByName
 from sqlalchemy import sql
 from z3c.saconfig import Session
 from zope.i18nmessageid import MessageFactory
@@ -27,6 +26,7 @@ locals = threading.local()
 log = logging.getLogger(__name__)
 
 pl_message = MessageFactory("plonelocales")
+CONTENT_LANGUAGE_COOKIE = "CONTENT_LANGUAGE"
 
 
 def setRequest(request):
@@ -82,37 +82,84 @@ def CreateEmailTo(sender_name, sender_email, recipient, subject, body):
     return mail
 
 
-def setLanguage(request, context, lang=None):
-    """Switch Plone to another language.
+def _getContentLanguageCookie(request):
+    """Gets the preferred content language from a cookie.
+
+    This mimics `getLanguageCookie` from `plone.i18n`.
+
+    Don't use this directly.  Use `getContentLanguagePref` instead.
+    """
+    langCookie = request.cookies.get(CONTENT_LANGUAGE_COOKIE)
+    if not langCookie:
+        return None
+    lt = api.portal.get_tool("portal_languages")
+    if langCookie in lt.getSupportedLanguages():
+        return langCookie
+    # Bad cookie, throw it away.
+    request.RESPONSE.expireCookie(CONTENT_LANGUAGE_COOKIE, path="/")
+    return None
+
+
+def getContentLanguagePref(request):
+    """Gets the preferred content language.
+
+    Get it from a cookie.  Fall back to the default language of the site.
+    """
+    res = _getContentLanguageCookie(request)
+    if res is not None:
+        return res
+    return api.portal.get_registry_record("plone.default_language")
+
+
+def _setContentLanguageCookie(lang=None, request=None):
+    """Sets a cookie for overriding language content negotiation.
+
+    This mimics `setLanguageCookie` from `plone.i18n`.
+
+    Don't use this directly.  Use `setLanguage` instead.
+    If `lang` is None or otherwise empty, expire the cookie.
+    """
+    if not lang:
+        # At first I wanted to expire the cookie, if it was set.
+        # But that would always expire the cookie when you view a country.
+        return None
+    lt = api.portal.get_tool("portal_languages")
+    if lang not in lt.getSupportedLanguages():
+        return None
+    if lang != _getContentLanguageCookie(request):
+        request.RESPONSE.setCookie(CONTENT_LANGUAGE_COOKIE, lang, path="/")
+    return lang
+
+
+def setLanguage(request, context=None, lang=None):
+    """Switch Plone to prefer another language for content.
 
     If no language is given via the `lang` parameter the language is
     taken from a `language` request parameter. If a dialect was chosen
     but is not available the main language is used instead. If the main
     language is also unavailable switch back to English.
+
+    Changed in version 19.2.2: this only affects content, NOT the UI.
+    We no longer set the I18N_LANGUAGE cookie, but a new CONTENT_LANGUAGE
+    cookie.
+    Since this version, `context` is no longer required as parameter,
+    as we don't use it.  We could warn about it, but let's not for now:
+    we may need it in the future.
     """
     if lang is None:
         lang = request.form.get("language")
     if not lang:
+        # Fall back to language neutral.
+        _setContentLanguageCookie(lang=None, request=request)
         return
 
     lang = lang.lower()
-    lt = getToolByName(context, "portal_languages")
-    res = lt.setLanguageCookie(lang=lang, request=request)
+    res = _setContentLanguageCookie(lang=lang, request=request)
     if res is None and "-" in lang:
         lang = lang.split("-")[0]
-        res = lt.setLanguageCookie(lang=lang, request=request)
+        res = _setContentLanguageCookie(lang=lang, request=request)
         if res is None:
             log.warning("Failed to switch language to %r", lang)
-            lt.setLanguageCookie(lang="en", request=request)
-            lang = "en"
-
-    # In addition to setting the cookie also update the PTS language.
-    # This effectively switches Plone over to the new language without
-    # requiring a new HTTP request.
-    request["LANGUAGE"] = lang
-    binding = request.get("LANGUAGE_TOOL", None)
-    if binding is not None:
-        binding.LANGUAGE = lang
 
 
 def remove_empty_modules(nodes):

--- a/src/euphorie/deployment/profiles/default/registry.xml
+++ b/src/euphorie/deployment/profiles/default/registry.xml
@@ -34,7 +34,7 @@
           interface="plone.i18n.interfaces.ILanguageSchema"
           name="plone.use_request_negotiation"
   >
-    <value>False</value>
+    <value>True</value>
   </record>
   <record field="use_cctld_negotiation"
           interface="plone.i18n.interfaces.ILanguageSchema"

--- a/src/euphorie/deployment/profiles/default/registry.xml
+++ b/src/euphorie/deployment/profiles/default/registry.xml
@@ -246,6 +246,24 @@
     </field>
     <value>True</value>
   </record>
+  <record name="euphorie.language_preferences__enabled">
+    <field type="plone.registry.field.Bool">
+      <title>Allow to modify language preferences in the settings panel</title>
+      <default>True</default>
+      <missing_value>True</missing_value>
+      <required>False</required>
+    </field>
+    <value>True</value>
+  </record>
+  <record name="euphorie.content_language_preference__enabled">
+    <field type="plone.registry.field.Bool">
+      <title>Allow to modify content language preference in the settings panel</title>
+      <default>True</default>
+      <missing_value>True</missing_value>
+      <required>False</required>
+    </field>
+    <value>True</value>
+  </record>
   <record name="euphorie.notifications__enabled">
     <field type="plone.registry.field.Bool">
       <title>Enable notifications system</title>

--- a/src/euphorie/testing.py
+++ b/src/euphorie/testing.py
@@ -178,13 +178,15 @@ class EuphorieFunctionalTestCase(EuphorieIntegrationTestCase):
         "password": TEST_USER_PASSWORD,
     }
 
-    def get_browser(self, logged_in=False, credentials={}):
+    def get_browser(self, logged_in=False, credentials={}, language=""):
         """Return a browser, potentially a logged in one.
 
         The default credentials are the admin ones
         """
         commit()
         browser = Browser(self.app)
+        if language:
+            browser.addHeader("Accept-Language", language)
         if logged_in or credentials:
             username = credentials.get(
                 "username", self._default_credentials["username"]

--- a/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/registry.xml
+++ b/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/registry.xml
@@ -6,4 +6,22 @@
   >
     <value>True</value>
   </record>
+  <record name="euphorie.language_preferences__enabled">
+    <field type="plone.registry.field.Bool">
+      <title>Allow to modify language preferences in the settings panel</title>
+      <default>True</default>
+      <missing_value>True</missing_value>
+      <required>False</required>
+    </field>
+    <value>True</value>
+  </record>
+  <record name="euphorie.content_language_preference__enabled">
+    <field type="plone.registry.field.Bool">
+      <title>Allow to modify content language preference in the settings panel</title>
+      <default>True</default>
+      <missing_value>True</missing_value>
+      <required>False</required>
+    </field>
+    <value>True</value>
+  </record>
 </registry>

--- a/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/registry.xml
+++ b/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/registry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <record field="use_request_negotiation"
+          interface="plone.i18n.interfaces.ILanguageSchema"
+          name="plone.use_request_negotiation"
+  >
+    <value>True</value>
+  </record>
+</registry>

--- a/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateLanguageSettings(UpgradeStep):
+    """Update language settings: use_request_negotiation=True."""
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/upgrade.py
+++ b/src/euphorie/upgrade/deployment/v19/20260413000000_update_language_settings/upgrade.py
@@ -2,7 +2,10 @@ from ftw.upgrade import UpgradeStep
 
 
 class UpdateLanguageSettings(UpgradeStep):
-    """Update language settings: use_request_negotiation=True."""
+    """Update language settings: use_request_negotiation=True.
+
+    And allow to modify language preferences in the settings panel.
+    """
 
     def __call__(self):
         self.install_upgrade_profile()


### PR DESCRIPTION
Refs https://github.com/syslabcom/scrum/issues/3642

Marked as draft to first get a general okay, before diving into technical details.