### PR TITLE
Fix typo when reporting all roles for country managers.

### DIFF
--- a/news/+f1d7ab4e.bugfix.rst
+++ b/news/+f1d7ab4e.bugfix.rst
@@ -1,0 +1,3 @@
+Fix typo when reporting all roles for country managers.
+This had ``CountryyManager`` with two instead of one ``y``.
+[maurits]

--- a/src/euphorie/content/countrymanager.py
+++ b/src/euphorie/content/countrymanager.py
@@ -55,6 +55,8 @@ class CountryManagerLocalRoleProvider:
     role within their country.
     """
 
+    _managed_roles = ("CountryManager", "Editor", "Contributor", "Reader", "Reviewer")
+
     def __init__(self, context):
         self.context = context
 
@@ -69,7 +71,7 @@ class CountryManagerLocalRoleProvider:
             return ()
 
         if user.getPhysicalPath()[:-1] == aq_inner(self.context).getPhysicalPath():
-            return ("CountryManager", "Editor", "Contributor", "Reader", "Reviewer")
+            return self._managed_roles
         else:
             return ()
 
@@ -82,7 +84,7 @@ class CountryManagerLocalRoleProvider:
         return [
             (
                 manager.getUserId(),
-                ("CountryyManager", "Editor", "Contributor", "Reader", "Reviewer"),
+                self._managed_roles,
             )
             for manager in managers
         ]


### PR DESCRIPTION
This had ``CountryyManager`` with two instead of one ``y``.

There were two tuples, with this typo as only difference. So define the tuple once.

Refs https://github.com/syslabcom/scrum/issues/4282