### PR TITLE
Do not compile HTML static resources

### DIFF
--- a/news/4798.feature.rst
+++ b/news/4798.feature.rst
@@ -1,0 +1,1 @@
+Fix errors that might happen in help pages when the template engine tries to compile them. @ale-rt

--- a/src/euphorie/__init__.py
+++ b/src/euphorie/__init__.py
@@ -1,5 +1,8 @@
 from euphorie import patches  # noqa: F401
+from euphorie.patches.resource_directory import patch_resource_directory
 from zope.i18nmessageid import MessageFactory as mf
+
+patch_resource_directory()
 
 MessageFactory = mf("euphorie")
 

--- a/src/euphorie/patches/resource_directory.py
+++ b/src/euphorie/patches/resource_directory.py
@@ -1,0 +1,17 @@
+from logging import getLogger
+from Products.Five.browser.resource import DirectoryResource
+
+logger = getLogger(__name__)
+
+
+def patch_resource_directory():
+    """Patch the DirectoryResource to not interpret .html files as page templates.
+
+    The DirectoryResource object returned by the ++resource++ namespace traversal
+    has a resource_factories dict that maps
+    which file extensions should be interpreted as page templates.
+    Help pages coming from proto are not page templates,
+    but contain code snippet that might break chameleon, so we clear that dict.
+    """
+    logger.info("PATCH:Patching DirectoryResource for html files")
+    DirectoryResource.resource_factories.pop("html", None)


### PR DESCRIPTION
Reources like:
```
++resource++euphorie.resources/assets/oira/help/en/illustrations/report-download.html
```
can throw an error if they because Chameleon tries to compile them.

Refs. https://github.com/syslabcom/scrum/issues/4798