### PR TITLE
Fix headings in the tools print preview.

### DIFF
--- a/news/4878.bugfix.rst
+++ b/news/4878.bugfix.rst
@@ -1,0 +1,1 @@
+Fix headings in the tools print preview.  [maurits]

--- a/src/euphorie/client/browser/session.py
+++ b/src/euphorie/client/browser/session.py
@@ -458,7 +458,7 @@ class Involve(SessionMixin, BrowserView):
 class ContentsPreview(BrowserView):
     """A View for displaying the full contents of a tool and printing them.
 
-    View name: @@contents-preview
+    View name: @@panel-contents-preview
     """
 
     no_splash = True

--- a/src/euphorie/client/browser/templates/panel-contents-preview.pt
+++ b/src/euphorie/client/browser/templates/panel-contents-preview.pt
@@ -62,7 +62,21 @@
                               solutions python:view.get_solutions(node);
                             "
                         >
-                          <em>${node/title}</em>
+                          <tal:switch switch="node/depth">
+                            <tal:case case="python:2">
+                              <h3>${python:view.get_title(node)}</h3>
+                            </tal:case>
+                            <tal:case case="python:3">
+                              <h4>${python:view.get_title(node)}</h4>
+                            </tal:case>
+                            <tal:case case="python:4">
+                              <h5>${python:view.get_title(node)}</h5>
+                            </tal:case>
+                            <tal:case case="python:5">
+                              <h6>${python:view.get_title(node)}</h6>
+                            </tal:case>
+                          </tal:switch>
+
                           <p tal:replace="structure python:webhelpers.get_safe_html(description)"></p>
                           <ul class="manual-checklist"
                               tal:condition="solutions"
@@ -74,13 +88,13 @@
                           >
                             <tal:switch switch="node/depth">
                               <tal:case case="python:2">
-                                <h3 i18n:translate="label_legal_reference">Legal and policy references</h3>
-                              </tal:case>
-                              <tal:case case="python:3">
                                 <h4 i18n:translate="label_legal_reference">Legal and policy references</h4>
                               </tal:case>
-                              <tal:case case="python:4">
+                              <tal:case case="python:3">
                                 <h5 i18n:translate="label_legal_reference">Legal and policy references</h5>
+                              </tal:case>
+                              <tal:case case="python:4">
+                                <h6 i18n:translate="label_legal_reference">Legal and policy references</h6>
                               </tal:case>
                               <tal:case case="python:5">
                                 <h6 i18n:translate="label_legal_reference">Legal and policy references</h6>


### PR DESCRIPTION
Refs https://github.com/syslabcom/scrum/issues/4878

* Turn the risk from an `em` tag to a h3-h6, depending on its depth in the three
* Make the "Legal and policy references" header one level smaller (h3 to h4, h4 to h5, etc). So one level below the new risk level.

So with a very undeep tree (just module and risk):

```
* Module depth 1, h2
  * Risk depth 2, h3
    * Legal header, h4
```

The template left room for a lowest risk depth of 5.  I only reached depth 4, but maybe there are ways to get more depth. Anyway, at that lowest depth 5 of a risk, we get:

```
* Module depth 4, h5
  * Risk depth 5, h6
    * Legal header, h6.  There is no `h7`.
```

Before, all risks were shown with tag `em`, regardless of their depth:

<img width="455" height="743" alt="Screenshot 2026-06-12 at 12 04 17" src="https://github.com/user-attachments/assets/d7efc472-6650-44d6-bae6-42b50b7eea6e" />

At first I only decreased the Legal header, and put the Risk always at `h3`:

<img width="396" height="844" alt="Screenshot 2026-06-12 at 12 04 25" src="https://github.com/user-attachments/assets/d344d644-4816-45fc-a78c-73bf80a45d0c" />

That did not look right either, so I made the Risk header dependent on the depth as well, just like the template was already doing for Modules:

<img width="441" height="729" alt="Screenshot 2026-06-12 at 12 10 44" src="https://github.com/user-attachments/assets/4bb7b6fa-8eb3-4c73-bce0-93592df0ef17" />



