### PR TITLE
Fix editing risk in OiRA Creator when using French (simple) evaluation.

### DIFF
--- a/news/4978.bugfix.rst
+++ b/news/4978.bugfix.rst
@@ -1,0 +1,1 @@
+Fix editing risk in OiRA Creator when using French (simple) evaluation.  [maurits]

--- a/src/euphorie/content/risk.py
+++ b/src/euphorie/content/risk.py
@@ -39,6 +39,7 @@ from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import Invalid
+from zope.interface import invariant
 from zope.interface import noLongerProvides
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
@@ -432,7 +433,7 @@ class IFrenchEvaluation(model.Schema):
                 ),
             ]
         ),
-        required=True,
+        required=False,
         default=0,
     )
 
@@ -465,9 +466,20 @@ class IFrenchEvaluation(model.Schema):
                 ),
             ]
         ),
-        required=True,
+        required=False,
         default=0,
     )
+
+    @invariant
+    def french_invariant(data):
+        if data.type != "risk" or data.evaluation_method != "calculated":
+            return
+        if data.default_severity is None and data.default_frequency is None:
+            raise Invalid(_("Default frequency and severity are missing."))
+        if data.default_severity is None:
+            raise Invalid(_("Default severity is missing."))
+        if data.default_frequency is None:
+            raise Invalid(_("Default frequency is missing."))
 
 
 class IKinneyEvaluation(model.Schema):


### PR DESCRIPTION
Problem is that the `default_severity` and `default_frequency` fields in `IFrenchEvaluation` have a `pat-depends` setting and are required.  In contrast, the `IKinneyEvaluation` also has `default_frequency` (plus two similar fields), with the same `pat-depends` setting.  But these are not required. In all cases, there is a default value in the schema.

So I change the French fields to not be required.

For good measure I add an invariant to check that these formerly required fields are filled in when the `pat-depends` conditions are met.  Since these fields have a default (even though this is zero), the invariant is unlikely to actually fail, unless the fields are really not submitted at all.

Note: to test this, you need to create a Tool (Survey group) with "simple" evalation. This is a field that can only be set during creation. It took me a while to figure out what the difference was between the online example and my local one.